### PR TITLE
Release: Marketplace fixes — proposal checkout flow, role access, RAVIO v2

### DIFF
--- a/src/components/bidding/ProposalFormDialog.tsx
+++ b/src/components/bidding/ProposalFormDialog.tsx
@@ -48,7 +48,7 @@ export function ProposalFormDialog({ request, open, onOpenChange }: ProposalForm
   const [proposedCheckIn, setProposedCheckIn] = useState(request.check_in_date);
   const [proposedCheckOut, setProposedCheckOut] = useState(request.check_out_date);
   const [validUntil, setValidUntil] = useState(
-    format(addDays(new Date(), 7), 'yyyy-MM-dd')
+    format(addDays(new Date(), 1), 'yyyy-MM-dd')
   );
 
   // Fetch owner's properties
@@ -107,7 +107,7 @@ export function ProposalFormDialog({ request, open, onOpenChange }: ProposalForm
     setMessage('');
     setProposedCheckIn(request.check_in_date);
     setProposedCheckOut(request.check_out_date);
-    setValidUntil(format(addDays(new Date(), 7), 'yyyy-MM-dd'));
+    setValidUntil(format(addDays(new Date(), 1), 'yyyy-MM-dd'));
   };
 
   const selectedProperty = properties.find(p => p.id === selectedPropertyId);


### PR DESCRIPTION
## Summary
- **#112 fix**: Auto-create listing when renter accepts a travel proposal (enables "Proceed to Checkout" flow)
- **#111 fix**: Proposal validity default changed from 7 days to 24 hours
- **#110 fix**: Owners can no longer bid on their own listings
- **#113 fix**: Role-based UI gating — renters don't see "List Property", owners see "View Details" instead of "Place Bid"
- **#114 fix**: Improved property-to-listing flow with better empty states and discoverability
- **#121 fix**: Admin and Executive Dashboard routes now wrapped with ProtectedRoute
- **#115**: RAVIO chatbot avatar replaced with v2 image
- Docs: GitHub Issues workflow in CLAUDE.md, repo URL migration

## Test plan
- [x] 306/306 tests passing
- [x] 0 TypeScript errors
- [x] Build clean
- [ ] Manual: Login as renter → accept a proposal → verify "Proceed to Checkout" appears
- [ ] Manual: Login as owner → verify cannot bid on own listings
- [ ] Manual: Login as renter → verify "List Property" link is hidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)