### PR TITLE
Fix: property dropdown, form persistence, Google OAuth, proposal checkout

### DIFF
--- a/src/components/owner/OwnerProperties.tsx
+++ b/src/components/owner/OwnerProperties.tsx
@@ -61,7 +61,7 @@ const getBrandLabel = (brand: VacationClubBrand): string => {
 };
 
 interface PropertyFormData {
-  brand: VacationClubBrand;
+  brand: VacationClubBrand | "";
   resort_name: string;
   location: string;
   description: string;
@@ -72,7 +72,7 @@ interface PropertyFormData {
 }
 
 const initialFormData: PropertyFormData = {
-  brand: "hilton_grand_vacations",
+  brand: "",
   resort_name: "",
   location: "",
   description: "",
@@ -122,6 +122,11 @@ const OwnerProperties = () => {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!user) return;
+
+    if (!formData.brand) {
+      toast.error("Please select a vacation club brand");
+      return;
+    }
 
     setIsSaving(true);
     try {
@@ -313,9 +318,9 @@ const OwnerProperties = () => {
             <form onSubmit={handleSubmit} className="space-y-4">
               <div className="grid gap-4 md:grid-cols-2">
                 <div className="space-y-2">
-                  <Label htmlFor="brand">Vacation Club Brand</Label>
+                  <Label htmlFor="brand">Vacation Club Brand *</Label>
                   <Select
-                    value={formData.brand}
+                    value={formData.brand || undefined}
                     onValueChange={(value: VacationClubBrand) =>
                       setFormData((prev) => ({ ...prev, brand: value }))
                     }
@@ -432,7 +437,7 @@ const OwnerProperties = () => {
                 <Button type="button" variant="outline" onClick={() => handleDialogChange(false)}>
                   Cancel
                 </Button>
-                <Button type="submit" disabled={isSaving}>
+                <Button type="submit" disabled={isSaving || !formData.brand}>
                   {isSaving ? "Saving..." : editingProperty ? "Update" : "Add Property"}
                 </Button>
               </DialogFooter>

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -19,7 +19,7 @@ const Login = () => {
   
   const [staffOnlyMode, setStaffOnlyMode] = useState(false);
 
-  const { signIn, signOut, isConfigured, user, profile, isRavTeam, isPasswordRecovery } = useAuth();
+  const { signIn, signInWithGoogle, signOut, isConfigured, user, profile, isRavTeam, isPasswordRecovery } = useAuth();
   const navigate = useNavigate();
   const { toast } = useToast();
 
@@ -118,7 +118,12 @@ const Login = () => {
             <div className="bg-card rounded-2xl shadow-card-hover p-4 sm:p-6 md:p-8">
               {/* Social Login */}
               <div className="space-y-3 mb-6">
-                <Button variant="outline" className="w-full" type="button">
+                <Button
+                  variant="outline"
+                  className="w-full"
+                  type="button"
+                  onClick={() => signInWithGoogle()}
+                >
                   <svg className="w-5 h-5 mr-2" viewBox="0 0 24 24">
                     <path
                       fill="currentColor"
@@ -138,12 +143,6 @@ const Login = () => {
                     />
                   </svg>
                   Continue with Google
-                </Button>
-                <Button variant="outline" className="w-full" type="button">
-                  <svg className="w-5 h-5 mr-2" fill="currentColor" viewBox="0 0 24 24">
-                    <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
-                  </svg>
-                  Continue with GitHub
                 </Button>
               </div>
 

--- a/src/pages/Signup.tsx
+++ b/src/pages/Signup.tsx
@@ -24,7 +24,7 @@ const Signup = () => {
   const [isSignupComplete, setIsSignupComplete] = useState(false);
   const [staffOnlyMode, setStaffOnlyMode] = useState(false);
 
-  const { signUp, isConfigured } = useAuth();
+  const { signUp, signInWithGoogle, isConfigured } = useAuth();
 
   // Check if platform is in staff-only mode
   useEffect(() => {
@@ -164,7 +164,12 @@ const Signup = () => {
 
               {/* Social Signup */}
               <div className="space-y-3 mb-6">
-                <Button variant="outline" className="w-full" type="button">
+                <Button
+                  variant="outline"
+                  className="w-full"
+                  type="button"
+                  onClick={() => signInWithGoogle()}
+                >
                   <svg className="w-5 h-5 mr-2" viewBox="0 0 24 24">
                     <path
                       fill="currentColor"


### PR DESCRIPTION
## Summary
- **#109**: Brand dropdown in Add Property now shows placeholder instead of pre-selecting first option
- **#118**: ListProperty form state persisted in localStorage — survives page refresh after role upgrade
- **#86**: Google OAuth buttons wired on Login & Signup; removed non-functional GitHub button
- **#112**: Auto-create listing when renter accepts a travel proposal (enables checkout flow)
- **#111**: Proposal validity default changed from 7 days to 24 hours

## Test plan
- [x] 306/306 tests passing
- [x] 0 TypeScript errors
- [x] Build clean
- [ ] Manual: Add Property → verify brand dropdown shows "Select brand" placeholder
- [ ] Manual: Fill ListProperty form → refresh page → verify form state restored
- [ ] Manual: Google OAuth button click redirects to Google (requires Supabase config)
- [ ] Manual: Accept proposal → verify "Proceed to Checkout" button appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)