### PR TITLE
fix(build): increase PWA precache size limit to 4MB

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -44,7 +44,7 @@ export default defineConfig(({ mode }) => {
         registerType: "autoUpdate",
         workbox: {
           globPatterns: ["**/*.{js,css,html,ico,png,svg,woff2}"],
-          maximumFileSizeToCacheInBytes: 3 * 1024 * 1024,
+          maximumFileSizeToCacheInBytes: 4 * 1024 * 1024,
           runtimeCaching: [
             {
               urlPattern: /^https:\/\/fonts\.googleapis\.com\/.*/i,


### PR DESCRIPTION
## Summary

Main JS bundle grew to 3.16 MB after Session 27 features, exceeding the 3MB Workbox precache limit. This caused both preview and production Vercel builds to fail.

## Fix

Bumped `maximumFileSizeToCacheInBytes` from 3MB to 4MB in `vite.config.ts`.

## Test plan

- [x] `npm run build` passes locally
- [x] PWA precache generates successfully (77 entries)

🤖 Generated with [Claude Code](https://claude.com/claude-code)