### PR TITLE
fix: is_rav_team RLS policy in referral migration

### DIFF
--- a/supabase/migrations/043_referral_program.sql
+++ b/supabase/migrations/043_referral_program.sql
@@ -78,7 +78,7 @@ END $$;
 -- RAV team can read all referrals
 DO $$ BEGIN
   CREATE POLICY referrals_select_admin ON public.referrals
-    FOR SELECT USING (public.is_rav_team());
+    FOR SELECT USING (public.is_rav_team(auth.uid()));
 EXCEPTION WHEN duplicate_object THEN NULL;
 END $$;
 


### PR DESCRIPTION
One-line fix: `is_rav_team()` → `is_rav_team(auth.uid())` in migration 043.