### PR TITLE
docs(testing): update test counts to 676/90 for Session 37

### DIFF
--- a/docs/testing/OPERATIONAL-GUIDE.md
+++ b/docs/testing/OPERATIONAL-GUIDE.md
@@ -4,7 +4,7 @@
 
 | Command | What It Does |
 |---------|--------------|
-| `npm test` | Run all unit + integration tests (627 tests) |
+| `npm test` | Run all unit + integration tests (676 tests) |
 | `npm run test:p0` | Run P0 critical-path tests only (97 tests, ~2s) |
 | `npm run test:watch` | Watch mode (re-run on change) |
 | `npm run test:coverage` | Tests + coverage report |
@@ -17,7 +17,7 @@
 
 ### Unit + Integration Tests
 ```bash
-# Run all tests (627 tests, ~64s)
+# Run all tests (676 tests, ~64s)
 npm test
 
 # Run P0 critical-path tests only (97 tests, ~2s)

--- a/docs/testing/TEST-STRATEGY.md
+++ b/docs/testing/TEST-STRATEGY.md
@@ -38,7 +38,7 @@ This document defines the testing strategy for Rent-A-Vacation, a vacation renta
   /-------------\   Example: pricing, sort, cancellation policy, iCal, timeline
 ```
 
-**Current Total:** 627 tests across 86 test files (all passing)
+**Current Total:** 676 tests across 90 test files (all passing)
 **P0 Critical Path:** 97 tests tagged `@p0` across 14 files — run with `npm run test:p0`
 
 ---
@@ -220,7 +220,7 @@ These are **non-negotiable** - if ANY of these break, users can't use the platfo
 ### Testing Stack
 | Tool | Purpose | Status |
 |------|---------|--------|
-| **Vitest** | Unit + Integration | ✅ Active — 627 tests |
+| **Vitest** | Unit + Integration | ✅ Active — 676 tests |
 | **Playwright** | E2E testing | ✅ Active — 3 smoke tests |
 | **Percy.io** | Visual regression | ⏸ Disabled (private repo requires paid plan) |
 | **GitHub Actions** | CI/CD | ✅ Active — lint → test → e2e → lighthouse |
@@ -305,7 +305,7 @@ describe('Authentication', () => {
 - P0 test case library with `@p0` tagging (97 tests)
 - CI test reporting via dorny/test-reporter (JUnit XML)
 - Lighthouse CI audit
-- **Final: 627 tests, 86 test files, all passing**
+- **Final: 676 tests, 90 test files, all passing**
 
 ---
 
@@ -313,7 +313,7 @@ describe('Authentication', () => {
 
 ### Quantitative (Actual as of March 2026)
 - **Test Execution Time:** ~64s locally, <3 min in CI
-- **Total Tests:** 627 (86 test files)
+- **Total Tests:** 676 (90 test files)
 - **P0 Tests:** 97 tagged `@p0` across 14 files
 - **E2E Tests:** 3 smoke tests (homepage, rentals, navigation)
 - **CI/CD Pass Rate:** >95%

--- a/docs/testing/TESTING-GUIDELINES.md
+++ b/docs/testing/TESTING-GUIDELINES.md
@@ -42,7 +42,7 @@ e2e/
     └── pages.spec.ts               ← Percy snapshots (disabled)
 ```
 
-**Current total:** 627 tests across 86 test files (March 2026)
+**Current total:** 676 tests across 90 test files (March 2026)
 
 ## Test Types
 

--- a/docs/testing/TESTING-STATUS.md
+++ b/docs/testing/TESTING-STATUS.md
@@ -1,7 +1,7 @@
 # Testing Status
 
 > Current state of the RAV test suite. Updated each session.
-> **Last Updated:** March 4, 2026 (Session 36)
+> **Last Updated:** March 5, 2026 (Session 37)
 
 ---
 
@@ -9,8 +9,8 @@
 
 | Metric | Value |
 |--------|-------|
-| **Total tests** | 627 |
-| **Test files** | 86 |
+| **Total tests** | 676 |
+| **Test files** | 90 |
 | **P0 critical-path tests** | 97 (tagged `@p0`) |
 | **E2E smoke tests** | 3 (Playwright) |
 | **Local run time** | ~65s |
@@ -60,6 +60,7 @@ npm run test:e2e:headed   # Playwright with browser visible
 
 | Session | Tests | Files | Notes |
 |---------|-------|-------|-------|
+| 37 | 676 | 90 | Dynamic pricing, referral program |
 | 36 | 627 | 86 | Admin tools, disputes expansion |
 | 35 | 592 | 81 | OpenAPI, P0 library, iCal |
 | 34 | 574 | 78 | Realtime, destinations, saved searches |


### PR DESCRIPTION
Updates TESTING-STATUS, TEST-STRATEGY, TESTING-GUIDELINES, OPERATIONAL-GUIDE with 676 tests / 90 files.