### PR TITLE
feat: RAV Tools hub, Public API, brand naming & SEO

### DIFF
--- a/docs/COMPLETED-PHASES.md
+++ b/docs/COMPLETED-PHASES.md
@@ -1,7 +1,59 @@
 # Completed Phases Archive
 
 > Detailed records of completed project phases, moved from [PROJECT-HUB.md](PROJECT-HUB.md) to keep the hub concise.
-> **Last Archived:** March 5, 2026
+> **Last Archived:** March 10, 2026
+
+---
+
+## Session 38: Public API & Edge-Case Schema Fixes
+
+**Completed:** March 10, 2026
+**Issues Closed:** #173, #174
+**Follow-up Issues Created:** #188, #189, #190, #191, #192
+
+### What Was Done
+
+#### Edge-Case Schema Fixes (#173)
+Documentation-only improvements to `docs/api/openapi.yaml`. Added `x-sse-events` extension to `/text-chat` documenting all 4 SSE event types (`search_results`, `token`, `done`, `error`). Added dual-input format documentation to `/voice-search` clarifying direct API vs VAPI webhook payload detection. Added `x-auth-note` to `/process-escrow-release` documenting JWT admin vs service role cron authentication paths. Clarified rate limit header behavior: `Retry-After` on 429 only, no `X-RateLimit-*` on success today. Marked 9 internal-only endpoints with `x-internal: true` (6 notification senders, `process-deadline-reminders`, `idle-listing-alerts`, `seed-manager`). Validated with Redocly CLI: 0 errors, 6 minor warnings. Synced to `public/api/openapi.yaml`.
+
+#### Public API Layer (#174)
+**API Key Infrastructure (B1):** Migration 044 — `api_keys` table (hashed key, owner, name, scopes[], tier, rate limits, usage counters, active/revoked status, expiry) + `api_request_log` table (per-request analytics: key_id, endpoint, method, status, response_time_ms, IP). 4 RPCs: `validate_api_key` (returns key record if valid+active+not expired), `increment_api_key_usage` (atomic daily counter with auto-reset), `list_api_keys` (admin-only with owner email join), `get_api_key_stats` (per-key endpoint breakdown). Key format: `rav_pk_<32 hex chars>`, SHA-256 hashed at rest. Shared modules: `_shared/api-auth.ts` (key validation, scope checking, rate limit enforcement, fire-and-forget logging), `_shared/api-response.ts` (JSON envelope, pagination parsing, CORS, rate limit headers). Admin UI: `AdminApiKeys.tsx` — create key (generate+show once+copy), revoke key (confirmation dialog), per-key usage stats table. New "API Keys" tab in AdminDashboard gated behind `isRavAdmin()`. `useApiKeys.ts` — 4 hooks (list, stats, create, revoke). Admin lifecycle flow manifest updated.
+
+**API Gateway (B2):** `supabase/functions/api-gateway/index.ts` — single edge function routing all `/v1/*` paths, deployed with `--no-verify-jwt`. 5 read-only endpoints: `GET /v1/listings` (filtered+paginated PostgREST query), `GET /v1/listings/:id` (single listing with property/resort/unit joins), `POST /v1/search` (reuses `searchProperties()` from `_shared/property-search.ts`), `GET /v1/destinations` (static data from `_shared/destinations.ts`), `GET /v1/resorts` (paginated resort directory). Dual auth: API Key (`X-API-Key` header) or JWT (`Authorization: Bearer`). Three rate limit tiers: free (100/day, 10/min), partner (10K/day, 100/min), premium (100K/day, 500/min). Standard JSON envelope: `{ data, meta: { page, per_page, total_count, total_pages }, api_version: "v1" }`. Rate limit headers on all API key responses. Per-request logging (fire-and-forget).
+
+**Public API Spec (B4):** `docs/api/public-api.yaml` — OpenAPI 3.0.3 spec documenting only the 5 public endpoints with partner-facing language, example requests/responses, rate limit tiers, pagination schema. Validated with Redocly (0 errors). `src/pages/Developers.tsx` — public Swagger UI page at `/developers` (no auth required), renders `public-api.yaml`.
+
+**Architectural Decision:** DEC-024 — Public API Architecture (single gateway, API key auth, tiered rate limiting, read-only v1, URL-based versioning).
+
+### Migrations
+- **044_api_keys.sql:** `api_keys` + `api_request_log` tables, 4 RPCs (`validate_api_key`, `increment_api_key_usage`, `list_api_keys`, `get_api_key_stats`), RLS (service role only), indexes, `updated_at` trigger
+
+### Deployment
+- Migration 044 deployed to **DEV** (`npx supabase db push --include-all`)
+- `api-gateway` edge function deployed to **DEV** (`npx supabase functions deploy api-gateway --no-verify-jwt`)
+
+### Files Created (14)
+- `supabase/migrations/044_api_keys.sql`
+- `supabase/functions/_shared/api-auth.ts`, `supabase/functions/_shared/api-response.ts`, `supabase/functions/_shared/destinations.ts`
+- `supabase/functions/api-gateway/index.ts`
+- `src/hooks/admin/useApiKeys.ts`
+- `src/components/admin/AdminApiKeys.tsx`
+- `src/pages/Developers.tsx`
+- `docs/api/public-api.yaml`
+- `src/lib/apiAuth.test.ts`
+- `src/hooks/admin/__tests__/useApiKeys.test.ts`
+- `src/components/admin/__tests__/AdminApiKeys.test.tsx`
+
+### Files Modified (7)
+- `docs/api/openapi.yaml`, `public/api/openapi.yaml`
+- `src/pages/AdminDashboard.tsx`
+- `src/flows/admin-lifecycle.ts`
+- `src/App.tsx`
+- `docs/PROJECT-HUB.md`
+- `src/pages/Documentation.tsx`
+
+### Test Status
+724 tests passing, 94 test files, 0 TypeScript errors, 0 lint errors, build clean
 
 ---
 

--- a/docs/PROJECT-HUB.md
+++ b/docs/PROJECT-HUB.md
@@ -3,7 +3,7 @@
 > **Architectural decisions, session context, and agent instructions**
 > **Task tracking has moved to [GitHub Issues & Milestones](https://github.com/rent-a-vacation/rav-website/issues)**
 > **Project board: [RAV Roadmap](https://github.com/orgs/rent-a-vacation/projects/1)**
-> **Last Updated:** March 5, 2026 (Session 37: #99, #105)
+> **Last Updated:** March 10, 2026 (Session 38: #173, #174)
 > **Repository:** https://github.com/rent-a-vacation/rav-website
 > **App Version:** v0.9.0 (build version visible in footer)
 
@@ -96,7 +96,15 @@ gh issue create --repo rent-a-vacation/rav-website --title "..." --label "..." -
 - **Supabase CLI:** currently linked to DEV
 - **dev and main:** in sync (PR #183, #184 merged)
 
-### Session Handoff (Sessions 25-37)
+### Session Handoff (Sessions 25-38)
+
+**Session 38 — Public API & Edge-Case Schema Fixes (Mar 10):**
+- Closed #173 (Schema Fixes): Added `x-sse-events`, `x-auth-note`, `x-internal` extensions to OpenAPI spec. Clarified dual-input (voice-search) and rate limit headers. Validated with Redocly (0 errors).
+- Closed #174 (Public API Layer): Migration 044 (api_keys + api_request_log tables, 4 RPCs). `api-gateway` edge function with 5 read-only endpoints (listings, listing by ID, search, destinations, resorts). Dual auth (API Key + JWT). Tiered rate limits (free/partner/premium). Admin "API Keys" tab. `/developers` public Swagger UI page.
+- Created follow-up issues: #188 (write endpoints), #189 (OAuth2), #190 (webhooks to partners), #191 (chat endpoint), #192 (SDK packages)
+- DEC-024: Public API Architecture decision logged
+- Deployed migration 044 + api-gateway edge function to DEV
+- Tests: 676→724 (+48 new, 94 test files)
 
 **Session 37 — Dynamic Pricing & Referral Program (Mar 5):**
 - Closed #99 (Dynamic Pricing): `src/lib/dynamicPricing.ts` — urgency discount (graduated 0-15%), seasonal factor (month-based historical data), demand adjustment (pending bids + saved searches). Migration 042: `get_dynamic_pricing_data` RPC. `useDynamicPricing` hook. Enhanced `PricingSuggestion` component with factor badges. 33 tests.
@@ -595,6 +603,47 @@ gh issue create --repo rent-a-vacation/rav-website --title "..." --label "..." -
 
 ---
 
+### DEC-024: Public API Architecture
+**Date:** March 10, 2026
+**Decision:** Single API gateway edge function with API key authentication and tiered rate limiting
+**Status:** Approved
+
+**Context:** RAV needs a public REST API for the upcoming mobile app (Capacitor), partner integrations (travel agents, aggregators), and developer experience.
+
+**Approach:**
+- Single `api-gateway` edge function handling all `/v1/*` routes (deployed with `--no-verify-jwt`)
+- Dual auth: API Key (`X-API-Key` header) for partners, JWT (`Authorization: Bearer`) for own apps
+- API keys: `rav_pk_<32 hex>` format, SHA-256 hashed at rest, shown once at creation
+- Three rate limit tiers: free (100/day), partner (10K/day), premium (100K/day)
+- Read-only endpoints only: listings, search, destinations, resorts (no write ops in v1)
+- URL-based versioning (`/v1/`), 6-month deprecation notice for breaking changes
+- Standard JSON envelope: `{ data, meta: { page, per_page, total_count }, api_version: "v1" }`
+
+**Deferred enhancements (tracked in GitHub Issues):**
+- #188 — Write endpoints (bookings, bids, travel requests via API)
+- #189 — OAuth2 authentication for partner integrations
+- #190 — Webhook delivery to partners (event notifications)
+- #191 — Chat endpoint (`/v1/chat`) via gateway
+- #192 — SDK packages for partners (npm, Python)
+
+---
+
+### DEC-025: RAV Tools Hub & Brand Naming
+**Date:** March 10, 2026
+**Decision:** Create `/tools` hub page for all free tools; rename "Fee Freedom Calculator" to "RAV SmartFee"
+**Status:** Approved
+
+**Context:** Brand names were surfaced across the UI (Phase 1). A central hub page groups all free tools for SEO and discoverability.
+
+**Approach:**
+- `/tools` route renders `RavTools.tsx` — card grid with 2 built tools + 4 coming-soon placeholders
+- "Fee Freedom Calculator" renamed to "RAV SmartFee" in Header, Footer, and brand docs
+- JSON-LD `ItemList` schema on `/tools`, `HowTo` on `/calculator`, `Organization` on `/`
+- `usePageMeta()` added to 7 pages missing it (Index, Rentals, PropertyDetail, BiddingMarketplace, Checkout, ExecutiveDashboard, OwnerDashboard)
+- Future tools: Vacation Cost Comparator, Rental Yield Estimator, Resort Finder Quiz, Trip Budget Planner
+
+---
+
 ### DEC-011: Mobile App Strategy
 **Date:** February 15, 2026
 **Decision:** PWA first (Phase 11), then Capacitor native shells (Phase 12)
@@ -697,6 +746,6 @@ gh issue create --repo rent-a-vacation/rav-website --title "..." --label "..." -
 
 ---
 
-**Last updated:** March 4, 2026 (Session 36: Admin Tools, Docs & Disputes — #176-#180)
+**Last updated:** March 5, 2026 (Session 37: Dynamic Pricing & Referral Program — #99, #105)
 **Maintained by:** Sujit
 **Tracking:** [GitHub Issues](https://github.com/rent-a-vacation/rav-website/issues) · [RAV Roadmap](https://github.com/orgs/rent-a-vacation/projects/1) · [Milestones](https://github.com/rent-a-vacation/rav-website/milestones)

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -15,8 +15,12 @@ info:
     **Rate Limiting:** Many endpoints implement per-user or per-IP rate limiting.
     Exceeding limits returns HTTP 429 with a `Retry-After` header.
 
-    **Rate Limit Headers:** Rate-limited responses include:
+    **Rate Limit Headers:** Currently, rate-limited responses (HTTP 429) include:
     - `Retry-After` — seconds until the limit resets
+
+    Note: `X-RateLimit-Remaining`, `X-RateLimit-Limit`, and `X-RateLimit-Reset` headers
+    are NOT included on successful responses today. The future Public API (v1) will add
+    full rate limit headers on all responses.
   version: 1.0.0
   license:
     name: Proprietary
@@ -70,7 +74,13 @@ paths:
         Searches active listings with filtering by destination, price, dates, bedrooms,
         property type, amenities, and guest count.
 
-        Also accepts VAPI webhook format with `message.functionCall.parameters`.
+        **Dual input format:** Accepts two request shapes:
+        1. **Direct API call** — flat JSON with search parameters at the top level
+        2. **VAPI webhook** — nested payload where parameters are at `message.functionCall.parameters`
+
+        The endpoint auto-detects format: if `message.type === "function-call"` is present,
+        parameters are extracted from the VAPI webhook structure. Otherwise, the top-level
+        body is used directly as search parameters.
 
         **Rate limit:** 30 requests/minute per IP (in-memory sliding window).
       security: []
@@ -154,6 +164,21 @@ paths:
         unit: seconds
         scope: user
         storage: database
+      x-sse-events:
+        - event: search_results
+          data_type: array
+          data_schema: SearchResult[]
+          description: JSON array of matching listings (emitted when tool call triggers property search)
+        - event: token
+          data_type: string
+          description: Individual text token from the AI response stream
+        - event: done
+          data_type: string
+          data_value: "[DONE]"
+          description: Signals end of the SSE stream — client should close connection
+        - event: error
+          data_type: string
+          description: Error message if OpenRouter or tool call fails mid-stream
       requestBody:
         required: true
         content:
@@ -579,6 +604,14 @@ paths:
       security:
         - SupabaseJWT: []
         - {}
+      x-auth-note: |
+        Two authentication paths are supported:
+        1. **JWT (admin):** Standard Supabase JWT with `rav_admin` or `rav_staff` role.
+           Used when admin manually triggers escrow release from the dashboard.
+        2. **Service role key:** `Authorization: Bearer <service_role_key>` with no user context.
+           Used by scheduled cron jobs. The endpoint detects service role by checking
+           if the token's role claim is "service_role".
+        When neither auth method succeeds, returns 401 Unauthorized.
       requestBody:
         required: false
         content:
@@ -607,6 +640,7 @@ paths:
     post:
       operationId: sendEmail
       tags: [Notifications]
+      x-internal: true
       summary: Send a generic email via Resend
       description: |
         Generic email sender for arbitrary HTML content.
@@ -648,6 +682,7 @@ paths:
     post:
       operationId: sendContactForm
       tags: [Notifications]
+      x-internal: true
       summary: Submit a contact form message
       description: |
         Sends contact form submissions to the RAV support inbox
@@ -690,6 +725,7 @@ paths:
     post:
       operationId: sendApprovalEmail
       tags: [Notifications]
+      x-internal: true
       summary: Send user/role approval or rejection email
       description: |
         Transactional email for user account approvals and role upgrade decisions.
@@ -732,6 +768,7 @@ paths:
     post:
       operationId: sendBookingConfirmationReminder
       tags: [Notifications]
+      x-internal: true
       summary: Send booking/checkin confirmation reminder emails
       description: |
         Sends templated booking and checkin emails to owners and renters.
@@ -776,6 +813,7 @@ paths:
     post:
       operationId: sendCancellationEmail
       tags: [Notifications]
+      x-internal: true
       summary: Send cancellation confirmation email to renter
       description: |
         Sends a cancellation confirmation email with details about the
@@ -829,6 +867,7 @@ paths:
     post:
       operationId: sendVerificationNotification
       tags: [Notifications]
+      x-internal: true
       summary: Send owner verification approval/rejection email
       description: |
         Sends verification decision emails to property owners with trust level
@@ -1140,6 +1179,7 @@ paths:
     post:
       operationId: processDeadlineReminders
       tags: [Notifications]
+      x-internal: true
       summary: Process scheduled deadline reminders and timeouts
       description: |
         Scheduled task that sends multiple reminder types:
@@ -1169,6 +1209,7 @@ paths:
     post:
       operationId: idleListingAlerts
       tags: [Alerts]
+      x-internal: true
       summary: Send proactive email alerts for idle listings (cron)
       description: |
         Cron-triggered function that sends email alerts to owners whose active listings have:
@@ -1201,6 +1242,7 @@ paths:
     post:
       operationId: seedManager
       tags: [Admin]
+      x-internal: true
       summary: Manage seed data (DEV environment only)
       description: |
         Development-only utility for managing 3-layer test data.

--- a/docs/api/public-api.yaml
+++ b/docs/api/public-api.yaml
@@ -1,0 +1,557 @@
+openapi: 3.0.3
+info:
+  title: Rent-A-Vacation Public API
+  description: |
+    Public REST API for accessing RAV marketplace data.
+    Use this API to browse vacation listings, search properties,
+    and access destination information.
+
+    **Base URL:** `https://xzfllqndrlmhclqfybew.supabase.co/functions/v1/api-gateway`
+
+    **Authentication:** All requests require either:
+    - `X-API-Key` header with a valid API key (for partners)
+    - `Authorization: Bearer <jwt>` header with a Supabase JWT (for own apps)
+
+    **Rate Limiting:** API key requests are rate-limited per tier:
+    | Tier | Daily | Per-Minute |
+    |------|-------|------------|
+    | Free | 100 | 10 |
+    | Partner | 10,000 | 100 |
+    | Premium | 100,000 | 500 |
+
+    Rate limit headers are included on all responses:
+    - `X-RateLimit-Limit` — maximum requests per day
+    - `X-RateLimit-Remaining` — requests remaining today
+    - `X-RateLimit-Reset` — Unix timestamp when the limit resets
+
+    **Pagination:** List endpoints support `?page=1&per_page=20` (max 50 per page).
+
+    **Versioning:** URL-based (`/v1/`). Breaking changes will use `/v2/` with
+    6-month deprecation notice via `Sunset` and `Deprecation` headers.
+  version: 1.0.0
+  contact:
+    name: RAV Developer Support
+    email: dev@rent-a-vacation.com
+
+servers:
+  - url: https://xzfllqndrlmhclqfybew.supabase.co/functions/v1/api-gateway
+    description: Production
+  - url: https://oukbxqnlxnkainnligfz.supabase.co/functions/v1/api-gateway
+    description: Development
+
+tags:
+  - name: Listings
+    description: Browse and search vacation rental listings
+  - name: Search
+    description: AI-powered property search
+  - name: Destinations
+    description: Destination and resort directory
+
+paths:
+  /v1/listings:
+    get:
+      operationId: listListings
+      tags: [Listings]
+      summary: Browse vacation listings with filters
+      description: |
+        Returns paginated active listings with property, resort, and unit type details.
+        Supports filtering by destination, price range, dates, bedrooms, and brand.
+      security:
+        - ApiKeyAuth: []
+        - BearerAuth: []
+      parameters:
+        - name: destination
+          in: query
+          schema:
+            type: string
+          description: Filter by city, state, or country (partial match)
+          example: "Hawaii"
+        - name: min_price
+          in: query
+          schema:
+            type: number
+          description: Minimum total price in USD
+        - name: max_price
+          in: query
+          schema:
+            type: number
+          description: Maximum total price in USD
+        - name: bedrooms
+          in: query
+          schema:
+            type: integer
+          description: Minimum number of bedrooms
+        - name: brand
+          in: query
+          schema:
+            type: string
+          description: Resort brand filter (partial match)
+          example: "Marriott"
+        - name: check_in
+          in: query
+          schema:
+            type: string
+            format: date
+          description: Earliest check-in date (YYYY-MM-DD)
+        - name: check_out
+          in: query
+          schema:
+            type: string
+            format: date
+          description: Latest check-out date (YYYY-MM-DD)
+        - name: page
+          in: query
+          schema:
+            type: integer
+            default: 1
+          description: Page number
+        - name: per_page
+          in: query
+          schema:
+            type: integer
+            default: 20
+            maximum: 50
+          description: Results per page (max 50)
+      responses:
+        '200':
+          description: Paginated listing results
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListingsResponse'
+              example:
+                data:
+                  - id: "550e8400-e29b-41d4-a716-446655440000"
+                    check_in_date: "2026-06-01"
+                    check_out_date: "2026-06-08"
+                    owner_price: 1200
+                    nightly_rate: 171
+                    status: "active"
+                    properties:
+                      name: "Marriott Grande Vista"
+                      city: "Orlando"
+                      state: "FL"
+                      bedrooms: 2
+                      bathrooms: 2
+                      sleeps: 8
+                meta:
+                  page: 1
+                  per_page: 20
+                  total_count: 117
+                  total_pages: 6
+                api_version: "v1"
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '429':
+          $ref: '#/components/responses/RateLimited'
+
+  /v1/listings/{id}:
+    get:
+      operationId: getListingById
+      tags: [Listings]
+      summary: Get a single listing with full details
+      security:
+        - ApiKeyAuth: []
+        - BearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: Listing UUID
+      responses:
+        '200':
+          description: Listing details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SingleListingResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          description: Listing not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /v1/search:
+    post:
+      operationId: searchProperties
+      tags: [Search]
+      summary: AI-powered property search
+      description: |
+        Search vacation listings using natural language parameters.
+        Uses the same search engine as the RAV voice and chat assistants.
+        Returns up to 20 matching results.
+      security:
+        - ApiKeyAuth: []
+        - BearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SearchRequest'
+            example:
+              destination: "Hawaii"
+              max_price: 2000
+              bedrooms: 2
+              check_in_date: "2026-06-01"
+              check_out_date: "2026-06-08"
+      responses:
+        '200':
+          description: Search results
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SearchResponse'
+        '400':
+          description: Invalid request body
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+  /v1/destinations:
+    get:
+      operationId: listDestinations
+      tags: [Destinations]
+      summary: Get all vacation destinations
+      description: |
+        Returns the complete destination directory with cities.
+        Static data — 10 destinations, 35 cities.
+      security:
+        - ApiKeyAuth: []
+        - BearerAuth: []
+      responses:
+        '200':
+          description: Destination list
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DestinationsResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+  /v1/resorts:
+    get:
+      operationId: listResorts
+      tags: [Destinations]
+      summary: Browse resort directory
+      description: |
+        Paginated resort listing with unit types.
+      security:
+        - ApiKeyAuth: []
+        - BearerAuth: []
+      parameters:
+        - name: page
+          in: query
+          schema:
+            type: integer
+            default: 1
+        - name: per_page
+          in: query
+          schema:
+            type: integer
+            default: 20
+            maximum: 50
+      responses:
+        '200':
+          description: Resort list
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResortsResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+components:
+  securitySchemes:
+    ApiKeyAuth:
+      type: apiKey
+      in: header
+      name: X-API-Key
+      description: |
+        Partner API key in format `rav_pk_<32 hex chars>`.
+        Obtain from the RAV admin dashboard.
+    BearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+      description: Supabase JWT token for authenticated users.
+
+  schemas:
+    PaginationMeta:
+      type: object
+      properties:
+        page:
+          type: integer
+        per_page:
+          type: integer
+        total_count:
+          type: integer
+        total_pages:
+          type: integer
+
+    ListingsResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: string
+                format: uuid
+              check_in_date:
+                type: string
+                format: date
+              check_out_date:
+                type: string
+                format: date
+              owner_price:
+                type: number
+              nightly_rate:
+                type: number
+              status:
+                type: string
+              properties:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  city:
+                    type: string
+                  state:
+                    type: string
+                  country:
+                    type: string
+                  bedrooms:
+                    type: integer
+                  bathrooms:
+                    type: number
+                  sleeps:
+                    type: integer
+                  amenities:
+                    type: array
+                    items:
+                      type: string
+        meta:
+          $ref: '#/components/schemas/PaginationMeta'
+        api_version:
+          type: string
+
+    SingleListingResponse:
+      type: object
+      properties:
+        data:
+          type: object
+          description: Full listing object with nested property, resort, and unit type
+        api_version:
+          type: string
+
+    SearchRequest:
+      type: object
+      properties:
+        destination:
+          type: string
+          description: City, state, or resort name
+        check_in_date:
+          type: string
+          format: date
+        check_out_date:
+          type: string
+          format: date
+        min_price:
+          type: number
+        max_price:
+          type: number
+        bedrooms:
+          type: integer
+        property_type:
+          type: string
+          description: Resort brand filter
+        amenities:
+          type: array
+          items:
+            type: string
+        max_guests:
+          type: integer
+        flexible_dates:
+          type: boolean
+
+    SearchResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            type: object
+            properties:
+              listing_id:
+                type: string
+                format: uuid
+              property_name:
+                type: string
+              location:
+                type: string
+              check_in:
+                type: string
+                format: date
+              check_out:
+                type: string
+                format: date
+              price:
+                type: number
+              bedrooms:
+                type: integer
+              bathrooms:
+                type: number
+              sleeps:
+                type: integer
+              brand:
+                type: string
+              amenities:
+                type: array
+                items:
+                  type: string
+        meta:
+          type: object
+          properties:
+            total_count:
+              type: integer
+        api_version:
+          type: string
+
+    DestinationsResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            type: object
+            properties:
+              slug:
+                type: string
+              name:
+                type: string
+              region:
+                type: string
+              description:
+                type: string
+              cities:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    slug:
+                      type: string
+                    name:
+                      type: string
+                    description:
+                      type: string
+              featured:
+                type: boolean
+        meta:
+          type: object
+          properties:
+            total_count:
+              type: integer
+        api_version:
+          type: string
+
+    ResortsResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: string
+                format: uuid
+              name:
+                type: string
+              brand:
+                type: string
+              rating:
+                type: number
+              city:
+                type: string
+              state:
+                type: string
+              unit_types:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    bedrooms:
+                      type: integer
+                    max_occupancy:
+                      type: integer
+        meta:
+          $ref: '#/components/schemas/PaginationMeta'
+        api_version:
+          type: string
+
+    ErrorResponse:
+      type: object
+      properties:
+        error:
+          type: object
+          properties:
+            code:
+              type: string
+            message:
+              type: string
+        api_version:
+          type: string
+
+  responses:
+    Unauthorized:
+      description: Missing or invalid authentication
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+          example:
+            error:
+              code: "unauthorized"
+              message: "Missing or invalid authentication. Provide X-API-Key header or Authorization: Bearer <jwt>."
+            api_version: "v1"
+
+    RateLimited:
+      description: Rate limit exceeded
+      headers:
+        Retry-After:
+          schema:
+            type: integer
+          description: Seconds until rate limit resets
+        X-RateLimit-Limit:
+          schema:
+            type: integer
+        X-RateLimit-Remaining:
+          schema:
+            type: integer
+        X-RateLimit-Reset:
+          schema:
+            type: integer
+          description: Unix timestamp
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+          example:
+            error:
+              code: "rate_limit_exceeded"
+              message: "Daily API key rate limit exceeded."
+            api_version: "v1"

--- a/docs/brand-assets/BRAND-CONCEPTS.md
+++ b/docs/brand-assets/BRAND-CONCEPTS.md
@@ -129,7 +129,7 @@ RAVIO is the named AI personality behind all AI-powered features on the platform
 
 ---
 
-### 4. Fee Freedom Calculator
+### 4. RAV SmartFee
 
 **What It Is:** Free public tool that shows owners how many weeks to rent to cover maintenance fees.
 
@@ -145,7 +145,7 @@ RAVIO is the named AI personality behind all AI-powered features on the platform
 > "Enter your brand, unit type, and annual fee. We show you the break-even math instantly."
 
 **Medium:**
-> "You're paying maintenance fees every year for weeks you don't use. The Fee Freedom Calculator shows you exactly how many weeks you need to list on Rent-A-Vacation to cover those fees — and start earning a profit. It's free, it takes 30 seconds, and you don't need an account. Over [X] owners have already calculated their path to Fee Freedom."
+> "You're paying maintenance fees every year for weeks you don't use. The RAV SmartFee shows you exactly how many weeks you need to list on Rent-A-Vacation to cover those fees — and start earning a profit. It's free, it takes 30 seconds, and you don't need an account. Over [X] owners have already calculated their path to Fee Freedom."
 
 **CTA Options:**
 - "Calculate Your Fee Freedom"
@@ -422,7 +422,7 @@ You approve guests and earn income.
 ━━━ The numbers ━━━
 ✓ Listing is FREE — no monthly fees
 ✓ 10-15% commission on successful bookings only
-✓ Fee Freedom Calculator shows your break-even
+✓ RAV SmartFee shows your break-even
 ✓ TrustShield builds your reputation
 ✓ Owner's Edge dashboard tracks everything
 
@@ -442,7 +442,7 @@ Stop Paying. Start Earning.
 - Vacation Wishes
 - Name Your Price
 - RAV SmartPrice
-- Fee Freedom Calculator
+- RAV SmartFee
 - TrustShield
 - PaySafe
 - ResortIQ
@@ -467,7 +467,7 @@ Stop Paying. Start Earning.
 
 | Month | Campaign | Primary Channel | Goal |
 |-------|----------|----------------|------|
-| **Apr** | "Fee Freedom Calculator" launch | SEO blog + social | Owner leads |
+| **Apr** | "RAV SmartFee" launch | SEO blog + social | Owner leads |
 | **May** | "Ask RAVIO" launch video | Social video + PR | Brand awareness |
 | **Jun** | Beta launch announcement | Email + community | Beta signups |
 | **Jul** | "Vacation Wishes" campaign | Social + email | Traveler acquisition |

--- a/public/api/openapi.yaml
+++ b/public/api/openapi.yaml
@@ -15,8 +15,12 @@ info:
     **Rate Limiting:** Many endpoints implement per-user or per-IP rate limiting.
     Exceeding limits returns HTTP 429 with a `Retry-After` header.
 
-    **Rate Limit Headers:** Rate-limited responses include:
+    **Rate Limit Headers:** Currently, rate-limited responses (HTTP 429) include:
     - `Retry-After` — seconds until the limit resets
+
+    Note: `X-RateLimit-Remaining`, `X-RateLimit-Limit`, and `X-RateLimit-Reset` headers
+    are NOT included on successful responses today. The future Public API (v1) will add
+    full rate limit headers on all responses.
   version: 1.0.0
   license:
     name: Proprietary
@@ -70,7 +74,13 @@ paths:
         Searches active listings with filtering by destination, price, dates, bedrooms,
         property type, amenities, and guest count.
 
-        Also accepts VAPI webhook format with `message.functionCall.parameters`.
+        **Dual input format:** Accepts two request shapes:
+        1. **Direct API call** — flat JSON with search parameters at the top level
+        2. **VAPI webhook** — nested payload where parameters are at `message.functionCall.parameters`
+
+        The endpoint auto-detects format: if `message.type === "function-call"` is present,
+        parameters are extracted from the VAPI webhook structure. Otherwise, the top-level
+        body is used directly as search parameters.
 
         **Rate limit:** 30 requests/minute per IP (in-memory sliding window).
       security: []
@@ -154,6 +164,21 @@ paths:
         unit: seconds
         scope: user
         storage: database
+      x-sse-events:
+        - event: search_results
+          data_type: array
+          data_schema: SearchResult[]
+          description: JSON array of matching listings (emitted when tool call triggers property search)
+        - event: token
+          data_type: string
+          description: Individual text token from the AI response stream
+        - event: done
+          data_type: string
+          data_value: "[DONE]"
+          description: Signals end of the SSE stream — client should close connection
+        - event: error
+          data_type: string
+          description: Error message if OpenRouter or tool call fails mid-stream
       requestBody:
         required: true
         content:
@@ -579,6 +604,14 @@ paths:
       security:
         - SupabaseJWT: []
         - {}
+      x-auth-note: |
+        Two authentication paths are supported:
+        1. **JWT (admin):** Standard Supabase JWT with `rav_admin` or `rav_staff` role.
+           Used when admin manually triggers escrow release from the dashboard.
+        2. **Service role key:** `Authorization: Bearer <service_role_key>` with no user context.
+           Used by scheduled cron jobs. The endpoint detects service role by checking
+           if the token's role claim is "service_role".
+        When neither auth method succeeds, returns 401 Unauthorized.
       requestBody:
         required: false
         content:
@@ -607,6 +640,7 @@ paths:
     post:
       operationId: sendEmail
       tags: [Notifications]
+      x-internal: true
       summary: Send a generic email via Resend
       description: |
         Generic email sender for arbitrary HTML content.
@@ -648,6 +682,7 @@ paths:
     post:
       operationId: sendContactForm
       tags: [Notifications]
+      x-internal: true
       summary: Submit a contact form message
       description: |
         Sends contact form submissions to the RAV support inbox
@@ -690,6 +725,7 @@ paths:
     post:
       operationId: sendApprovalEmail
       tags: [Notifications]
+      x-internal: true
       summary: Send user/role approval or rejection email
       description: |
         Transactional email for user account approvals and role upgrade decisions.
@@ -732,6 +768,7 @@ paths:
     post:
       operationId: sendBookingConfirmationReminder
       tags: [Notifications]
+      x-internal: true
       summary: Send booking/checkin confirmation reminder emails
       description: |
         Sends templated booking and checkin emails to owners and renters.
@@ -776,6 +813,7 @@ paths:
     post:
       operationId: sendCancellationEmail
       tags: [Notifications]
+      x-internal: true
       summary: Send cancellation confirmation email to renter
       description: |
         Sends a cancellation confirmation email with details about the
@@ -829,6 +867,7 @@ paths:
     post:
       operationId: sendVerificationNotification
       tags: [Notifications]
+      x-internal: true
       summary: Send owner verification approval/rejection email
       description: |
         Sends verification decision emails to property owners with trust level
@@ -1140,6 +1179,7 @@ paths:
     post:
       operationId: processDeadlineReminders
       tags: [Notifications]
+      x-internal: true
       summary: Process scheduled deadline reminders and timeouts
       description: |
         Scheduled task that sends multiple reminder types:
@@ -1169,6 +1209,7 @@ paths:
     post:
       operationId: idleListingAlerts
       tags: [Alerts]
+      x-internal: true
       summary: Send proactive email alerts for idle listings (cron)
       description: |
         Cron-triggered function that sends email alerts to owners whose active listings have:
@@ -1201,6 +1242,7 @@ paths:
     post:
       operationId: seedManager
       tags: [Admin]
+      x-internal: true
       summary: Manage seed data (DEV environment only)
       description: |
         Development-only utility for managing 3-layer test data.

--- a/public/api/public-api.yaml
+++ b/public/api/public-api.yaml
@@ -1,0 +1,557 @@
+openapi: 3.0.3
+info:
+  title: Rent-A-Vacation Public API
+  description: |
+    Public REST API for accessing RAV marketplace data.
+    Use this API to browse vacation listings, search properties,
+    and access destination information.
+
+    **Base URL:** `https://xzfllqndrlmhclqfybew.supabase.co/functions/v1/api-gateway`
+
+    **Authentication:** All requests require either:
+    - `X-API-Key` header with a valid API key (for partners)
+    - `Authorization: Bearer <jwt>` header with a Supabase JWT (for own apps)
+
+    **Rate Limiting:** API key requests are rate-limited per tier:
+    | Tier | Daily | Per-Minute |
+    |------|-------|------------|
+    | Free | 100 | 10 |
+    | Partner | 10,000 | 100 |
+    | Premium | 100,000 | 500 |
+
+    Rate limit headers are included on all responses:
+    - `X-RateLimit-Limit` — maximum requests per day
+    - `X-RateLimit-Remaining` — requests remaining today
+    - `X-RateLimit-Reset` — Unix timestamp when the limit resets
+
+    **Pagination:** List endpoints support `?page=1&per_page=20` (max 50 per page).
+
+    **Versioning:** URL-based (`/v1/`). Breaking changes will use `/v2/` with
+    6-month deprecation notice via `Sunset` and `Deprecation` headers.
+  version: 1.0.0
+  contact:
+    name: RAV Developer Support
+    email: dev@rent-a-vacation.com
+
+servers:
+  - url: https://xzfllqndrlmhclqfybew.supabase.co/functions/v1/api-gateway
+    description: Production
+  - url: https://oukbxqnlxnkainnligfz.supabase.co/functions/v1/api-gateway
+    description: Development
+
+tags:
+  - name: Listings
+    description: Browse and search vacation rental listings
+  - name: Search
+    description: AI-powered property search
+  - name: Destinations
+    description: Destination and resort directory
+
+paths:
+  /v1/listings:
+    get:
+      operationId: listListings
+      tags: [Listings]
+      summary: Browse vacation listings with filters
+      description: |
+        Returns paginated active listings with property, resort, and unit type details.
+        Supports filtering by destination, price range, dates, bedrooms, and brand.
+      security:
+        - ApiKeyAuth: []
+        - BearerAuth: []
+      parameters:
+        - name: destination
+          in: query
+          schema:
+            type: string
+          description: Filter by city, state, or country (partial match)
+          example: "Hawaii"
+        - name: min_price
+          in: query
+          schema:
+            type: number
+          description: Minimum total price in USD
+        - name: max_price
+          in: query
+          schema:
+            type: number
+          description: Maximum total price in USD
+        - name: bedrooms
+          in: query
+          schema:
+            type: integer
+          description: Minimum number of bedrooms
+        - name: brand
+          in: query
+          schema:
+            type: string
+          description: Resort brand filter (partial match)
+          example: "Marriott"
+        - name: check_in
+          in: query
+          schema:
+            type: string
+            format: date
+          description: Earliest check-in date (YYYY-MM-DD)
+        - name: check_out
+          in: query
+          schema:
+            type: string
+            format: date
+          description: Latest check-out date (YYYY-MM-DD)
+        - name: page
+          in: query
+          schema:
+            type: integer
+            default: 1
+          description: Page number
+        - name: per_page
+          in: query
+          schema:
+            type: integer
+            default: 20
+            maximum: 50
+          description: Results per page (max 50)
+      responses:
+        '200':
+          description: Paginated listing results
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListingsResponse'
+              example:
+                data:
+                  - id: "550e8400-e29b-41d4-a716-446655440000"
+                    check_in_date: "2026-06-01"
+                    check_out_date: "2026-06-08"
+                    owner_price: 1200
+                    nightly_rate: 171
+                    status: "active"
+                    properties:
+                      name: "Marriott Grande Vista"
+                      city: "Orlando"
+                      state: "FL"
+                      bedrooms: 2
+                      bathrooms: 2
+                      sleeps: 8
+                meta:
+                  page: 1
+                  per_page: 20
+                  total_count: 117
+                  total_pages: 6
+                api_version: "v1"
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '429':
+          $ref: '#/components/responses/RateLimited'
+
+  /v1/listings/{id}:
+    get:
+      operationId: getListingById
+      tags: [Listings]
+      summary: Get a single listing with full details
+      security:
+        - ApiKeyAuth: []
+        - BearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: Listing UUID
+      responses:
+        '200':
+          description: Listing details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SingleListingResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          description: Listing not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /v1/search:
+    post:
+      operationId: searchProperties
+      tags: [Search]
+      summary: AI-powered property search
+      description: |
+        Search vacation listings using natural language parameters.
+        Uses the same search engine as the RAV voice and chat assistants.
+        Returns up to 20 matching results.
+      security:
+        - ApiKeyAuth: []
+        - BearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SearchRequest'
+            example:
+              destination: "Hawaii"
+              max_price: 2000
+              bedrooms: 2
+              check_in_date: "2026-06-01"
+              check_out_date: "2026-06-08"
+      responses:
+        '200':
+          description: Search results
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SearchResponse'
+        '400':
+          description: Invalid request body
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+  /v1/destinations:
+    get:
+      operationId: listDestinations
+      tags: [Destinations]
+      summary: Get all vacation destinations
+      description: |
+        Returns the complete destination directory with cities.
+        Static data — 10 destinations, 35 cities.
+      security:
+        - ApiKeyAuth: []
+        - BearerAuth: []
+      responses:
+        '200':
+          description: Destination list
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DestinationsResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+  /v1/resorts:
+    get:
+      operationId: listResorts
+      tags: [Destinations]
+      summary: Browse resort directory
+      description: |
+        Paginated resort listing with unit types.
+      security:
+        - ApiKeyAuth: []
+        - BearerAuth: []
+      parameters:
+        - name: page
+          in: query
+          schema:
+            type: integer
+            default: 1
+        - name: per_page
+          in: query
+          schema:
+            type: integer
+            default: 20
+            maximum: 50
+      responses:
+        '200':
+          description: Resort list
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResortsResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+components:
+  securitySchemes:
+    ApiKeyAuth:
+      type: apiKey
+      in: header
+      name: X-API-Key
+      description: |
+        Partner API key in format `rav_pk_<32 hex chars>`.
+        Obtain from the RAV admin dashboard.
+    BearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+      description: Supabase JWT token for authenticated users.
+
+  schemas:
+    PaginationMeta:
+      type: object
+      properties:
+        page:
+          type: integer
+        per_page:
+          type: integer
+        total_count:
+          type: integer
+        total_pages:
+          type: integer
+
+    ListingsResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: string
+                format: uuid
+              check_in_date:
+                type: string
+                format: date
+              check_out_date:
+                type: string
+                format: date
+              owner_price:
+                type: number
+              nightly_rate:
+                type: number
+              status:
+                type: string
+              properties:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  city:
+                    type: string
+                  state:
+                    type: string
+                  country:
+                    type: string
+                  bedrooms:
+                    type: integer
+                  bathrooms:
+                    type: number
+                  sleeps:
+                    type: integer
+                  amenities:
+                    type: array
+                    items:
+                      type: string
+        meta:
+          $ref: '#/components/schemas/PaginationMeta'
+        api_version:
+          type: string
+
+    SingleListingResponse:
+      type: object
+      properties:
+        data:
+          type: object
+          description: Full listing object with nested property, resort, and unit type
+        api_version:
+          type: string
+
+    SearchRequest:
+      type: object
+      properties:
+        destination:
+          type: string
+          description: City, state, or resort name
+        check_in_date:
+          type: string
+          format: date
+        check_out_date:
+          type: string
+          format: date
+        min_price:
+          type: number
+        max_price:
+          type: number
+        bedrooms:
+          type: integer
+        property_type:
+          type: string
+          description: Resort brand filter
+        amenities:
+          type: array
+          items:
+            type: string
+        max_guests:
+          type: integer
+        flexible_dates:
+          type: boolean
+
+    SearchResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            type: object
+            properties:
+              listing_id:
+                type: string
+                format: uuid
+              property_name:
+                type: string
+              location:
+                type: string
+              check_in:
+                type: string
+                format: date
+              check_out:
+                type: string
+                format: date
+              price:
+                type: number
+              bedrooms:
+                type: integer
+              bathrooms:
+                type: number
+              sleeps:
+                type: integer
+              brand:
+                type: string
+              amenities:
+                type: array
+                items:
+                  type: string
+        meta:
+          type: object
+          properties:
+            total_count:
+              type: integer
+        api_version:
+          type: string
+
+    DestinationsResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            type: object
+            properties:
+              slug:
+                type: string
+              name:
+                type: string
+              region:
+                type: string
+              description:
+                type: string
+              cities:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    slug:
+                      type: string
+                    name:
+                      type: string
+                    description:
+                      type: string
+              featured:
+                type: boolean
+        meta:
+          type: object
+          properties:
+            total_count:
+              type: integer
+        api_version:
+          type: string
+
+    ResortsResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: string
+                format: uuid
+              name:
+                type: string
+              brand:
+                type: string
+              rating:
+                type: number
+              city:
+                type: string
+              state:
+                type: string
+              unit_types:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    bedrooms:
+                      type: integer
+                    max_occupancy:
+                      type: integer
+        meta:
+          $ref: '#/components/schemas/PaginationMeta'
+        api_version:
+          type: string
+
+    ErrorResponse:
+      type: object
+      properties:
+        error:
+          type: object
+          properties:
+            code:
+              type: string
+            message:
+              type: string
+        api_version:
+          type: string
+
+  responses:
+    Unauthorized:
+      description: Missing or invalid authentication
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+          example:
+            error:
+              code: "unauthorized"
+              message: "Missing or invalid authentication. Provide X-API-Key header or Authorization: Bearer <jwt>."
+            api_version: "v1"
+
+    RateLimited:
+      description: Rate limit exceeded
+      headers:
+        Retry-After:
+          schema:
+            type: integer
+          description: Seconds until rate limit resets
+        X-RateLimit-Limit:
+          schema:
+            type: integer
+        X-RateLimit-Remaining:
+          schema:
+            type: integer
+        X-RateLimit-Reset:
+          schema:
+            type: integer
+          description: Unix timestamp
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+          example:
+            error:
+              code: "rate_limit_exceeded"
+              message: "Daily API key rate limit exceeded."
+            api_version: "v1"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ import Index from "./pages/Index";
 import HowItWorksPage from "./pages/HowItWorksPage";
 import Destinations from "./pages/Destinations";
 import FAQ from "./pages/FAQ";
+import RavTools from "./pages/RavTools";
 import Login from "./pages/Login";
 import Signup from "./pages/Signup";
 import ForgotPassword from "./pages/ForgotPassword";
@@ -46,6 +47,7 @@ const UserJourneys = lazy(() => import("./pages/UserJourneys"));
 const Terms = lazy(() => import("./pages/Terms"));
 const Privacy = lazy(() => import("./pages/Privacy"));
 const ApiDocs = lazy(() => import("./pages/ApiDocs"));
+const Developers = lazy(() => import("./pages/Developers"));
 const DestinationDetail = lazy(() => import("./pages/DestinationDetail"));
 
 import { PWAInstallBanner } from "@/components/PWAInstallBanner";
@@ -172,6 +174,7 @@ const App = () => (
             <Route path="/user-journeys" element={<UserJourneys />} />
             <Route path="/contact" element={<Contact />} />
             <Route path="/calculator" element={<MaintenanceFeeCalculator />} />
+            <Route path="/tools" element={<RavTools />} />
 
             {/* Protected routes — require approved account */}
             <Route path="/rentals" element={<ProtectedRoute><Rentals /></ProtectedRoute>} />
@@ -188,7 +191,8 @@ const App = () => (
             <Route path="/account" element={<ProtectedRoute><AccountSettings /></ProtectedRoute>} />
             <Route path="/checkin" element={<ProtectedRoute><TravelerCheckin /></ProtectedRoute>} />
 
-            {/* Internal tools */}
+            {/* Developer & internal tools */}
+            <Route path="/developers" element={<Developers />} />
             <Route path="/api-docs" element={<ApiDocs />} />
 
             {/* Legacy routes - redirect to proper sections */}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -44,7 +44,8 @@ const Footer = () => {
               <li><Link to="/how-it-works#pricing" className="hover:text-white transition-colors">Pricing & Fees</Link></li>
               <li><Link to="/how-it-works#success-stories" className="hover:text-white transition-colors">Success Stories</Link></li>
               <li><Link to="/faq" className="hover:text-white transition-colors">Owner FAQs</Link></li>
-              <li><Link to="/calculator" className="hover:text-white transition-colors">Fee Calculator</Link></li>
+              <li><Link to="/calculator" className="hover:text-white transition-colors">RAV SmartFee</Link></li>
+              <li><Link to="/tools" className="hover:text-white transition-colors">RAV Tools</Link></li>
             </ul>
           </div>
 

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
-import { Menu, X, ChevronDown, User, LogOut, LayoutDashboard, ShieldCheck, Gavel, Store, BarChart3, Calculator, BookOpen, Settings, GitBranch, Plane } from "lucide-react";
+import { Menu, X, ChevronDown, User, LogOut, LayoutDashboard, ShieldCheck, Gavel, Store, BarChart3, Calculator, BookOpen, Settings, GitBranch, Plane, Wrench } from "lucide-react";
 import { Link, useNavigate } from "react-router-dom";
 import { useAuth } from "@/contexts/AuthContext";
 import { NotificationBell } from "@/components/bidding/NotificationBell";
@@ -106,7 +106,16 @@ const Header = () => {
                     onClick={() => setIsDropdownOpen(false)}
                   >
                     <Calculator className="h-4 w-4" />
-                    Fee Calculator
+                    RAV SmartFee
+                  </Link>
+                  <Link
+                    to="/tools"
+                    role="menuitem"
+                    className="flex items-center gap-2 px-4 py-2 rounded-lg hover:bg-muted transition-colors"
+                    onClick={() => setIsDropdownOpen(false)}
+                  >
+                    <Wrench className="h-4 w-4" />
+                    RAV Tools
                   </Link>
                 </div>
               )}
@@ -171,7 +180,7 @@ const Header = () => {
                       <DropdownMenuItem asChild>
                         <Link to="/executive-dashboard" className="flex items-center gap-2 cursor-pointer">
                           <BarChart3 className="h-4 w-4" />
-                          Executive Dashboard
+                          RAV Command
                         </Link>
                       </DropdownMenuItem>
                     )}
@@ -188,7 +197,7 @@ const Header = () => {
                       <DropdownMenuItem asChild>
                         <Link to="/owner-dashboard" className="flex items-center gap-2 cursor-pointer">
                           <LayoutDashboard className="h-4 w-4" />
-                          Owner Dashboard
+                          Owner's Edge
                         </Link>
                       </DropdownMenuItem>
                     )}
@@ -323,7 +332,15 @@ const Header = () => {
               onClick={() => setIsMenuOpen(false)}
             >
               <Calculator className="h-4 w-4" />
-              Fee Calculator
+              RAV SmartFee
+            </Link>
+            <Link
+              to="/tools"
+              className="text-foreground py-2 flex items-center gap-2"
+              onClick={() => setIsMenuOpen(false)}
+            >
+              <Wrench className="h-4 w-4" />
+              RAV Tools
             </Link>
             <Link
               to="/faq"
@@ -361,7 +378,7 @@ const Header = () => {
                       onClick={() => setIsMenuOpen(false)}
                     >
                       <BarChart3 className="h-4 w-4" />
-                      Executive Dashboard
+                      RAV Command
                     </Link>
                   )}
                   {isRavTeam() && (
@@ -381,7 +398,7 @@ const Header = () => {
                       onClick={() => setIsMenuOpen(false)}
                     >
                       <LayoutDashboard className="h-4 w-4" />
-                      Owner Dashboard
+                      Owner's Edge
                     </Link>
                   )}
                   <Link

--- a/src/components/admin/AdminApiKeys.tsx
+++ b/src/components/admin/AdminApiKeys.tsx
@@ -1,0 +1,387 @@
+import { useState } from "react";
+import { useAuth } from "@/contexts/AuthContext";
+import {
+  useApiKeys,
+  useCreateApiKey,
+  useRevokeApiKey,
+  useApiKeyStats,
+} from "@/hooks/admin/useApiKeys";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { useToast } from "@/hooks/use-toast";
+import { Key, Plus, Copy, Ban, BarChart3 } from "lucide-react";
+
+const SCOPE_OPTIONS = [
+  { value: "listings:read", label: "Listings (Read)" },
+  { value: "search", label: "Search" },
+  { value: "chat", label: "Chat" },
+];
+
+const TIER_OPTIONS = [
+  { value: "free", label: "Free (100/day, 10/min)" },
+  { value: "partner", label: "Partner (10K/day, 100/min)" },
+  { value: "premium", label: "Premium (100K/day, 500/min)" },
+];
+
+export default function AdminApiKeys() {
+  const { user } = useAuth();
+  const { toast } = useToast();
+  const { data: keys = [], isLoading } = useApiKeys();
+  const createKey = useCreateApiKey();
+  const revokeKey = useRevokeApiKey();
+
+  const [createOpen, setCreateOpen] = useState(false);
+  const [newKeyName, setNewKeyName] = useState("");
+  const [newKeyTier, setNewKeyTier] = useState<"free" | "partner" | "premium">("free");
+  const [selectedScopes, setSelectedScopes] = useState<string[]>(["listings:read"]);
+  const [generatedKey, setGeneratedKey] = useState<string | null>(null);
+
+  const [revokeTarget, setRevokeTarget] = useState<string | null>(null);
+  const [statsKeyId, setStatsKeyId] = useState<string | null>(null);
+  const { data: stats = [] } = useApiKeyStats(statsKeyId);
+
+  const handleCreate = async () => {
+    if (!newKeyName.trim() || !user?.id) return;
+
+    try {
+      const fullKey = await createKey.mutateAsync({
+        name: newKeyName.trim(),
+        scopes: selectedScopes,
+        tier: newKeyTier,
+        ownerId: user.id,
+      });
+      setGeneratedKey(fullKey);
+      toast({ title: "API key created", description: "Copy the key now — it won't be shown again." });
+    } catch {
+      toast({ title: "Error", description: "Failed to create API key", variant: "destructive" });
+    }
+  };
+
+  const handleCopy = async (text: string) => {
+    await navigator.clipboard.writeText(text);
+    toast({ title: "Copied to clipboard" });
+  };
+
+  const handleRevoke = async () => {
+    if (!revokeTarget) return;
+    try {
+      await revokeKey.mutateAsync(revokeTarget);
+      toast({ title: "API key revoked" });
+    } catch {
+      toast({ title: "Error", description: "Failed to revoke key", variant: "destructive" });
+    }
+    setRevokeTarget(null);
+  };
+
+  const resetCreateDialog = () => {
+    setNewKeyName("");
+    setNewKeyTier("free");
+    setSelectedScopes(["listings:read"]);
+    setGeneratedKey(null);
+    setCreateOpen(false);
+  };
+
+  if (isLoading) {
+    return <div className="p-8 text-center text-muted-foreground">Loading API keys...</div>;
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-2xl font-bold">API Keys</h2>
+          <p className="text-muted-foreground">
+            Manage API keys for the public REST API (v1)
+          </p>
+        </div>
+
+        <Dialog open={createOpen} onOpenChange={(open) => {
+          if (!open) resetCreateDialog();
+          else setCreateOpen(true);
+        }}>
+          <DialogTrigger asChild>
+            <Button className="gap-2">
+              <Plus className="h-4 w-4" />
+              Create Key
+            </Button>
+          </DialogTrigger>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>Create API Key</DialogTitle>
+              <DialogDescription>
+                The key will only be shown once. Store it securely.
+              </DialogDescription>
+            </DialogHeader>
+
+            {generatedKey ? (
+              <div className="space-y-4">
+                <div className="p-4 bg-green-50 dark:bg-green-950 border border-green-200 dark:border-green-800 rounded-lg">
+                  <Label className="text-sm font-medium text-green-800 dark:text-green-200">
+                    Your API Key (copy now!)
+                  </Label>
+                  <div className="flex items-center gap-2 mt-2">
+                    <code className="flex-1 text-sm break-all bg-white dark:bg-gray-900 px-3 py-2 rounded border">
+                      {generatedKey}
+                    </code>
+                    <Button size="icon" variant="outline" onClick={() => handleCopy(generatedKey)}>
+                      <Copy className="h-4 w-4" />
+                    </Button>
+                  </div>
+                </div>
+                <DialogFooter>
+                  <Button onClick={resetCreateDialog}>Done</Button>
+                </DialogFooter>
+              </div>
+            ) : (
+              <div className="space-y-4">
+                <div className="space-y-2">
+                  <Label htmlFor="key-name">Name</Label>
+                  <Input
+                    id="key-name"
+                    placeholder="e.g., Travel Agent Partner"
+                    value={newKeyName}
+                    onChange={(e) => setNewKeyName(e.target.value)}
+                  />
+                </div>
+
+                <div className="space-y-2">
+                  <Label>Tier</Label>
+                  <Select value={newKeyTier} onValueChange={(v) => setNewKeyTier(v as "free" | "partner" | "premium")}>
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {TIER_OPTIONS.map((t) => (
+                        <SelectItem key={t.value} value={t.value}>{t.label}</SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+
+                <div className="space-y-2">
+                  <Label>Scopes</Label>
+                  <div className="space-y-1">
+                    {SCOPE_OPTIONS.map((scope) => (
+                      <label key={scope.value} className="flex items-center gap-2 text-sm">
+                        <input
+                          type="checkbox"
+                          checked={selectedScopes.includes(scope.value)}
+                          onChange={(e) => {
+                            if (e.target.checked) {
+                              setSelectedScopes([...selectedScopes, scope.value]);
+                            } else {
+                              setSelectedScopes(selectedScopes.filter((s) => s !== scope.value));
+                            }
+                          }}
+                        />
+                        {scope.label}
+                      </label>
+                    ))}
+                  </div>
+                </div>
+
+                <DialogFooter>
+                  <Button variant="outline" onClick={resetCreateDialog}>Cancel</Button>
+                  <Button onClick={handleCreate} disabled={!newKeyName.trim() || createKey.isPending}>
+                    {createKey.isPending ? "Creating..." : "Create Key"}
+                  </Button>
+                </DialogFooter>
+              </div>
+            )}
+          </DialogContent>
+        </Dialog>
+      </div>
+
+      {/* Keys Table */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Key className="h-5 w-5" />
+            Active Keys ({keys.filter((k) => k.is_active).length})
+          </CardTitle>
+          <CardDescription>
+            Keys are hashed — only the prefix is visible after creation
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {keys.length === 0 ? (
+            <p className="text-center text-muted-foreground py-8">
+              No API keys yet. Create one to get started.
+            </p>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Name</TableHead>
+                  <TableHead>Prefix</TableHead>
+                  <TableHead>Tier</TableHead>
+                  <TableHead>Scopes</TableHead>
+                  <TableHead>Usage (Today)</TableHead>
+                  <TableHead>Last Used</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead>Actions</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {keys.map((key) => (
+                  <TableRow key={key.id}>
+                    <TableCell className="font-medium">{key.name}</TableCell>
+                    <TableCell>
+                      <code className="text-xs bg-muted px-1.5 py-0.5 rounded">
+                        {key.key_prefix}...
+                      </code>
+                    </TableCell>
+                    <TableCell>
+                      <Badge variant={key.tier === "premium" ? "default" : key.tier === "partner" ? "secondary" : "outline"}>
+                        {key.tier}
+                      </Badge>
+                    </TableCell>
+                    <TableCell>
+                      <div className="flex flex-wrap gap-1">
+                        {key.scopes.map((s) => (
+                          <Badge key={s} variant="outline" className="text-xs">{s}</Badge>
+                        ))}
+                      </div>
+                    </TableCell>
+                    <TableCell>
+                      {key.daily_usage} / {key.daily_limit}
+                    </TableCell>
+                    <TableCell className="text-sm text-muted-foreground">
+                      {key.last_used_at
+                        ? new Date(key.last_used_at).toLocaleDateString()
+                        : "Never"}
+                    </TableCell>
+                    <TableCell>
+                      {key.is_active ? (
+                        <Badge variant="default" className="bg-green-600">Active</Badge>
+                      ) : (
+                        <Badge variant="destructive">Revoked</Badge>
+                      )}
+                    </TableCell>
+                    <TableCell>
+                      <div className="flex gap-1">
+                        <Button
+                          size="icon"
+                          variant="ghost"
+                          onClick={() => setStatsKeyId(statsKeyId === key.id ? null : key.id)}
+                          title="View stats"
+                        >
+                          <BarChart3 className="h-4 w-4" />
+                        </Button>
+                        {key.is_active && (
+                          <Button
+                            size="icon"
+                            variant="ghost"
+                            className="text-destructive"
+                            onClick={() => setRevokeTarget(key.id)}
+                            title="Revoke key"
+                          >
+                            <Ban className="h-4 w-4" />
+                          </Button>
+                        )}
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Stats Panel */}
+      {statsKeyId && stats.length > 0 && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <BarChart3 className="h-5 w-5" />
+              Usage Stats (Last 7 Days)
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Date</TableHead>
+                  <TableHead>Endpoint</TableHead>
+                  <TableHead>Requests</TableHead>
+                  <TableHead>Avg Response (ms)</TableHead>
+                  <TableHead>Errors</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {stats.map((s, i) => (
+                  <TableRow key={i}>
+                    <TableCell>{s.day}</TableCell>
+                    <TableCell><code className="text-xs">{s.endpoint}</code></TableCell>
+                    <TableCell>{s.request_count}</TableCell>
+                    <TableCell>{s.avg_response_time_ms}ms</TableCell>
+                    <TableCell className={s.error_count > 0 ? "text-destructive font-medium" : ""}>
+                      {s.error_count}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Revoke Confirmation */}
+      <AlertDialog open={!!revokeTarget} onOpenChange={() => setRevokeTarget(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Revoke API Key?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This will immediately invalidate the key. Any applications using it will lose access.
+              This action cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={handleRevoke} className="bg-destructive text-destructive-foreground">
+              Revoke Key
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}

--- a/src/components/admin/__tests__/AdminApiKeys.test.tsx
+++ b/src/components/admin/__tests__/AdminApiKeys.test.tsx
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { renderWithProviders } from "@/test/helpers/render";
+
+// Mock hooks
+const mockKeys = [
+  {
+    id: "key-1",
+    owner_user_id: "user-1",
+    owner_email: "partner@example.com",
+    name: "Travel Agent API",
+    key_prefix: "rav_pk_abcd",
+    scopes: ["listings:read", "search"],
+    tier: "partner",
+    daily_limit: 10000,
+    per_minute_limit: 100,
+    daily_usage: 42,
+    is_active: true,
+    revoked_at: null,
+    expires_at: null,
+    last_used_at: "2026-03-10T12:00:00Z",
+    created_at: "2026-03-01T00:00:00Z",
+  },
+  {
+    id: "key-2",
+    owner_user_id: "user-1",
+    owner_email: "partner@example.com",
+    name: "Revoked Key",
+    key_prefix: "rav_pk_1234",
+    scopes: ["listings:read"],
+    tier: "free",
+    daily_limit: 100,
+    per_minute_limit: 10,
+    daily_usage: 0,
+    is_active: false,
+    revoked_at: "2026-03-05T00:00:00Z",
+    expires_at: null,
+    last_used_at: null,
+    created_at: "2026-02-01T00:00:00Z",
+  },
+];
+
+vi.mock("@/hooks/admin/useApiKeys", () => ({
+  useApiKeys: () => ({ data: mockKeys, isLoading: false }),
+  useCreateApiKey: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useRevokeApiKey: () => ({ mutateAsync: vi.fn() }),
+  useApiKeyStats: () => ({ data: [] }),
+}));
+
+vi.mock("@/contexts/AuthContext", () => ({
+  useAuth: () => ({
+    user: { id: "admin-1", email: "admin@rav.com" },
+    isRavAdmin: () => true,
+    isRavTeam: () => true,
+  }),
+}));
+
+vi.mock("@/hooks/use-toast", () => ({
+  useToast: () => ({ toast: vi.fn() }),
+}));
+
+import AdminApiKeys from "../AdminApiKeys";
+
+describe("AdminApiKeys", () => {
+  it("renders the API Keys header", () => {
+    renderWithProviders(<AdminApiKeys />);
+    expect(screen.getByText("API Keys")).toBeInTheDocument();
+  });
+
+  it("shows active key count", () => {
+    renderWithProviders(<AdminApiKeys />);
+    expect(screen.getByText(/Active Keys \(1\)/)).toBeInTheDocument();
+  });
+
+  it("displays key name and prefix", () => {
+    renderWithProviders(<AdminApiKeys />);
+    expect(screen.getByText("Travel Agent API")).toBeInTheDocument();
+    expect(screen.getByText("rav_pk_abcd...")).toBeInTheDocument();
+  });
+
+  it("shows tier badges", () => {
+    renderWithProviders(<AdminApiKeys />);
+    expect(screen.getByText("partner")).toBeInTheDocument();
+    expect(screen.getByText("free")).toBeInTheDocument();
+  });
+
+  it("shows usage counter", () => {
+    renderWithProviders(<AdminApiKeys />);
+    expect(screen.getByText("42 / 10000")).toBeInTheDocument();
+  });
+
+  it("shows active and revoked status badges", () => {
+    renderWithProviders(<AdminApiKeys />);
+    expect(screen.getByText("Active")).toBeInTheDocument();
+    expect(screen.getByText("Revoked")).toBeInTheDocument();
+  });
+
+  it("has Create Key button", () => {
+    renderWithProviders(<AdminApiKeys />);
+    expect(screen.getByText("Create Key")).toBeInTheDocument();
+  });
+});

--- a/src/components/bidding/PostRequestCTA.tsx
+++ b/src/components/bidding/PostRequestCTA.tsx
@@ -23,11 +23,11 @@ export function PostRequestCTA({ searchDestination, searchCheckIn, searchCheckOu
       <Search className="w-8 h-8 text-muted-foreground mx-auto mb-3" />
       <h4 className="font-semibold text-lg mb-2">Can&apos;t find what you need?</h4>
       <p className="text-sm text-muted-foreground mb-4">
-        Post a request and let owners come to you. Tell us what you need — owners with matching weeks will send you proposals.
+        Make a Vacation Wish and let owners come to you. Tell us what you need — owners with matching weeks will send you proposals.
       </p>
       <Link to={href}>
         <Button>
-          Post a Travel Request
+          Make a Vacation Wish
           <ArrowRight className="w-4 h-4 ml-2" />
         </Button>
       </Link>

--- a/src/components/bidding/TravelRequestForm.tsx
+++ b/src/components/bidding/TravelRequestForm.tsx
@@ -125,17 +125,17 @@ export function TravelRequestForm({ onSuccess, defaultValues }: TravelRequestFor
       <DialogTrigger asChild>
         <Button size="lg" className="gap-2">
           <Sparkles className="h-4 w-4" />
-          Post Travel Request
+          Make a Vacation Wish
         </Button>
       </DialogTrigger>
       <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <Sparkles className="h-5 w-5 text-accent" />
-            Name Your Own Vacation
+            Vacation Wishes
           </DialogTitle>
           <DialogDescription>
-            Tell us what you're looking for and let property owners come to you with offers!
+            Tell us your dream trip — verified owners compete with personalized proposals!
           </DialogDescription>
         </DialogHeader>
 

--- a/src/components/bidding/__tests__/PostRequestCTA.test.tsx
+++ b/src/components/bidding/__tests__/PostRequestCTA.test.tsx
@@ -15,30 +15,30 @@ describe('PostRequestCTA', () => {
   it('renders the CTA card', () => {
     renderCTA();
     expect(screen.getByText(/Can't find what you need/)).toBeDefined();
-    expect(screen.getByText('Post a Travel Request')).toBeDefined();
+    expect(screen.getByText('Make a Vacation Wish')).toBeDefined();
   });
 
   it('renders descriptive text', () => {
     renderCTA();
-    expect(screen.getByText(/Post a request and let owners come to you/)).toBeDefined();
+    expect(screen.getByText(/Make a Vacation Wish and let owners come to you/)).toBeDefined();
   });
 
   it('link includes destination param when provided', () => {
     renderCTA({ searchDestination: 'Orlando' });
-    const link = screen.getByText('Post a Travel Request').closest('a');
+    const link = screen.getByText('Make a Vacation Wish').closest('a');
     expect(link?.getAttribute('href')).toContain('destination=Orlando');
   });
 
   it('link includes date params when provided', () => {
     renderCTA({ searchCheckIn: '2026-04-15', searchCheckOut: '2026-04-22' });
-    const link = screen.getByText('Post a Travel Request').closest('a');
+    const link = screen.getByText('Make a Vacation Wish').closest('a');
     expect(link?.getAttribute('href')).toContain('checkin=2026-04-15');
     expect(link?.getAttribute('href')).toContain('checkout=2026-04-22');
   });
 
   it('link includes tab=requests and prefill=true', () => {
     renderCTA();
-    const link = screen.getByText('Post a Travel Request').closest('a');
+    const link = screen.getByText('Make a Vacation Wish').closest('a');
     expect(link?.getAttribute('href')).toContain('tab=requests');
     expect(link?.getAttribute('href')).toContain('prefill=true');
   });

--- a/src/components/fair-value/FairValueCard.tsx
+++ b/src/components/fair-value/FairValueCard.tsx
@@ -45,7 +45,7 @@ export function FairValueCard({ listingId, viewerRole }: FairValueCardProps) {
   return (
     <div className="bg-card rounded-xl border p-4 space-y-3">
       <div className="flex items-center justify-between">
-        <span className="text-sm font-medium text-foreground">Fair Value Score</span>
+        <span className="text-sm font-medium text-foreground">RAV SmartPrice</span>
         <Tooltip>
           <TooltipTrigger asChild>
             <button type="button" className="text-muted-foreground hover:text-foreground transition-colors" aria-label="More info">

--- a/src/components/owner/OwnerVerification.tsx
+++ b/src/components/owner/OwnerVerification.tsx
@@ -296,7 +296,7 @@ export const OwnerVerification = () => {
             <div className="flex items-center gap-3">
               {getTrustLevelIcon(verification?.trust_level || "new")}
               <div>
-                <CardTitle>Verification Status</CardTitle>
+                <CardTitle>TrustShield Status</CardTitle>
                 <CardDescription>
                   {TRUST_LEVEL_LABELS[verification?.trust_level || "new"]} Owner
                 </CardDescription>
@@ -381,7 +381,7 @@ export const OwnerVerification = () => {
       {verification?.verification_status === "approved" && (
         <Alert className="border-primary/50 bg-primary/10">
           <CheckCircle2 className="h-4 w-4 text-primary" />
-          <AlertTitle>Verified Owner</AlertTitle>
+          <AlertTitle>TrustShield Verified</AlertTitle>
           <AlertDescription>
             Congratulations! Your ownership has been verified. You can now list up to{" "}
             {verification.trust_level === "premium" ? 20 : 
@@ -536,9 +536,9 @@ export const OwnerVerification = () => {
       {/* Trust Level Benefits */}
       <Card>
         <CardHeader>
-          <CardTitle>Trust Level Benefits</CardTitle>
+          <CardTitle>TrustShield Levels</CardTitle>
           <CardDescription>
-            Increase your trust level to unlock more features
+            Build your TrustShield reputation to unlock more features
           </CardDescription>
         </CardHeader>
         <CardContent>

--- a/src/components/owner/PricingSuggestion.tsx
+++ b/src/components/owner/PricingSuggestion.tsx
@@ -60,7 +60,7 @@ export function PricingSuggestion({ currentRate, brand, location, bedrooms, chec
     <div className="bg-muted/50 rounded-lg p-3 space-y-2">
       <div className="flex items-center justify-between">
         <p className="text-xs font-medium text-muted-foreground">
-          Market range ({comparableCount} listings)
+          SmartPrice range ({comparableCount} listings)
         </p>
         <div className={`flex items-center gap-1 text-xs font-medium ${colorClass}`}>
           <Icon className="h-3 w-3" />
@@ -107,7 +107,7 @@ export function PricingSuggestion({ currentRate, brand, location, bedrooms, chec
           </div>
 
           <p className="text-[10px] text-muted-foreground">
-            Based on booking history, seasonality & demand
+            RAV SmartPrice — based on booking history, seasonality & demand
             {dynamic.confidence === "low" && " (limited data)"}
           </p>
         </div>

--- a/src/components/resort/ResortSelector.tsx
+++ b/src/components/resort/ResortSelector.tsx
@@ -72,7 +72,7 @@ export function ResortSelector({
 
   return (
     <Command className="border rounded-md">
-      <CommandInput placeholder={`Search ${resorts.length} resorts...`} />
+      <CommandInput placeholder={`ResortIQ — search ${resorts.length} resorts...`} />
       <CommandList>
         <CommandEmpty>No resorts found.</CommandEmpty>
         <CommandGroup>

--- a/src/flows/admin-lifecycle.ts
+++ b/src/flows/admin-lifecycle.ts
@@ -203,6 +203,17 @@ export const adminLifecycle: FlowDefinition = {
       branches: [],
     },
     {
+      id: 'api_keys',
+      route: '/admin',
+      label: 'API Key Management',
+      component: 'AdminApiKeys',
+      tab: 'api-keys',
+      roles: ['rav_admin'],
+      description: 'Create, revoke, and monitor public API keys for partners and integrations. Per-key usage analytics and rate limit management.',
+      tables: ['api_keys', 'api_request_log'],
+      branches: [],
+    },
+    {
       id: 'executive_dashboard',
       route: '/executive-dashboard',
       label: 'Executive Dashboard',

--- a/src/flows/owner-lifecycle.ts
+++ b/src/flows/owner-lifecycle.ts
@@ -58,9 +58,19 @@ export const ownerLifecycle: FlowDefinition = {
       tables: ['referral_codes', 'referrals'],
     },
     {
+      id: 'rav_tools',
+      route: '/tools',
+      label: 'RAV Tools Hub',
+      component: 'RavTools',
+      description: 'Central hub for all free tools: RAV SmartFee calculator, SmartPrice, and coming-soon tools',
+      branches: [
+        { condition: 'Opens calculator', targetStepId: 'fee_calculator', label: 'RAV SmartFee' },
+      ],
+    },
+    {
       id: 'fee_calculator',
       route: '/calculator',
-      label: 'Maintenance Fee Calculator',
+      label: 'RAV SmartFee Calculator',
       component: 'MaintenanceFeeCalculator',
       description: 'Calculate breakeven point and projected savings vs. maintenance fees',
       branches: [

--- a/src/hooks/admin/__tests__/useApiKeys.test.ts
+++ b/src/hooks/admin/__tests__/useApiKeys.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { createHookWrapper } from "@/test/helpers/render";
+
+// Mock supabase
+const mockRpc = vi.fn();
+const mockInsert = vi.fn();
+const mockUpdate = vi.fn();
+const mockEq = vi.fn();
+
+vi.mock("@/lib/supabase", () => ({
+  supabase: {
+    rpc: (...args: unknown[]) => mockRpc(...args),
+    from: () => ({
+      insert: (...args: unknown[]) => mockInsert(...args),
+      update: (...args: unknown[]) => {
+        mockUpdate(...args);
+        return { eq: (...eqArgs: unknown[]) => mockEq(...eqArgs) };
+      },
+    }),
+  },
+}));
+
+import { useApiKeys, useCreateApiKey, useRevokeApiKey, useApiKeyStats } from "../useApiKeys";
+
+const wrapper = createHookWrapper();
+
+describe("useApiKeys", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("fetches API keys via RPC", async () => {
+    const mockKeys = [
+      { id: "key-1", name: "Test Key", tier: "free", is_active: true },
+    ];
+    mockRpc.mockResolvedValueOnce({ data: mockKeys, error: null });
+
+    const { result } = renderHook(() => useApiKeys(), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(mockKeys);
+    expect(mockRpc).toHaveBeenCalledWith("list_api_keys");
+  });
+
+  it("handles RPC error", async () => {
+    mockRpc.mockResolvedValueOnce({ data: null, error: { message: "Unauthorized" } });
+
+    const { result } = renderHook(() => useApiKeys(), { wrapper });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});
+
+describe("useApiKeyStats", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("fetches stats for a specific key", async () => {
+    const mockStats = [
+      { endpoint: "/v1/listings", request_count: 50, avg_response_time_ms: 120, error_count: 2, day: "2026-03-10" },
+    ];
+    mockRpc.mockResolvedValueOnce({ data: mockStats, error: null });
+
+    const { result } = renderHook(() => useApiKeyStats("key-1"), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(mockStats);
+    expect(mockRpc).toHaveBeenCalledWith("get_api_key_stats", { p_key_id: "key-1", p_days: 7 });
+  });
+
+  it("does not fetch when keyId is null", () => {
+    renderHook(() => useApiKeyStats(null), { wrapper });
+    expect(mockRpc).not.toHaveBeenCalled();
+  });
+});
+
+describe("useCreateApiKey", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("generates key and inserts hashed version", async () => {
+    mockInsert.mockResolvedValueOnce({ error: null });
+
+    const { result } = renderHook(() => useCreateApiKey(), { wrapper });
+
+    let generatedKey = "";
+    await waitFor(async () => {
+      generatedKey = await result.current.mutateAsync({
+        name: "Test Partner",
+        scopes: ["listings:read"],
+        tier: "free",
+        ownerId: "user-1",
+      });
+    });
+
+    expect(generatedKey).toMatch(/^rav_pk_[a-f0-9]{32}$/);
+    expect(mockInsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "Test Partner",
+        scopes: ["listings:read"],
+        tier: "free",
+        daily_limit: 100,
+        per_minute_limit: 10,
+      })
+    );
+  });
+});
+
+describe("useRevokeApiKey", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("sets is_active to false and revoked_at", async () => {
+    mockEq.mockResolvedValueOnce({ error: null });
+
+    const { result } = renderHook(() => useRevokeApiKey(), { wrapper });
+
+    await waitFor(async () => {
+      await result.current.mutateAsync("key-1");
+    });
+
+    expect(mockUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        is_active: false,
+      })
+    );
+    expect(mockEq).toHaveBeenCalledWith("id", "key-1");
+  });
+});

--- a/src/hooks/admin/useApiKeys.ts
+++ b/src/hooks/admin/useApiKeys.ts
@@ -1,0 +1,136 @@
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { supabase } from "@/lib/supabase";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const rpc = supabase.rpc as any;
+
+export interface ApiKeyRow {
+  id: string;
+  owner_user_id: string;
+  owner_email: string;
+  name: string;
+  key_prefix: string;
+  scopes: string[];
+  tier: string;
+  daily_limit: number;
+  per_minute_limit: number;
+  daily_usage: number;
+  is_active: boolean;
+  revoked_at: string | null;
+  expires_at: string | null;
+  last_used_at: string | null;
+  created_at: string;
+}
+
+export interface ApiKeyStats {
+  endpoint: string;
+  request_count: number;
+  avg_response_time_ms: number;
+  error_count: number;
+  day: string;
+}
+
+const API_KEY_TIERS = {
+  free: { daily: 100, perMinute: 10 },
+  partner: { daily: 10_000, perMinute: 100 },
+  premium: { daily: 100_000, perMinute: 500 },
+} as const;
+
+/** List all API keys (admin only) */
+export function useApiKeys() {
+  return useQuery<ApiKeyRow[]>({
+    queryKey: ["api-keys"],
+    queryFn: async () => {
+      const { data, error } = await rpc("list_api_keys");
+      if (error) throw error;
+      return (data ?? []) as ApiKeyRow[];
+    },
+  });
+}
+
+/** Get usage stats for a specific API key */
+export function useApiKeyStats(keyId: string | null, days = 7) {
+  return useQuery<ApiKeyStats[]>({
+    queryKey: ["api-key-stats", keyId, days],
+    enabled: !!keyId,
+    queryFn: async () => {
+      const { data, error } = await rpc("get_api_key_stats", {
+        p_key_id: keyId,
+        p_days: days,
+      });
+      if (error) throw error;
+      return (data ?? []) as ApiKeyStats[];
+    },
+  });
+}
+
+/** Create a new API key — returns the full key (shown once) */
+export function useCreateApiKey() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (params: {
+      name: string;
+      scopes: string[];
+      tier: keyof typeof API_KEY_TIERS;
+      ownerId: string;
+    }) => {
+      // Generate key client-side (shown to user once)
+      const bytes = new Uint8Array(16);
+      crypto.getRandomValues(bytes);
+      const hex = Array.from(bytes)
+        .map((b) => b.toString(16).padStart(2, "0"))
+        .join("");
+      const fullKey = `rav_pk_${hex}`;
+      const keyPrefix = fullKey.substring(0, 12);
+
+      // Hash the key for storage
+      const encoder = new TextEncoder();
+      const hashBuffer = await crypto.subtle.digest(
+        "SHA-256",
+        encoder.encode(fullKey)
+      );
+      const keyHash = Array.from(new Uint8Array(hashBuffer))
+        .map((b) => b.toString(16).padStart(2, "0"))
+        .join("");
+
+      const tierLimits = API_KEY_TIERS[params.tier];
+
+      const { error } = await supabase.from("api_keys").insert({
+        owner_user_id: params.ownerId,
+        name: params.name,
+        key_prefix: keyPrefix,
+        key_hash: keyHash,
+        scopes: params.scopes,
+        tier: params.tier,
+        daily_limit: tierLimits.daily,
+        per_minute_limit: tierLimits.perMinute,
+      });
+
+      if (error) throw error;
+      return fullKey; // Return the full key — shown to user once
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["api-keys"] });
+    },
+  });
+}
+
+/** Revoke an API key */
+export function useRevokeApiKey() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (keyId: string) => {
+      const { error } = await supabase
+        .from("api_keys")
+        .update({ is_active: false, revoked_at: new Date().toISOString() })
+        .eq("id", keyId);
+
+      if (error) throw error;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["api-keys"] });
+    },
+  });
+}

--- a/src/lib/apiAuth.test.ts
+++ b/src/lib/apiAuth.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi } from "vitest";
+import { hasScope } from "../../supabase/functions/_shared/api-auth";
+
+// We test the pure functions that can be imported without Deno runtime.
+// The hashApiKey/generateApiKey use Web Crypto which is available in Vitest.
+
+describe("hasScope", () => {
+  it("returns true for wildcard scope", () => {
+    expect(hasScope(["*"], "listings:read")).toBe(true);
+    expect(hasScope(["*"], "anything")).toBe(true);
+  });
+
+  it("returns true for direct match", () => {
+    expect(hasScope(["listings:read", "search"], "search")).toBe(true);
+    expect(hasScope(["listings:read"], "listings:read")).toBe(true);
+  });
+
+  it("returns true for parent scope match", () => {
+    expect(hasScope(["listings"], "listings:read")).toBe(true);
+  });
+
+  it("returns false when scope not present", () => {
+    expect(hasScope(["search"], "listings:read")).toBe(false);
+    expect(hasScope([], "search")).toBe(false);
+  });
+
+  it("does not match child to parent", () => {
+    // Having "listings:read" should not grant "listings:write"
+    expect(hasScope(["listings:read"], "listings:write")).toBe(false);
+  });
+});
+
+describe("API key format", () => {
+  it("validates key format regex", () => {
+    const validKey = "rav_pk_0123456789abcdef0123456789abcdef";
+    const formatRegex = /^rav_pk_[a-f0-9]{32}$/;
+    expect(formatRegex.test(validKey)).toBe(true);
+  });
+
+  it("rejects invalid formats", () => {
+    const formatRegex = /^rav_pk_[a-f0-9]{32}$/;
+    expect(formatRegex.test("rav_pk_short")).toBe(false);
+    expect(formatRegex.test("invalid_key")).toBe(false);
+    expect(formatRegex.test("rav_pk_UPPERCASE12345678901234567890")).toBe(false);
+    expect(formatRegex.test("")).toBe(false);
+  });
+});
+
+describe("API key hashing", () => {
+  it("produces consistent SHA-256 hash via Web Crypto", async () => {
+    const key = "rav_pk_0123456789abcdef0123456789abcdef";
+    const encoder = new TextEncoder();
+    const hashBuffer = await crypto.subtle.digest("SHA-256", encoder.encode(key));
+    const hash = Array.from(new Uint8Array(hashBuffer))
+      .map((b) => b.toString(16).padStart(2, "0"))
+      .join("");
+
+    // Same input produces same output
+    const hashBuffer2 = await crypto.subtle.digest("SHA-256", encoder.encode(key));
+    const hash2 = Array.from(new Uint8Array(hashBuffer2))
+      .map((b) => b.toString(16).padStart(2, "0"))
+      .join("");
+
+    expect(hash).toBe(hash2);
+    expect(hash.length).toBe(64); // SHA-256 = 64 hex chars
+  });
+
+  it("produces different hashes for different keys", async () => {
+    const encoder = new TextEncoder();
+    const hash1Buffer = await crypto.subtle.digest("SHA-256", encoder.encode("rav_pk_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"));
+    const hash1 = Array.from(new Uint8Array(hash1Buffer)).map((b) => b.toString(16).padStart(2, "0")).join("");
+    const hash2Buffer = await crypto.subtle.digest("SHA-256", encoder.encode("rav_pk_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"));
+    const hash2 = Array.from(new Uint8Array(hash2Buffer)).map((b) => b.toString(16).padStart(2, "0")).join("");
+
+    expect(hash1).not.toBe(hash2);
+  });
+});
+
+describe("API key generation", () => {
+  it("generates keys in correct format", () => {
+    const bytes = new Uint8Array(16);
+    crypto.getRandomValues(bytes);
+    const hex = Array.from(bytes)
+      .map((b) => b.toString(16).padStart(2, "0"))
+      .join("");
+    const key = `rav_pk_${hex}`;
+
+    expect(key).toMatch(/^rav_pk_[a-f0-9]{32}$/);
+  });
+
+  it("generates unique keys", () => {
+    const keys = new Set<string>();
+    for (let i = 0; i < 100; i++) {
+      const bytes = new Uint8Array(16);
+      crypto.getRandomValues(bytes);
+      const hex = Array.from(bytes)
+        .map((b) => b.toString(16).padStart(2, "0"))
+        .join("");
+      keys.add(`rav_pk_${hex}`);
+    }
+    expect(keys.size).toBe(100);
+  });
+});
+
+describe("API response envelope", () => {
+  it("pagination parsing handles defaults", () => {
+    const url = new URL("https://example.com/v1/listings");
+    const page = Math.max(1, parseInt(url.searchParams.get("page") ?? "1", 10) || 1);
+    const perPage = Math.min(50, Math.max(1, parseInt(url.searchParams.get("per_page") ?? "20", 10) || 20));
+
+    expect(page).toBe(1);
+    expect(perPage).toBe(20);
+  });
+
+  it("pagination parsing respects params", () => {
+    const url = new URL("https://example.com/v1/listings?page=3&per_page=10");
+    const page = Math.max(1, parseInt(url.searchParams.get("page") ?? "1", 10) || 1);
+    const perPage = Math.min(50, Math.max(1, parseInt(url.searchParams.get("per_page") ?? "20", 10) || 20));
+
+    expect(page).toBe(3);
+    expect(perPage).toBe(10);
+  });
+
+  it("pagination clamps per_page to max 50", () => {
+    const url = new URL("https://example.com/v1/listings?per_page=200");
+    const perPage = Math.min(50, Math.max(1, parseInt(url.searchParams.get("per_page") ?? "20", 10) || 20));
+    expect(perPage).toBe(50);
+  });
+
+  it("pagination handles negative page", () => {
+    const url = new URL("https://example.com/v1/listings?page=-5");
+    const page = Math.max(1, parseInt(url.searchParams.get("page") ?? "1", 10) || 1);
+    expect(page).toBe(1);
+  });
+
+  it("rate limit tier defaults are correct", () => {
+    const tiers = {
+      free: { daily: 100, perMinute: 10 },
+      partner: { daily: 10_000, perMinute: 100 },
+      premium: { daily: 100_000, perMinute: 500 },
+    };
+
+    expect(tiers.free.daily).toBe(100);
+    expect(tiers.partner.daily).toBe(10_000);
+    expect(tiers.premium.perMinute).toBe(500);
+  });
+});

--- a/src/pages/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard.tsx
@@ -34,6 +34,7 @@ import {
   Receipt,
   Database,
   Rocket,
+  Key,
 } from "lucide-react";
 import AdminOverview from "@/components/admin/AdminOverview";
 import AdminProperties from "@/components/admin/AdminProperties";
@@ -55,6 +56,7 @@ import AdminDisputes from "@/components/admin/AdminDisputes";
 import AdminTaxReporting from "@/components/admin/AdminTaxReporting";
 import AdminResortImport from "@/components/admin/AdminResortImport";
 import { LaunchReadinessChecklist } from "@/components/admin/LaunchReadinessChecklist";
+import AdminApiKeys from "@/components/admin/AdminApiKeys";
 
 const IS_DEV = import.meta.env.VITE_SUPABASE_URL?.includes("oukbxqnlxnkainnligfz");
 
@@ -65,7 +67,7 @@ const AdminDashboard = () => {
   const [pendingCount, setPendingCount] = useState(0);
   const [roleRequestCount, setRoleRequestCount] = useState(0);
 
-  const ADMIN_ONLY_TABS = ['financials', 'tax', 'payouts', 'memberships', 'settings', 'launch', 'voice', 'dev-tools'];
+  const ADMIN_ONLY_TABS = ['financials', 'tax', 'payouts', 'memberships', 'settings', 'launch', 'voice', 'api-keys', 'dev-tools'];
 
   const requestedTab = searchParams.get("tab") || "overview";
   // Redirect staff away from admin-only tabs
@@ -277,6 +279,12 @@ const AdminDashboard = () => {
                 <span className="hidden sm:inline">Resorts</span>
               </TabsTrigger>
             )}
+            {isRavAdmin() && (
+              <TabsTrigger value="api-keys" className="gap-2">
+                <Key className="h-4 w-4" />
+                <span className="hidden sm:inline">API Keys</span>
+              </TabsTrigger>
+            )}
             {IS_DEV && isRavAdmin() && (
               <TabsTrigger value="dev-tools" className="gap-2">
                 <Wrench className="h-4 w-4" />
@@ -392,6 +400,12 @@ const AdminDashboard = () => {
           {isRavAdmin() && (
             <TabsContent value="resorts">
               <AdminResortImport />
+            </TabsContent>
+          )}
+
+          {isRavAdmin() && (
+            <TabsContent value="api-keys">
+              <AdminApiKeys />
             </TabsContent>
           )}
 

--- a/src/pages/BiddingMarketplace.tsx
+++ b/src/pages/BiddingMarketplace.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
 import Header from '@/components/Header';
 import Footer from '@/components/Footer';
+import { usePageMeta } from '@/hooks/usePageMeta';
 import { useAuth } from '@/contexts/AuthContext';
 import { useTextChat } from '@/hooks/useTextChat';
 import { TextChatPanel } from '@/components/TextChatPanel';
@@ -33,6 +34,8 @@ import { format, formatDistanceToNow, differenceInDays } from 'date-fns';
 import type { ListingWithBidding } from '@/types/bidding';
 
 const BiddingMarketplace = () => {
+  usePageMeta('Name Your Price Marketplace', 'Bid on vacation rentals and negotiate directly with verified owners. Place offers at your price.');
+
   const { user, isRenter, isPropertyOwner } = useAuth();
   const { toast } = useToast();
   const [searchParams] = useSearchParams();
@@ -127,7 +130,7 @@ const BiddingMarketplace = () => {
               </TabsTrigger>
               <TabsTrigger value="requests" className="gap-2">
                 <Send className="h-4 w-4" />
-                Tell Us What You Want
+                Vacation Wishes
               </TabsTrigger>
             </TabsList>
 
@@ -190,7 +193,7 @@ const BiddingMarketplace = () => {
             <TabsContent value="requests" className="space-y-6">
               <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
                 <div>
-                  <h2 className="text-xl sm:text-2xl font-bold">Open Travel Requests</h2>
+                  <h2 className="text-xl sm:text-2xl font-bold">Open Vacation Wishes</h2>
                   <p className="text-muted-foreground">
                     Renters looking for vacation rentals - submit your proposal!
                   </p>
@@ -224,7 +227,7 @@ const BiddingMarketplace = () => {
                 <Card className="border-dashed">
                   <CardContent className="flex flex-col items-center justify-center py-16">
                     <Send className="h-12 w-12 text-muted-foreground mb-4" />
-                    <h3 className="text-lg font-semibold mb-2">No travel requests yet</h3>
+                    <h3 className="text-lg font-semibold mb-2">No vacation wishes yet</h3>
                     <p className="text-muted-foreground text-center mb-4">
                       Be the first to post your travel needs and get offers from owners!
                     </p>
@@ -300,7 +303,7 @@ const BiddingMarketplace = () => {
                 <div className="flex gap-4">
                   <div className="flex-shrink-0 h-8 w-8 rounded-full bg-accent/10 flex items-center justify-center text-accent font-bold">2</div>
                   <div>
-                    <p className="font-medium">Browse Travel Requests</p>
+                    <p className="font-medium">Browse Vacation Wishes</p>
                     <p className="text-sm text-muted-foreground">Find renters looking for properties like yours</p>
                   </div>
                 </div>

--- a/src/pages/Checkout.tsx
+++ b/src/pages/Checkout.tsx
@@ -27,8 +27,11 @@ import type { Resort, ResortUnitType } from "@/types/database";
 import { calculateNights, computeFeeBreakdown } from "@/lib/pricing";
 import { EmailVerificationBanner } from "@/components/EmailVerificationBanner";
 import { CancellationPolicyDetail } from "@/components/CancellationPolicyDetail";
+import { usePageMeta } from "@/hooks/usePageMeta";
 
 const Checkout = () => {
+  usePageMeta('Secure Checkout', 'Complete your vacation rental booking securely with PaySafe escrow protection.');
+
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const { user, isEmailVerified } = useAuth();
@@ -303,11 +306,11 @@ const Checkout = () => {
               <div className="flex items-center gap-6 p-4 bg-muted/50 rounded-lg">
                 <div className="flex items-center gap-2 text-sm text-muted-foreground">
                   <Shield className="w-5 h-5 text-primary" />
-                  Secure payment via Stripe
+                  PaySafe — funds held in escrow until check-in
                 </div>
                 <div className="flex items-center gap-2 text-sm text-muted-foreground">
                   <Check className="w-5 h-5 text-primary" />
-                  Verified property
+                  TrustShield verified property
                 </div>
               </div>
             </div>

--- a/src/pages/Developers.tsx
+++ b/src/pages/Developers.tsx
@@ -1,0 +1,85 @@
+import { useEffect, useRef } from "react";
+import Header from "@/components/Header";
+import Footer from "@/components/Footer";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const getSwaggerUI = (): any => (window as Record<string, unknown>).SwaggerUIBundle;
+
+/**
+ * Public API documentation page using Swagger UI.
+ * No auth required — accessible to all visitors.
+ * Renders the public-api.yaml spec (partner-facing, read-only endpoints only).
+ * Route: /developers
+ */
+export default function Developers() {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const initialized = useRef(false);
+
+  useEffect(() => {
+    if (!containerRef.current || initialized.current) return;
+
+    // Load CSS
+    const link = document.createElement("link");
+    link.rel = "stylesheet";
+    link.href = "https://unpkg.com/swagger-ui-dist@5/swagger-ui.css";
+    document.head.appendChild(link);
+
+    // Load JS
+    const script = document.createElement("script");
+    script.src = "https://unpkg.com/swagger-ui-dist@5/swagger-ui-bundle.js";
+    script.onload = () => {
+      const SwaggerUIBundle = getSwaggerUI();
+      if (containerRef.current && SwaggerUIBundle) {
+        SwaggerUIBundle({
+          url: "/api/public-api.yaml",
+          dom_id: "#swagger-ui-public",
+          deepLinking: true,
+          presets: [
+            SwaggerUIBundle.presets.apis,
+            SwaggerUIBundle.SwaggerUIStandalonePreset,
+          ],
+          layout: "BaseLayout",
+        });
+        initialized.current = true;
+      }
+    };
+    document.body.appendChild(script);
+
+    return () => {
+      document.head.removeChild(link);
+      document.body.removeChild(script);
+    };
+  }, []);
+
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Header />
+      <main className="flex-1 pt-16 md:pt-20">
+        <div className="max-w-screen-xl mx-auto px-4 py-8">
+          <div className="mb-6">
+            <h1 className="text-3xl font-bold text-gray-900">
+              Developer API
+            </h1>
+            <p className="text-muted-foreground mt-2">
+              REST API for accessing RAV marketplace data. Browse listings, search properties,
+              and explore destinations programmatically.
+            </p>
+            <div className="flex items-center gap-4 mt-4">
+              <span className="text-xs bg-blue-100 text-blue-800 px-2 py-1 rounded font-medium">
+                v1
+              </span>
+              <span className="text-xs bg-green-100 text-green-800 px-2 py-1 rounded font-medium">
+                Read-Only
+              </span>
+              <span className="text-sm text-muted-foreground">
+                Base URL: <code className="bg-muted px-1.5 py-0.5 rounded text-xs">/functions/v1/api-gateway</code>
+              </span>
+            </div>
+          </div>
+          <div id="swagger-ui-public" ref={containerRef} />
+        </div>
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/src/pages/Documentation.tsx
+++ b/src/pages/Documentation.tsx
@@ -104,6 +104,7 @@ const Documentation = () => {
     { id: "ical-export", label: "iCal Calendar Export", icon: CalendarDays },
     { id: "dynamic-pricing", label: "Dynamic Pricing", icon: Zap },
     { id: "referral-program", label: "Referral Program", icon: Share2 },
+    { id: "public-api", label: "Public API & API Keys", icon: Link2 },
   ];
 
   const currentDate = new Date().toLocaleDateString('en-US', { 
@@ -2815,6 +2816,111 @@ const Documentation = () => {
                       <li>• <strong>Duplicate Prevention:</strong> One referral per referred user (UNIQUE constraint)</li>
                       <li>• <strong>RLS:</strong> Users see own referrals; RAV team sees all</li>
                     </ul>
+                  </div>
+                </div>
+              </section>
+            )}
+
+            {(activeSection === "public-api" || isPrinting) && (
+              <section id="public-api" className="space-y-8">
+                <div>
+                  <h1 className="text-4xl font-bold text-foreground mb-4">Public API & API Keys</h1>
+                  <p className="text-xl text-muted-foreground">
+                    REST API for partners, mobile apps, and integrations. Managed via API keys with tiered rate limiting.
+                  </p>
+                </div>
+
+                <div className="space-y-6">
+                  <div className="bg-card rounded-xl p-6 border">
+                    <h3 className="font-semibold text-lg mb-4">Architecture</h3>
+                    <ul className="space-y-2 text-sm text-muted-foreground">
+                      <li>• <strong>Gateway:</strong> <code className="bg-muted px-1 rounded">api-gateway</code> edge function — single entry point for all <code className="bg-muted px-1 rounded">/v1/*</code> routes</li>
+                      <li>• <strong>Auth:</strong> Dual — API Key (<code className="bg-muted px-1 rounded">X-API-Key</code> header) for partners, JWT (<code className="bg-muted px-1 rounded">Authorization: Bearer</code>) for own apps</li>
+                      <li>• <strong>Key Format:</strong> <code className="bg-muted px-1 rounded">rav_pk_&lt;32 hex chars&gt;</code> — SHA-256 hashed at rest, shown once at creation</li>
+                      <li>• <strong>Tables:</strong> <code className="bg-muted px-1 rounded">api_keys</code> (hashed keys, scopes, tiers) + <code className="bg-muted px-1 rounded">api_request_log</code> (per-request analytics)</li>
+                      <li>• <strong>RPCs:</strong> <code className="bg-muted px-1 rounded">validate_api_key</code>, <code className="bg-muted px-1 rounded">increment_api_key_usage</code>, <code className="bg-muted px-1 rounded">list_api_keys</code>, <code className="bg-muted px-1 rounded">get_api_key_stats</code></li>
+                      <li>• <strong>Shared Modules:</strong> <code className="bg-muted px-1 rounded">_shared/api-auth.ts</code>, <code className="bg-muted px-1 rounded">_shared/api-response.ts</code></li>
+                      <li>• <strong>Admin UI:</strong> "API Keys" tab in Admin Dashboard (rav_admin only)</li>
+                      <li>• <strong>Public Docs:</strong> <code className="bg-muted px-1 rounded">/developers</code> — Swagger UI (no auth required)</li>
+                      <li>• <strong>Migration:</strong> 044</li>
+                    </ul>
+                  </div>
+
+                  <div className="bg-card rounded-xl p-6 border">
+                    <h3 className="font-semibold text-lg mb-4">Public Endpoints (Read-Only)</h3>
+                    <div className="overflow-x-auto">
+                      <table className="w-full text-sm">
+                        <thead>
+                          <tr className="border-b">
+                            <th className="text-left py-2 font-medium">Method</th>
+                            <th className="text-left py-2 font-medium">Path</th>
+                            <th className="text-left py-2 font-medium">Scope</th>
+                            <th className="text-left py-2 font-medium">Description</th>
+                          </tr>
+                        </thead>
+                        <tbody className="text-muted-foreground">
+                          <tr className="border-b"><td className="py-2"><code className="bg-muted px-1 rounded">GET</code></td><td><code className="bg-muted px-1 rounded">/v1/listings</code></td><td>listings:read</td><td>Browse with filters + pagination</td></tr>
+                          <tr className="border-b"><td className="py-2"><code className="bg-muted px-1 rounded">GET</code></td><td><code className="bg-muted px-1 rounded">/v1/listings/:id</code></td><td>listings:read</td><td>Single listing with full details</td></tr>
+                          <tr className="border-b"><td className="py-2"><code className="bg-muted px-1 rounded">POST</code></td><td><code className="bg-muted px-1 rounded">/v1/search</code></td><td>search</td><td>AI-powered property search</td></tr>
+                          <tr className="border-b"><td className="py-2"><code className="bg-muted px-1 rounded">GET</code></td><td><code className="bg-muted px-1 rounded">/v1/destinations</code></td><td>listings:read</td><td>Destination directory (10/35)</td></tr>
+                          <tr><td className="py-2"><code className="bg-muted px-1 rounded">GET</code></td><td><code className="bg-muted px-1 rounded">/v1/resorts</code></td><td>listings:read</td><td>Resort directory with unit types</td></tr>
+                        </tbody>
+                      </table>
+                    </div>
+                  </div>
+
+                  <div className="bg-card rounded-xl p-6 border">
+                    <h3 className="font-semibold text-lg mb-4">Rate Limit Tiers</h3>
+                    <div className="overflow-x-auto">
+                      <table className="w-full text-sm">
+                        <thead>
+                          <tr className="border-b">
+                            <th className="text-left py-2 font-medium">Tier</th>
+                            <th className="text-left py-2 font-medium">Daily</th>
+                            <th className="text-left py-2 font-medium">Per-Minute</th>
+                            <th className="text-left py-2 font-medium">Use Case</th>
+                          </tr>
+                        </thead>
+                        <tbody className="text-muted-foreground">
+                          <tr className="border-b"><td className="py-2">Free</td><td>100</td><td>10</td><td>Developer testing</td></tr>
+                          <tr className="border-b"><td className="py-2">Partner</td><td>10,000</td><td>100</td><td>Travel agents</td></tr>
+                          <tr><td className="py-2">Premium</td><td>100,000</td><td>500</td><td>Large integrators</td></tr>
+                        </tbody>
+                      </table>
+                    </div>
+                  </div>
+
+                  <div className="bg-card rounded-xl p-6 border">
+                    <h3 className="font-semibold text-lg mb-4">Response Format</h3>
+                    <ul className="space-y-2 text-sm text-muted-foreground">
+                      <li>• <strong>Success:</strong> <code className="bg-muted px-1 rounded">{"{ data, meta: { page, per_page, total_count, total_pages }, api_version: \"v1\" }"}</code></li>
+                      <li>• <strong>Error:</strong> <code className="bg-muted px-1 rounded">{"{ error: { code, message }, api_version: \"v1\" }"}</code></li>
+                      <li>• <strong>Rate Limit Headers:</strong> <code className="bg-muted px-1 rounded">X-RateLimit-Limit</code>, <code className="bg-muted px-1 rounded">X-RateLimit-Remaining</code>, <code className="bg-muted px-1 rounded">X-RateLimit-Reset</code></li>
+                      <li>• <strong>Pagination:</strong> <code className="bg-muted px-1 rounded">?page=1&per_page=20</code> (max 50 per page)</li>
+                      <li>• <strong>Versioning:</strong> URL-based (<code className="bg-muted px-1 rounded">/v1/</code>), 6-month deprecation notice via <code className="bg-muted px-1 rounded">Sunset</code> header</li>
+                    </ul>
+                  </div>
+
+                  <div className="bg-card rounded-xl p-6 border">
+                    <h3 className="font-semibold text-lg mb-4">Admin Key Management</h3>
+                    <ol className="space-y-3 text-sm text-muted-foreground">
+                      <li className="flex gap-3">
+                        <span className="h-6 w-6 rounded-full bg-primary/10 text-primary text-xs flex items-center justify-center font-bold flex-shrink-0">1</span>
+                        <span>Admin Dashboard → API Keys tab → Create Key</span>
+                      </li>
+                      <li className="flex gap-3">
+                        <span className="h-6 w-6 rounded-full bg-primary/10 text-primary text-xs flex items-center justify-center font-bold flex-shrink-0">2</span>
+                        <span>Choose name, tier, and scopes → key shown once (copy immediately)</span>
+                      </li>
+                      <li className="flex gap-3">
+                        <span className="h-6 w-6 rounded-full bg-primary/10 text-primary text-xs flex items-center justify-center font-bold flex-shrink-0">3</span>
+                        <span>Key appears in list with prefix, usage counter, and last-used timestamp</span>
+                      </li>
+                      <li className="flex gap-3">
+                        <span className="h-6 w-6 rounded-full bg-primary/10 text-primary text-xs flex items-center justify-center font-bold flex-shrink-0">4</span>
+                        <span>Revoke anytime — immediate, permanent, cannot be undone</span>
+                      </li>
+                    </ol>
                   </div>
                 </div>
               </section>

--- a/src/pages/ExecutiveDashboard.tsx
+++ b/src/pages/ExecutiveDashboard.tsx
@@ -12,8 +12,11 @@ import { IntegrationSettings } from '@/components/executive/IntegrationSettings'
 import { SectionDivider } from '@/components/executive/SectionDivider';
 import Header from '@/components/Header';
 import Footer from '@/components/Footer';
+import { usePageMeta } from '@/hooks/usePageMeta';
 
 const ExecutiveDashboard = () => {
+  usePageMeta('RAV Command', 'Executive dashboard for Rent-A-Vacation marketplace operations and business intelligence.');
+
   const { user, isRavTeam, isLoading } = useAuth();
   const [settingsOpen, setSettingsOpen] = useState(false);
 
@@ -44,9 +47,9 @@ const ExecutiveDashboard = () => {
           {/* Page header */}
           <div className="flex items-center justify-between mb-8">
             <div>
-              <h1 className="text-2xl font-bold text-white">Executive Dashboard</h1>
+              <h1 className="text-2xl font-bold text-white">RAV Command</h1>
               <p className="text-sm text-slate-400 mt-1 max-w-2xl">
-                Real-time marketplace performance, proprietary metrics like Liquidity Score and Bid Spread Index,
+                Boardroom-grade intelligence. Real-time marketplace performance, proprietary metrics like Liquidity Score and Bid Spread Index,
                 competitive benchmarking, and industry intelligence — all in one boardroom-ready view.
               </p>
             </div>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,5 +1,7 @@
+import { useEffect } from "react";
 import { Link } from "react-router-dom";
 import { useAuth } from "@/contexts/AuthContext";
+import { usePageMeta } from "@/hooks/usePageMeta";
 import { Search, LayoutDashboard, Gavel, Heart } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import Header from "@/components/Header";
@@ -73,6 +75,51 @@ const WelcomeBanner = () => {
 
 const Index = () => {
   const { user, isLoading } = useAuth();
+
+  usePageMeta(
+    'Luxury Vacation Rentals at 50–70% Off',
+    'Rent luxury timeshare vacation rentals at up to 70% off retail. Browse 117 resorts from Marriott, Hilton, Disney and more.'
+  );
+
+  // Inject Organization JSON-LD structured data
+  useEffect(() => {
+    const schema = {
+      '@context': 'https://schema.org',
+      '@type': 'Organization',
+      name: 'Rent-A-Vacation',
+      url: 'https://rent-a-vacation.com',
+      logo: 'https://rent-a-vacation.com/rav-logo.svg',
+      description:
+        'The open marketplace for vacation rentals. Rent directly from verified timeshare owners at 50-70% off retail prices.',
+      contactPoint: {
+        '@type': 'ContactPoint',
+        telephone: '+1-800-728-0800',
+        contactType: 'customer service',
+        email: 'support@rent-a-vacation.com',
+        areaServed: 'US',
+        availableLanguage: 'English',
+      },
+      address: {
+        '@type': 'PostalAddress',
+        streetAddress: '7874 Chase Meadows Dr W',
+        addressLocality: 'Jacksonville',
+        addressRegion: 'FL',
+        postalCode: '32256',
+        addressCountry: 'US',
+      },
+    };
+
+    const script = document.createElement('script');
+    script.type = 'application/ld+json';
+    script.id = 'org-schema';
+    script.textContent = JSON.stringify(schema);
+    document.head.appendChild(script);
+
+    return () => {
+      const existing = document.getElementById('org-schema');
+      if (existing) existing.remove();
+    };
+  }, []);
 
   return (
     <div className="min-h-screen">

--- a/src/pages/MaintenanceFeeCalculator.tsx
+++ b/src/pages/MaintenanceFeeCalculator.tsx
@@ -54,6 +54,54 @@ export default function MaintenanceFeeCalculator() {
     'Calculate how many weeks you need to rent your timeshare to cover annual maintenance fees. Free tool for Hilton, Marriott, Disney, Wyndham owners.'
   );
 
+  // Inject HowTo JSON-LD structured data
+  useEffect(() => {
+    const schema = {
+      '@context': 'https://schema.org',
+      '@type': 'HowTo',
+      name: 'Calculate Your Timeshare Break-Even',
+      description:
+        'Use the RAV SmartFee calculator to find out how many weeks you need to rent your timeshare to cover annual maintenance fees.',
+      step: [
+        {
+          '@type': 'HowToStep',
+          position: 1,
+          name: 'Select your brand',
+          text: 'Choose your vacation club brand (Hilton, Marriott, Disney, Wyndham, etc.) from the dropdown.',
+        },
+        {
+          '@type': 'HowToStep',
+          position: 2,
+          name: 'Enter your unit type',
+          text: 'Select your unit type (studio, 1-bedroom, 2-bedroom, etc.) to get accurate rental estimates.',
+        },
+        {
+          '@type': 'HowToStep',
+          position: 3,
+          name: 'Enter your maintenance fees',
+          text: 'Enter your annual maintenance fee amount in dollars.',
+        },
+        {
+          '@type': 'HowToStep',
+          position: 4,
+          name: 'View your results',
+          text: 'See your break-even analysis including weeks needed, potential earnings, and ROI percentage.',
+        },
+      ],
+    };
+
+    const script = document.createElement('script');
+    script.type = 'application/ld+json';
+    script.id = 'calculator-howto-schema';
+    script.textContent = JSON.stringify(schema);
+    document.head.appendChild(script);
+
+    return () => {
+      const existing = document.getElementById('calculator-howto-schema');
+      if (existing) existing.remove();
+    };
+  }, []);
+
   return (
     <div className="min-h-screen flex flex-col">
       <Header />
@@ -64,7 +112,7 @@ export default function MaintenanceFeeCalculator() {
           <div className="text-center mb-10">
             <div className="inline-flex items-center gap-2 bg-blue-50 text-blue-700 px-4 py-1.5 rounded-full text-sm font-medium mb-4">
               <Calculator className="h-4 w-4" />
-              Free Calculator
+              RAV SmartFee
             </div>
             <h1 className="text-3xl sm:text-4xl font-bold text-foreground mb-3">
               Will renting your timeshare cover your maintenance fees?

--- a/src/pages/OwnerDashboard.tsx
+++ b/src/pages/OwnerDashboard.tsx
@@ -59,6 +59,7 @@ import { BidActivityFeed } from "@/components/owner-dashboard/BidActivityFeed";
 import { PricingIntelligence } from "@/components/owner-dashboard/PricingIntelligence";
 import { MaintenanceFeeTracker } from "@/components/owner-dashboard/MaintenanceFeeTracker";
 import PortfolioOverview from "@/components/owner-dashboard/PortfolioOverview";
+import { usePageMeta } from "@/hooks/usePageMeta";
 
 // Backwards-compatible redirect map: old tab values → new ones
 const TAB_REDIRECTS: Record<string, string> = {
@@ -86,6 +87,8 @@ interface DashboardStats {
 }
 
 const OwnerDashboard = () => {
+  usePageMeta("Owner's Edge Dashboard", 'Manage your timeshare listings, bookings, earnings, and owner account.');
+
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
   const { user, isPropertyOwner, isRavTeam, isLoading: authLoading } = useAuth();
@@ -303,9 +306,9 @@ const OwnerDashboard = () => {
                 <ArrowLeft className="h-5 w-5" />
               </Button>
               <div>
-                <h1 className="text-xl sm:text-2xl font-bold">Owner Dashboard</h1>
+                <h1 className="text-xl sm:text-2xl font-bold">Owner's Edge</h1>
                 <p className="text-sm text-muted-foreground">
-                  Manage your properties, listings, and bookings
+                  Your command center — manage listings, bookings, earnings, and more
                 </p>
               </div>
             </div>

--- a/src/pages/PropertyDetail.tsx
+++ b/src/pages/PropertyDetail.tsx
@@ -32,6 +32,7 @@ import {
 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { useListing, useActiveListings } from "@/hooks/useListings";
+import { usePageMeta } from "@/hooks/usePageMeta";
 import { useFavoriteIds, useToggleFavorite } from "@/hooks/useFavorites";
 import { useAuth } from "@/hooks/useAuth";
 import { useToast } from "@/hooks/use-toast";
@@ -115,6 +116,20 @@ const PropertyDetail = () => {
   const resort = prop?.resort;
   const unitType = prop?.unit_type as unknown as Record<string, string> | undefined;
   const nights = listing ? calculateNights(listing.check_in_date, listing.check_out_date) : 0;
+
+  // Dynamic page meta
+  const resortName = (resort as Record<string, unknown> | undefined)?.resort_name as string || 'Resort';
+  const resortLoc = (resort as Record<string, unknown> | undefined)?.location as Record<string, string> | undefined;
+  const locationStr = resortLoc?.city && resortLoc?.state
+    ? `${resortLoc.city}, ${resortLoc.state}`
+    : prop?.location || '';
+  const unitTypeName = unitType?.name || (prop as Record<string, unknown>)?.unit_type_name as string || 'Unit';
+  usePageMeta(
+    listing ? `${resortName} — ${locationStr}` : 'Property Detail',
+    listing
+      ? `Book ${unitTypeName} at ${resortName}. Verified timeshare rental at up to 70% off retail.`
+      : 'View vacation rental property details.'
+  );
   const pricePerNight = listing?.nightly_rate || (nights > 0 && listing ? Math.round(listing.final_price / nights) : 0);
   const fees = listing ? computeFeeBreakdown(pricePerNight, nights, listing.cleaning_fee || 0) : null;
 

--- a/src/pages/RavTools.tsx
+++ b/src/pages/RavTools.tsx
@@ -1,0 +1,213 @@
+import { useEffect } from 'react';
+import { Link } from 'react-router-dom';
+import Header from '@/components/Header';
+import Footer from '@/components/Footer';
+import { usePageMeta } from '@/hooks/usePageMeta';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import {
+  Calculator,
+  TrendingUp,
+  BarChart3,
+  DollarSign,
+  Compass,
+  Wallet,
+  ArrowRight,
+  Wrench,
+} from 'lucide-react';
+
+interface Tool {
+  id: string;
+  brandName: string;
+  description: string;
+  status: 'built' | 'coming-soon';
+  route?: string;
+  icon: React.ElementType;
+}
+
+const TOOLS: Tool[] = [
+  {
+    id: 'smartfee',
+    brandName: 'RAV SmartFee',
+    description:
+      'Calculate how many weeks you need to rent your timeshare to cover annual maintenance fees. Free, no account needed.',
+    status: 'built',
+    route: '/calculator',
+    icon: Calculator,
+  },
+  {
+    id: 'smartprice',
+    brandName: 'RAV SmartPrice',
+    description:
+      'AI-powered fair value scoring that compares your listing to similar properties and shows whether it\'s priced right.',
+    status: 'built',
+    route: '/rentals',
+    icon: TrendingUp,
+  },
+  {
+    id: 'cost-comparator',
+    brandName: 'Vacation Cost Comparator',
+    description:
+      'Compare the total cost of a timeshare rental vs. hotel vs. Airbnb for the same destination and dates.',
+    status: 'coming-soon',
+    icon: BarChart3,
+  },
+  {
+    id: 'yield-estimator',
+    brandName: 'Rental Yield Estimator',
+    description:
+      'Project your annual rental income based on your resort, unit type, and local demand trends.',
+    status: 'coming-soon',
+    icon: DollarSign,
+  },
+  {
+    id: 'resort-quiz',
+    brandName: 'Resort Finder Quiz',
+    description:
+      'Answer a few questions about your ideal vacation and get matched to the perfect resort from our 117-resort database.',
+    status: 'coming-soon',
+    icon: Compass,
+  },
+  {
+    id: 'budget-planner',
+    brandName: 'Trip Budget Planner',
+    description:
+      'Plan your full trip budget including flights, car rental, dining, and activities alongside your accommodation.',
+    status: 'coming-soon',
+    icon: Wallet,
+  },
+];
+
+const RavTools = () => {
+  usePageMeta(
+    'RAV Tools — Free Vacation Planning Tools',
+    'Free tools for timeshare owners and travelers: maintenance fee calculator, smart pricing, cost comparisons, and more.'
+  );
+
+  // Inject ItemList JSON-LD structured data
+  useEffect(() => {
+    const schema = {
+      '@context': 'https://schema.org',
+      '@type': 'ItemList',
+      name: 'RAV Tools — Free Vacation Planning Tools',
+      description:
+        'Free tools for timeshare owners and travelers on Rent-A-Vacation.',
+      numberOfItems: TOOLS.length,
+      itemListElement: TOOLS.map((tool, index) => ({
+        '@type': 'ListItem',
+        position: index + 1,
+        name: tool.brandName,
+        description: tool.description,
+        ...(tool.route
+          ? { url: `https://rent-a-vacation.com${tool.route}` }
+          : {}),
+      })),
+    };
+
+    const script = document.createElement('script');
+    script.type = 'application/ld+json';
+    script.id = 'rav-tools-schema';
+    script.textContent = JSON.stringify(schema);
+    document.head.appendChild(script);
+
+    return () => {
+      const existing = document.getElementById('rav-tools-schema');
+      if (existing) existing.remove();
+    };
+  }, []);
+
+  return (
+    <div className="min-h-screen bg-background">
+      <Header />
+
+      {/* Hero */}
+      <section className="pt-32 pb-16 bg-gradient-warm">
+        <div className="container mx-auto px-4 text-center">
+          <div className="inline-flex items-center gap-2 bg-primary/10 text-primary px-4 py-1.5 rounded-full text-sm font-medium mb-4">
+            <Wrench className="h-4 w-4" />
+            RAV Tools
+          </div>
+          <h1 className="font-display text-4xl md:text-5xl font-bold text-foreground mb-6">
+            Free Tools for Smarter Vacations
+          </h1>
+          <p className="text-xl text-muted-foreground max-w-2xl mx-auto">
+            Whether you own a timeshare or you're planning your next getaway,
+            these tools help you make better decisions — all free, no account required.
+          </p>
+        </div>
+      </section>
+
+      {/* Tool Cards */}
+      <section className="py-16">
+        <div className="container mx-auto px-4">
+          <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
+            {TOOLS.map((tool) => {
+              const Icon = tool.icon;
+              const isBuilt = tool.status === 'built';
+
+              return (
+                <div
+                  key={tool.id}
+                  className={`bg-card rounded-xl shadow-card p-6 flex flex-col ${
+                    isBuilt
+                      ? 'hover:shadow-card-hover transition-shadow'
+                      : 'opacity-60'
+                  }`}
+                >
+                  <div className="flex items-start justify-between mb-4">
+                    <div className="h-12 w-12 rounded-lg bg-primary/10 flex items-center justify-center">
+                      <Icon className="h-6 w-6 text-primary" />
+                    </div>
+                    {!isBuilt && (
+                      <Badge variant="secondary">Coming Soon</Badge>
+                    )}
+                  </div>
+
+                  <h3 className="font-display text-lg font-semibold text-foreground mb-2">
+                    {tool.brandName}
+                  </h3>
+                  <p className="text-muted-foreground text-sm flex-1 mb-4">
+                    {tool.description}
+                  </p>
+
+                  {isBuilt && tool.route ? (
+                    <Link to={tool.route}>
+                      <Button className="w-full gap-2">
+                        Try it Free
+                        <ArrowRight className="h-4 w-4" />
+                      </Button>
+                    </Link>
+                  ) : (
+                    <Button disabled className="w-full" variant="outline">
+                      Coming Soon
+                    </Button>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      </section>
+
+      {/* CTA */}
+      <section className="py-16 bg-muted/50">
+        <div className="container mx-auto px-4 text-center">
+          <h2 className="font-display text-2xl font-bold text-foreground mb-4">
+            Have a Tool Idea?
+          </h2>
+          <p className="text-muted-foreground mb-6 max-w-md mx-auto">
+            We're always building new tools for the vacation ownership community.
+            Let us know what would help you most.
+          </p>
+          <Link to="/contact">
+            <Button variant="outline">Share Your Idea</Button>
+          </Link>
+        </div>
+      </section>
+
+      <Footer />
+    </div>
+  );
+};
+
+export default RavTools;

--- a/src/pages/Rentals.tsx
+++ b/src/pages/Rentals.tsx
@@ -4,6 +4,7 @@ import { format } from "date-fns";
 import type { DateRange } from "react-day-picker";
 import Header from "@/components/Header";
 import Footer from "@/components/Footer";
+import { usePageMeta } from "@/hooks/usePageMeta";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Calendar as CalendarComponent } from "@/components/ui/calendar";
@@ -106,6 +107,8 @@ function getListingBrandLabel(listing: ActiveListing): string {
 }
 
 const Rentals = () => {
+  usePageMeta('Browse Vacation Rentals', 'Search and filter vacation rentals from verified timeshare owners. Compare prices and book at up to 70% off.');
+
   const [searchParams] = useSearchParams();
   const [viewMode, setViewMode] = useState<"grid" | "list">("grid");
   const [showFilters, setShowFilters] = useState(false);

--- a/src/pages/__tests__/RavTools.test.tsx
+++ b/src/pages/__tests__/RavTools.test.tsx
@@ -1,0 +1,76 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { cleanup } from '@testing-library/react';
+import { renderWithProviders, screen } from '@/test/helpers/render';
+import RavTools from '../RavTools';
+
+// Mock Header and Footer to avoid auth/build-globals dependencies
+vi.mock('@/components/Header', () => ({
+  default: () => <header data-testid="header">Header</header>,
+}));
+vi.mock('@/components/Footer', () => ({
+  default: () => <footer data-testid="footer">Footer</footer>,
+}));
+
+afterEach(() => {
+  cleanup();
+  const script = document.getElementById('rav-tools-schema');
+  if (script) script.remove();
+});
+
+describe('RavTools', () => {
+  it('renders all 6 tool cards', () => {
+    renderWithProviders(<RavTools />);
+    expect(screen.getByText('RAV SmartFee')).toBeInTheDocument();
+    expect(screen.getByText('RAV SmartPrice')).toBeInTheDocument();
+    expect(screen.getByText('Vacation Cost Comparator')).toBeInTheDocument();
+    expect(screen.getByText('Rental Yield Estimator')).toBeInTheDocument();
+    expect(screen.getByText('Resort Finder Quiz')).toBeInTheDocument();
+    expect(screen.getByText('Trip Budget Planner')).toBeInTheDocument();
+  });
+
+  it('renders page heading', () => {
+    renderWithProviders(<RavTools />);
+    expect(screen.getByText('Free Tools for Smarter Vacations')).toBeInTheDocument();
+  });
+
+  it('built tools have "Try it Free" buttons with links', () => {
+    renderWithProviders(<RavTools />);
+    const tryButtons = screen.getAllByText('Try it Free');
+    expect(tryButtons).toHaveLength(2);
+    const smartFeeLink = tryButtons[0].closest('a');
+    expect(smartFeeLink).toHaveAttribute('href', '/calculator');
+    const smartPriceLink = tryButtons[1].closest('a');
+    expect(smartPriceLink).toHaveAttribute('href', '/rentals');
+  });
+
+  it('coming soon tools show "Coming Soon" badges', () => {
+    renderWithProviders(<RavTools />);
+    const badges = screen.getAllByText('Coming Soon');
+    // 4 badge elements + 4 disabled buttons = 8 total
+    expect(badges.length).toBeGreaterThanOrEqual(4);
+  });
+
+  it('coming soon tools have disabled buttons', () => {
+    renderWithProviders(<RavTools />);
+    const comingSoonButtons = screen.getAllByRole('button', { name: 'Coming Soon' });
+    expect(comingSoonButtons).toHaveLength(4);
+    comingSoonButtons.forEach((btn) => {
+      expect(btn).toBeDisabled();
+    });
+  });
+
+  it('injects JSON-LD script for ItemList schema', () => {
+    renderWithProviders(<RavTools />);
+    const script = document.getElementById('rav-tools-schema');
+    expect(script).not.toBeNull();
+    const data = JSON.parse(script!.textContent!);
+    expect(data['@type']).toBe('ItemList');
+    expect(data.numberOfItems).toBe(6);
+    expect(data.itemListElement).toHaveLength(6);
+  });
+
+  it('sets page title correctly', () => {
+    renderWithProviders(<RavTools />);
+    expect(document.title).toContain('RAV Tools');
+  });
+});

--- a/supabase/functions/_shared/api-auth.ts
+++ b/supabase/functions/_shared/api-auth.ts
@@ -1,0 +1,153 @@
+/**
+ * API Key authentication and authorization for the Public API gateway.
+ * Handles key validation, rate limiting, scope checking, and request logging.
+ */
+
+// Use minimal interface to avoid import conflicts between esm.sh and npm
+type SupabaseClientLike = {
+  rpc: (fn: string, params: Record<string, unknown>) => Promise<{ data: unknown; error: { message: string } | null }>;
+  from: (table: string) => {
+    insert: (row: Record<string, unknown>) => Promise<{ error: { message: string } | null }>;
+  };
+};
+
+export interface ApiKeyRecord {
+  key_id: string;
+  owner_user_id: string;
+  name: string;
+  scopes: string[];
+  tier: string;
+  daily_limit: number;
+  per_minute_limit: number;
+  daily_usage: number;
+  daily_usage_reset_at: string;
+}
+
+/**
+ * Extract and validate an API key from the request.
+ * Returns the key record if valid, null if no key or invalid.
+ */
+export async function validateApiKey(
+  supabase: SupabaseClientLike,
+  request: Request
+): Promise<ApiKeyRecord | null> {
+  const apiKey = request.headers.get("X-API-Key");
+  if (!apiKey) return null;
+
+  // Validate format: rav_pk_<32 hex chars>
+  if (!/^rav_pk_[a-f0-9]{32}$/.test(apiKey)) return null;
+
+  const keyHash = await hashApiKey(apiKey);
+  const { data, error } = await supabase.rpc("validate_api_key", {
+    p_key_hash: keyHash,
+  });
+
+  if (error) {
+    console.error("[API-AUTH] Key validation error:", error.message);
+    return null;
+  }
+
+  const records = data as ApiKeyRecord[];
+  if (!records || records.length === 0) return null;
+
+  return records[0];
+}
+
+/**
+ * Check if an API key has the required scope.
+ */
+export function hasScope(keyScopes: string[], requiredScope: string): boolean {
+  // Wildcard scope grants all access
+  if (keyScopes.includes("*")) return true;
+
+  // Direct match
+  if (keyScopes.includes(requiredScope)) return true;
+
+  // Parent scope match: "listings:read" matches "listings"
+  const parentScope = requiredScope.split(":")[0];
+  if (keyScopes.includes(parentScope)) return true;
+
+  return false;
+}
+
+/**
+ * Increment API key daily usage counter.
+ * Returns true if within limit, false if rate limit exceeded.
+ */
+export async function checkApiKeyRateLimit(
+  supabase: SupabaseClientLike,
+  keyId: string
+): Promise<boolean> {
+  const { data: allowed, error } = await supabase.rpc("increment_api_key_usage", {
+    p_key_id: keyId,
+  });
+
+  if (error) {
+    // Fail-open on rate limit check errors
+    console.error("[API-AUTH] Rate limit check error:", error.message);
+    return true;
+  }
+
+  return allowed as boolean;
+}
+
+/**
+ * Log an API request (fire-and-forget — errors are swallowed).
+ */
+export function logApiRequest(
+  supabase: SupabaseClientLike,
+  params: {
+    keyId: string | null;
+    endpoint: string;
+    method: string;
+    statusCode: number;
+    responseTimeMs: number;
+    ipAddress: string | null;
+    userAgent: string | null;
+  }
+): void {
+  // Fire-and-forget — don't await
+  supabase.from("api_request_log").insert({
+    key_id: params.keyId,
+    endpoint: params.endpoint,
+    method: params.method,
+    status_code: params.statusCode,
+    response_time_ms: params.responseTimeMs,
+    ip_address: params.ipAddress,
+    user_agent: params.userAgent,
+  }).then(({ error }) => {
+    if (error) {
+      console.error("[API-AUTH] Request log error:", error.message);
+    }
+  });
+}
+
+/**
+ * SHA-256 hash of an API key string.
+ */
+export async function hashApiKey(key: string): Promise<string> {
+  const encoder = new TextEncoder();
+  const data = encoder.encode(key);
+  const hashBuffer = await crypto.subtle.digest("SHA-256", data);
+  const hashArray = Array.from(new Uint8Array(hashBuffer));
+  return hashArray.map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+/**
+ * Generate a new API key in the format: rav_pk_<32 hex chars>
+ */
+export function generateApiKey(): string {
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  const hex = Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+  return `rav_pk_${hex}`;
+}
+
+/** Rate limit tiers with default limits */
+export const API_KEY_TIERS = {
+  free: { daily: 100, perMinute: 10 },
+  partner: { daily: 10_000, perMinute: 100 },
+  premium: { daily: 100_000, perMinute: 500 },
+} as const;

--- a/supabase/functions/_shared/api-response.ts
+++ b/supabase/functions/_shared/api-response.ts
@@ -1,0 +1,117 @@
+/**
+ * Standardized response helpers for the Public API.
+ * Provides consistent envelope format, pagination, and rate limit headers.
+ */
+
+const API_VERSION = "v1";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers":
+    "authorization, x-client-info, apikey, content-type, x-api-key",
+  "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+};
+
+export interface PaginationMeta {
+  page: number;
+  per_page: number;
+  total_count: number;
+  total_pages: number;
+}
+
+/**
+ * Standard success response envelope.
+ */
+export function apiSuccess(
+  data: unknown,
+  meta?: Partial<PaginationMeta>,
+  status = 200
+): Response {
+  const body: Record<string, unknown> = {
+    data,
+    api_version: API_VERSION,
+  };
+
+  if (meta) {
+    body.meta = {
+      page: meta.page ?? 1,
+      per_page: meta.per_page ?? 20,
+      total_count: meta.total_count ?? 0,
+      total_pages: meta.total_pages ?? 0,
+    };
+  }
+
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      ...corsHeaders,
+      "Content-Type": "application/json",
+    },
+  });
+}
+
+/**
+ * Standard error response envelope.
+ */
+export function apiError(
+  code: string,
+  message: string,
+  status: number
+): Response {
+  return new Response(
+    JSON.stringify({
+      error: { code, message },
+      api_version: API_VERSION,
+    }),
+    {
+      status,
+      headers: {
+        ...corsHeaders,
+        "Content-Type": "application/json",
+      },
+    }
+  );
+}
+
+/**
+ * Add rate limit headers to an existing response.
+ */
+export function withRateLimitHeaders(
+  response: Response,
+  remaining: number,
+  limit: number,
+  resetAt: Date
+): Response {
+  const headers = new Headers(response.headers);
+  headers.set("X-RateLimit-Limit", String(limit));
+  headers.set("X-RateLimit-Remaining", String(Math.max(0, remaining)));
+  headers.set("X-RateLimit-Reset", String(Math.floor(resetAt.getTime() / 1000)));
+
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}
+
+/**
+ * Parse pagination parameters from URL query string.
+ * Defaults: page=1, per_page=20, max per_page=50.
+ */
+export function parsePagination(url: URL): { page: number; perPage: number; offset: number } {
+  const page = Math.max(1, parseInt(url.searchParams.get("page") ?? "1", 10) || 1);
+  const perPage = Math.min(50, Math.max(1, parseInt(url.searchParams.get("per_page") ?? "20", 10) || 20));
+  const offset = (page - 1) * perPage;
+
+  return { page, perPage, offset };
+}
+
+/**
+ * CORS preflight response.
+ */
+export function corsResponse(): Response {
+  return new Response(null, {
+    status: 204,
+    headers: corsHeaders,
+  });
+}

--- a/supabase/functions/_shared/destinations.ts
+++ b/supabase/functions/_shared/destinations.ts
@@ -1,0 +1,148 @@
+/**
+ * Destination and city data for the Public API.
+ * Mirrored from src/lib/destinations.ts for edge function use.
+ */
+
+export interface DestinationCity {
+  slug: string;
+  name: string;
+  description: string;
+}
+
+export interface Destination {
+  slug: string;
+  name: string;
+  region: string;
+  description: string;
+  cities: DestinationCity[];
+  featured: boolean;
+}
+
+export const DESTINATIONS: Destination[] = [
+  {
+    slug: 'hawaii',
+    name: 'Hawaii',
+    region: 'Pacific',
+    description: 'Experience world-class beaches, volcanic landscapes, and aloha spirit at luxury timeshare resorts across the Hawaiian islands.',
+    cities: [
+      { slug: 'maui', name: 'Maui', description: 'The Valley Isle — stunning beaches, whale watching, and the Road to Hana.' },
+      { slug: 'oahu', name: 'Oahu', description: 'Home to Waikiki Beach, Diamond Head, and Honolulu\'s vibrant culture.' },
+      { slug: 'big-island', name: 'Big Island', description: 'Active volcanoes, black sand beaches, and world-famous Kona coffee.' },
+      { slug: 'kauai', name: 'Kauai', description: 'The Garden Isle — Na Pali Coast, Waimea Canyon, and lush tropical beauty.' },
+    ],
+    featured: true,
+  },
+  {
+    slug: 'florida',
+    name: 'Florida',
+    region: 'Southeast',
+    description: 'From Orlando theme parks to Miami\'s art deco coast, Florida offers year-round sunshine and endless vacation possibilities.',
+    cities: [
+      { slug: 'orlando', name: 'Orlando', description: 'Theme park capital — Disney, Universal, and dozens of resort communities.' },
+      { slug: 'miami', name: 'Miami', description: 'Art Deco beaches, South Beach nightlife, and vibrant Latin culture.' },
+      { slug: 'tampa', name: 'Tampa', description: 'Gulf Coast charm with Busch Gardens, Clearwater Beach, and waterfront dining.' },
+      { slug: 'jacksonville', name: 'Jacksonville', description: 'Atlantic beaches, historic districts, and a thriving food scene.' },
+    ],
+    featured: true,
+  },
+  {
+    slug: 'california',
+    name: 'California',
+    region: 'West',
+    description: 'Sun-drenched coastlines, wine country, mountain resorts, and iconic cities make California a year-round destination.',
+    cities: [
+      { slug: 'san-diego', name: 'San Diego', description: 'Perfect weather, beautiful beaches, and the famous San Diego Zoo.' },
+      { slug: 'palm-springs', name: 'Palm Springs', description: 'Desert oasis with mid-century modern architecture and world-class golf.' },
+      { slug: 'lake-tahoe', name: 'Lake Tahoe', description: 'Crystal-clear alpine lake with skiing, hiking, and breathtaking scenery.' },
+      { slug: 'napa-valley', name: 'Napa Valley', description: 'World-renowned wine country with luxury resorts and gourmet dining.' },
+    ],
+    featured: false,
+  },
+  {
+    slug: 'mexico',
+    name: 'Mexico',
+    region: 'International',
+    description: 'Turquoise waters, ancient ruins, and vibrant culture — Mexico\'s resort destinations offer affordable luxury.',
+    cities: [
+      { slug: 'cancun', name: 'Cancun', description: 'Caribbean beaches, Mayan ruins, and a legendary hotel zone.' },
+      { slug: 'cabo-san-lucas', name: 'Cabo San Lucas', description: 'Where the desert meets the sea — deep-sea fishing and luxury resorts.' },
+      { slug: 'puerto-vallarta', name: 'Puerto Vallarta', description: 'Colonial charm, golden beaches, and the Sierra Madre mountains.' },
+      { slug: 'riviera-maya', name: 'Riviera Maya', description: 'Pristine cenotes, eco-parks, and boutique beachfront resorts.' },
+    ],
+    featured: true,
+  },
+  {
+    slug: 'caribbean',
+    name: 'Caribbean',
+    region: 'International',
+    description: 'Island-hop through turquoise waters, white sand beaches, and rum-infused culture across the Caribbean.',
+    cities: [
+      { slug: 'aruba', name: 'Aruba', description: 'One Happy Island — constant trade winds, eagle beach, and desert landscapes.' },
+      { slug: 'jamaica', name: 'Jamaica', description: 'Reggae rhythms, jerk cuisine, and the stunning Blue Mountains.' },
+      { slug: 'bahamas', name: 'Bahamas', description: 'Crystal-clear waters, swimming pigs, and 700 islands to explore.' },
+      { slug: 'st-maarten', name: 'St. Maarten', description: 'Two cultures on one island — French and Dutch Caribbean charm.' },
+    ],
+    featured: false,
+  },
+  {
+    slug: 'colorado',
+    name: 'Colorado',
+    region: 'Mountain',
+    description: 'World-class skiing, summer hiking, and mountain town charm in the heart of the Rocky Mountains.',
+    cities: [
+      { slug: 'vail', name: 'Vail', description: 'Legendary ski resort with European-style village and summer adventures.' },
+      { slug: 'breckenridge', name: 'Breckenridge', description: 'Historic mining town turned ski paradise with vibrant Main Street.' },
+      { slug: 'aspen', name: 'Aspen', description: 'Glamorous mountain retreat with four ski areas and cultural scene.' },
+      { slug: 'steamboat-springs', name: 'Steamboat Springs', description: 'Champagne powder snow and natural hot springs.' },
+    ],
+    featured: false,
+  },
+  {
+    slug: 'arizona',
+    name: 'Arizona',
+    region: 'Southwest',
+    description: 'Desert beauty, world-class spas, championship golf, and the awe-inspiring Grand Canyon.',
+    cities: [
+      { slug: 'scottsdale', name: 'Scottsdale', description: 'Luxury spas, championship golf, and vibrant Old Town nightlife.' },
+      { slug: 'sedona', name: 'Sedona', description: 'Red rock formations, spiritual vortexes, and stunning desert landscapes.' },
+      { slug: 'phoenix', name: 'Phoenix', description: 'Valley of the Sun — spring training baseball and desert mountain hikes.' },
+      { slug: 'tucson', name: 'Tucson', description: 'Saguaro National Park, historic missions, and authentic Southwestern cuisine.' },
+    ],
+    featured: false,
+  },
+  {
+    slug: 'nevada',
+    name: 'Nevada',
+    region: 'West',
+    description: 'Beyond the bright lights of Las Vegas, Nevada offers Lake Tahoe shores and vast desert adventures.',
+    cities: [
+      { slug: 'las-vegas', name: 'Las Vegas', description: 'Entertainment capital — world-class shows, dining, and resort experiences.' },
+      { slug: 'reno', name: 'Reno', description: 'The Biggest Little City — gateway to Sierra Nevada adventures.' },
+    ],
+    featured: false,
+  },
+  {
+    slug: 'south-carolina',
+    name: 'South Carolina',
+    region: 'Southeast',
+    description: 'Southern hospitality meets coastal charm with historic cities and pristine beach resorts.',
+    cities: [
+      { slug: 'myrtle-beach', name: 'Myrtle Beach', description: 'Grand Strand beaches, golf, and family-friendly attractions.' },
+      { slug: 'hilton-head', name: 'Hilton Head', description: 'Barrier island paradise with world-class golf and cycling paths.' },
+      { slug: 'charleston', name: 'Charleston', description: 'Historic district, award-winning restaurants, and plantation country.' },
+    ],
+    featured: false,
+  },
+  {
+    slug: 'utah',
+    name: 'Utah',
+    region: 'Mountain',
+    description: 'The Mighty Five national parks, world-class ski resorts, and dramatic red rock landscapes.',
+    cities: [
+      { slug: 'park-city', name: 'Park City', description: 'Olympic ski resort town with Sundance Film Festival and mountain biking.' },
+      { slug: 'st-george', name: 'St. George', description: 'Gateway to Zion National Park with year-round golf and hiking.' },
+      { slug: 'moab', name: 'Moab', description: 'Adventure capital near Arches and Canyonlands national parks.' },
+    ],
+    featured: false,
+  },
+];

--- a/supabase/functions/api-gateway/index.ts
+++ b/supabase/functions/api-gateway/index.ts
@@ -1,0 +1,455 @@
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { validateApiKey, hasScope, checkApiKeyRateLimit, logApiRequest } from "../_shared/api-auth.ts";
+import { apiSuccess, apiError, corsResponse, parsePagination, withRateLimitHeaders } from "../_shared/api-response.ts";
+import { searchProperties } from "../_shared/property-search.ts";
+import { DESTINATIONS } from "../_shared/destinations.ts";
+import type { ApiKeyRecord } from "../_shared/api-auth.ts";
+
+const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
+const SUPABASE_ANON_KEY = Deno.env.get("SUPABASE_ANON_KEY")!;
+const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+
+// ─── Route definitions ─────────────────────────────────────────────────────
+
+interface RouteConfig {
+  method: string;
+  scope: string;
+  handler: (req: Request, supabase: ReturnType<typeof createClient>, url: URL) => Promise<Response>;
+}
+
+const routes: Record<string, RouteConfig> = {
+  "GET /v1/listings": {
+    method: "GET",
+    scope: "listings:read",
+    handler: handleListings,
+  },
+  "GET /v1/listings/:id": {
+    method: "GET",
+    scope: "listings:read",
+    handler: handleListingById,
+  },
+  "POST /v1/search": {
+    method: "POST",
+    scope: "search",
+    handler: handleSearch,
+  },
+  "GET /v1/destinations": {
+    method: "GET",
+    scope: "listings:read",
+    handler: handleDestinations,
+  },
+  "GET /v1/resorts": {
+    method: "GET",
+    scope: "listings:read",
+    handler: handleResorts,
+  },
+};
+
+// ─── Main handler ───────────────────────────────────────────────────────────
+
+Deno.serve(async (req: Request) => {
+  if (req.method === "OPTIONS") {
+    return corsResponse();
+  }
+
+  const startTime = Date.now();
+  const url = new URL(req.url);
+
+  // Extract the path after /api-gateway (Supabase routes: /functions/v1/api-gateway/v1/...)
+  const fullPath = url.pathname;
+  const gatewayPrefix = "/api-gateway";
+  const apiPath = fullPath.includes(gatewayPrefix)
+    ? fullPath.substring(fullPath.indexOf(gatewayPrefix) + gatewayPrefix.length)
+    : fullPath;
+
+  // ── Auth: API Key or JWT ────────────────────────────────────────────────
+
+  const serviceClient = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+  let apiKeyRecord: ApiKeyRecord | null = null;
+  let authedViaJwt = false;
+
+  // Try API key first
+  apiKeyRecord = await validateApiKey(serviceClient, req);
+
+  // If no API key, try JWT
+  if (!apiKeyRecord) {
+    const authHeader = req.headers.get("Authorization");
+    if (authHeader?.startsWith("Bearer ")) {
+      const token = authHeader.replace("Bearer ", "");
+      // Skip service role key — that's not a user JWT
+      if (token !== SUPABASE_SERVICE_ROLE_KEY) {
+        const userClient = createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
+          global: { headers: { Authorization: `Bearer ${token}` } },
+        });
+        const { data: { user }, error } = await userClient.auth.getUser();
+        if (user && !error) {
+          authedViaJwt = true;
+        }
+      }
+    }
+  }
+
+  if (!apiKeyRecord && !authedViaJwt) {
+    return apiError("unauthorized", "Missing or invalid authentication. Provide X-API-Key header or Authorization: Bearer <jwt>.", 401);
+  }
+
+  // ── Route matching ────────────────────────────────────────────────────────
+
+  const { handler, scope, matchedPath } = matchRoute(req.method, apiPath);
+
+  if (!handler) {
+    return apiError("not_found", `No endpoint matches ${req.method} ${apiPath}`, 404);
+  }
+
+  // ── Scope check (API key only — JWT users have implicit access) ──────────
+
+  if (apiKeyRecord && !hasScope(apiKeyRecord.scopes, scope)) {
+    logRequest(serviceClient, apiKeyRecord?.key_id ?? null, matchedPath, req, 403, startTime);
+    return apiError("forbidden", `API key missing required scope: ${scope}`, 403);
+  }
+
+  // ── Rate limit check (API key only — JWT uses existing per-user limits) ──
+
+  if (apiKeyRecord) {
+    const allowed = await checkApiKeyRateLimit(serviceClient, apiKeyRecord.key_id);
+    if (!allowed) {
+      logRequest(serviceClient, apiKeyRecord.key_id, matchedPath, req, 429, startTime);
+      const retryAfter = 86400; // Daily limit — retry after 24h
+      return new Response(
+        JSON.stringify({
+          error: { code: "rate_limit_exceeded", message: "Daily API key rate limit exceeded." },
+          api_version: "v1",
+        }),
+        {
+          status: 429,
+          headers: {
+            "Content-Type": "application/json",
+            "Retry-After": String(retryAfter),
+            "Access-Control-Allow-Origin": "*",
+          },
+        }
+      );
+    }
+  }
+
+  // ── Execute handler ───────────────────────────────────────────────────────
+
+  try {
+    const response = await handler(req, serviceClient, url);
+
+    // Add rate limit headers for API key requests
+    let finalResponse = response;
+    if (apiKeyRecord) {
+      const remaining = apiKeyRecord.daily_limit - (apiKeyRecord.daily_usage + 1);
+      const resetAt = new Date(apiKeyRecord.daily_usage_reset_at);
+      resetAt.setHours(resetAt.getHours() + 24);
+      finalResponse = withRateLimitHeaders(response, remaining, apiKeyRecord.daily_limit, resetAt);
+    }
+
+    logRequest(serviceClient, apiKeyRecord?.key_id ?? null, matchedPath, req, response.status, startTime);
+    return finalResponse;
+  } catch (err) {
+    console.error(`[API-GATEWAY] Handler error on ${matchedPath}:`, err);
+    logRequest(serviceClient, apiKeyRecord?.key_id ?? null, matchedPath, req, 500, startTime);
+    return apiError("internal_error", "An unexpected error occurred.", 500);
+  }
+});
+
+// ─── Route matching helper ──────────────────────────────────────────────────
+
+function matchRoute(
+  method: string,
+  path: string
+): { handler: RouteConfig["handler"] | null; scope: string; matchedPath: string } {
+  // Normalize path: remove trailing slash
+  const normalizedPath = path.endsWith("/") && path.length > 1 ? path.slice(0, -1) : path;
+
+  // Try exact match first
+  const exactKey = `${method} ${normalizedPath}`;
+  if (routes[exactKey]) {
+    return { handler: routes[exactKey].handler, scope: routes[exactKey].scope, matchedPath: normalizedPath };
+  }
+
+  // Try parameterized match: /v1/listings/:id
+  const parts = normalizedPath.split("/");
+  if (parts.length === 4 && parts[1] === "v1" && parts[2] === "listings") {
+    const paramKey = `${method} /v1/listings/:id`;
+    if (routes[paramKey]) {
+      return { handler: routes[paramKey].handler, scope: routes[paramKey].scope, matchedPath: normalizedPath };
+    }
+  }
+
+  return { handler: null, scope: "", matchedPath: normalizedPath };
+}
+
+// ─── Fire-and-forget request logging ────────────────────────────────────────
+
+function logRequest(
+  supabase: ReturnType<typeof createClient>,
+  keyId: string | null,
+  endpoint: string,
+  req: Request,
+  status: number,
+  startTime: number
+) {
+  logApiRequest(supabase, {
+    keyId,
+    endpoint,
+    method: req.method,
+    statusCode: status,
+    responseTimeMs: Date.now() - startTime,
+    ipAddress: req.headers.get("x-forwarded-for") ?? req.headers.get("cf-connecting-ip") ?? null,
+    userAgent: req.headers.get("user-agent") ?? null,
+  });
+}
+
+// ─── Route Handlers ─────────────────────────────────────────────────────────
+
+/**
+ * GET /v1/listings — Browse listings with filters and pagination
+ */
+async function handleListings(
+  req: Request,
+  supabase: ReturnType<typeof createClient>,
+  url: URL
+): Promise<Response> {
+  const { page, perPage, offset } = parsePagination(url);
+
+  // Build query
+  let query = supabase
+    .from("listings")
+    .select(`
+      id,
+      check_in_date,
+      check_out_date,
+      owner_price,
+      nightly_rate,
+      status,
+      created_at,
+      properties!inner (
+        id,
+        name,
+        city,
+        state,
+        country,
+        bedrooms,
+        bathrooms,
+        sleeps,
+        amenities,
+        images,
+        resorts (
+          id,
+          name,
+          brand,
+          rating,
+          amenities
+        ),
+        unit_types (
+          id,
+          name,
+          square_footage
+        )
+      )
+    `, { count: "exact" })
+    .eq("status", "active");
+
+  // Filters
+  const destination = url.searchParams.get("destination");
+  if (destination) {
+    // Search city, state, or country
+    query = query.or(
+      `properties.city.ilike.%${destination}%,properties.state.ilike.%${destination}%,properties.country.ilike.%${destination}%`
+    );
+  }
+
+  const minPrice = url.searchParams.get("min_price");
+  if (minPrice) query = query.gte("owner_price", Number(minPrice));
+
+  const maxPrice = url.searchParams.get("max_price");
+  if (maxPrice) query = query.lte("owner_price", Number(maxPrice));
+
+  const bedrooms = url.searchParams.get("bedrooms");
+  if (bedrooms) query = query.gte("properties.bedrooms", Number(bedrooms));
+
+  const brand = url.searchParams.get("brand");
+  if (brand) query = query.ilike("properties.resorts.brand", `%${brand}%`);
+
+  const checkIn = url.searchParams.get("check_in");
+  if (checkIn) query = query.gte("check_in_date", checkIn);
+
+  const checkOut = url.searchParams.get("check_out");
+  if (checkOut) query = query.lte("check_out_date", checkOut);
+
+  // Pagination
+  query = query
+    .order("created_at", { ascending: false })
+    .range(offset, offset + perPage - 1);
+
+  const { data, error, count } = await query;
+
+  if (error) {
+    console.error("[API-GATEWAY] Listings query error:", error);
+    return apiError("query_error", error.message, 500);
+  }
+
+  const totalCount = count ?? 0;
+  return apiSuccess(data, {
+    page,
+    per_page: perPage,
+    total_count: totalCount,
+    total_pages: Math.ceil(totalCount / perPage),
+  });
+}
+
+/**
+ * GET /v1/listings/:id — Single listing with full details
+ */
+async function handleListingById(
+  req: Request,
+  supabase: ReturnType<typeof createClient>,
+  url: URL
+): Promise<Response> {
+  const fullPath = url.pathname;
+  const gatewayPrefix = "/api-gateway";
+  const apiPath = fullPath.includes(gatewayPrefix)
+    ? fullPath.substring(fullPath.indexOf(gatewayPrefix) + gatewayPrefix.length)
+    : fullPath;
+  const parts = apiPath.split("/");
+  const listingId = parts[3]; // /v1/listings/<id>
+
+  if (!listingId) {
+    return apiError("bad_request", "Missing listing ID", 400);
+  }
+
+  const { data, error } = await supabase
+    .from("listings")
+    .select(`
+      id,
+      check_in_date,
+      check_out_date,
+      owner_price,
+      nightly_rate,
+      status,
+      created_at,
+      properties!inner (
+        id,
+        name,
+        description,
+        city,
+        state,
+        country,
+        bedrooms,
+        bathrooms,
+        sleeps,
+        amenities,
+        images,
+        resorts (
+          id,
+          name,
+          brand,
+          rating,
+          amenities,
+          address,
+          city,
+          state
+        ),
+        unit_types (
+          id,
+          name,
+          square_footage,
+          max_occupancy
+        )
+      )
+    `)
+    .eq("id", listingId)
+    .single();
+
+  if (error || !data) {
+    return apiError("not_found", `Listing ${listingId} not found`, 404);
+  }
+
+  return apiSuccess(data);
+}
+
+/**
+ * POST /v1/search — AI-powered property search (reuses shared searchProperties)
+ */
+async function handleSearch(
+  req: Request,
+  supabase: ReturnType<typeof createClient>,
+  _url: URL
+): Promise<Response> {
+  let body;
+  try {
+    body = await req.json();
+  } catch {
+    return apiError("bad_request", "Invalid JSON body", 400);
+  }
+
+  const results = await searchProperties(supabase, body);
+
+  return apiSuccess(results, {
+    total_count: results.length,
+  });
+}
+
+/**
+ * GET /v1/destinations — Static destination directory
+ */
+async function handleDestinations(
+  _req: Request,
+  _supabase: ReturnType<typeof createClient>,
+  _url: URL
+): Promise<Response> {
+  return apiSuccess(DESTINATIONS, {
+    total_count: DESTINATIONS.length,
+  });
+}
+
+/**
+ * GET /v1/resorts — Resort directory with pagination
+ */
+async function handleResorts(
+  _req: Request,
+  supabase: ReturnType<typeof createClient>,
+  url: URL
+): Promise<Response> {
+  const { page, perPage, offset } = parsePagination(url);
+
+  const { data, error, count } = await supabase
+    .from("resorts")
+    .select(`
+      id,
+      name,
+      brand,
+      rating,
+      amenities,
+      address,
+      city,
+      state,
+      country,
+      unit_types (
+        id,
+        name,
+        bedrooms,
+        bathrooms,
+        max_occupancy,
+        square_footage
+      )
+    `, { count: "exact" })
+    .order("name")
+    .range(offset, offset + perPage - 1);
+
+  if (error) {
+    console.error("[API-GATEWAY] Resorts query error:", error);
+    return apiError("query_error", error.message, 500);
+  }
+
+  const totalCount = count ?? 0;
+  return apiSuccess(data, {
+    page,
+    per_page: perPage,
+    total_count: totalCount,
+    total_pages: Math.ceil(totalCount / perPage),
+  });
+}

--- a/supabase/migrations/044_api_keys.sql
+++ b/supabase/migrations/044_api_keys.sql
@@ -1,0 +1,223 @@
+-- Migration 044: API Key Infrastructure for Public API
+-- Provides API key management, rate limiting, and request logging
+
+-- ─── Tables ────────────────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS api_keys (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  owner_user_id uuid NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
+  name text NOT NULL,
+  key_prefix text NOT NULL,          -- First 8 chars of the key (for display: rav_pk_xxxx...)
+  key_hash text NOT NULL UNIQUE,     -- SHA-256 hash of the full key
+  scopes text[] NOT NULL DEFAULT '{}',
+  tier text NOT NULL DEFAULT 'free' CHECK (tier IN ('free', 'partner', 'premium')),
+  daily_limit integer NOT NULL DEFAULT 100,
+  per_minute_limit integer NOT NULL DEFAULT 10,
+  daily_usage integer NOT NULL DEFAULT 0,
+  daily_usage_reset_at timestamptz NOT NULL DEFAULT now(),
+  is_active boolean NOT NULL DEFAULT true,
+  revoked_at timestamptz,
+  expires_at timestamptz,
+  last_used_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS api_request_log (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  key_id uuid REFERENCES api_keys(id) ON DELETE SET NULL,
+  endpoint text NOT NULL,
+  method text NOT NULL DEFAULT 'GET',
+  status_code integer,
+  response_time_ms integer,
+  ip_address text,
+  user_agent text,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- Index for analytics queries
+CREATE INDEX IF NOT EXISTS idx_api_request_log_key_id ON api_request_log(key_id);
+CREATE INDEX IF NOT EXISTS idx_api_request_log_created_at ON api_request_log(created_at);
+CREATE INDEX IF NOT EXISTS idx_api_keys_key_hash ON api_keys(key_hash);
+CREATE INDEX IF NOT EXISTS idx_api_keys_owner ON api_keys(owner_user_id);
+
+-- Trigger for updated_at
+CREATE TRIGGER set_api_keys_updated_at
+  BEFORE UPDATE ON api_keys
+  FOR EACH ROW
+  EXECUTE FUNCTION update_updated_at_column();
+
+-- ─── RLS ────────────────────────────────────────────────────────────────────
+
+ALTER TABLE api_keys ENABLE ROW LEVEL SECURITY;
+ALTER TABLE api_request_log ENABLE ROW LEVEL SECURITY;
+
+-- Service role only — no direct frontend access
+-- Admin reads via service role client or RPCs
+
+-- ─── RPCs ───────────────────────────────────────────────────────────────────
+
+-- Validate an API key by its hash, returns the key record if valid
+CREATE OR REPLACE FUNCTION validate_api_key(p_key_hash text)
+RETURNS TABLE (
+  key_id uuid,
+  owner_user_id uuid,
+  name text,
+  scopes text[],
+  tier text,
+  daily_limit integer,
+  per_minute_limit integer,
+  daily_usage integer,
+  daily_usage_reset_at timestamptz
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+BEGIN
+  RETURN QUERY
+  SELECT
+    ak.id,
+    ak.owner_user_id,
+    ak.name,
+    ak.scopes,
+    ak.tier,
+    ak.daily_limit,
+    ak.per_minute_limit,
+    ak.daily_usage,
+    ak.daily_usage_reset_at
+  FROM api_keys ak
+  WHERE ak.key_hash = p_key_hash
+    AND ak.is_active = true
+    AND ak.revoked_at IS NULL
+    AND (ak.expires_at IS NULL OR ak.expires_at > now());
+
+  -- Update last_used_at as a side effect
+  UPDATE api_keys SET last_used_at = now() WHERE api_keys.key_hash = p_key_hash;
+END;
+$$;
+
+-- Increment daily usage counter with auto-reset, returns true if within limit
+CREATE OR REPLACE FUNCTION increment_api_key_usage(p_key_id uuid)
+RETURNS boolean
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_daily_limit integer;
+  v_current_usage integer;
+  v_reset_at timestamptz;
+BEGIN
+  SELECT daily_limit, daily_usage, daily_usage_reset_at
+  INTO v_daily_limit, v_current_usage, v_reset_at
+  FROM api_keys
+  WHERE id = p_key_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RETURN false;
+  END IF;
+
+  -- Auto-reset if a new day has started (24h since last reset)
+  IF v_reset_at < now() - interval '24 hours' THEN
+    UPDATE api_keys
+    SET daily_usage = 1, daily_usage_reset_at = now()
+    WHERE id = p_key_id;
+    RETURN true;
+  END IF;
+
+  -- Check if within limit
+  IF v_current_usage >= v_daily_limit THEN
+    RETURN false;
+  END IF;
+
+  -- Increment
+  UPDATE api_keys
+  SET daily_usage = daily_usage + 1
+  WHERE id = p_key_id;
+
+  RETURN true;
+END;
+$$;
+
+-- Admin: list all API keys (for admin dashboard)
+CREATE OR REPLACE FUNCTION list_api_keys()
+RETURNS TABLE (
+  id uuid,
+  owner_user_id uuid,
+  owner_email text,
+  name text,
+  key_prefix text,
+  scopes text[],
+  tier text,
+  daily_limit integer,
+  per_minute_limit integer,
+  daily_usage integer,
+  is_active boolean,
+  revoked_at timestamptz,
+  expires_at timestamptz,
+  last_used_at timestamptz,
+  created_at timestamptz
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+BEGIN
+  -- Only RAV admins can list all keys
+  IF NOT is_rav_team(auth.uid()) THEN
+    RAISE EXCEPTION 'Unauthorized';
+  END IF;
+
+  RETURN QUERY
+  SELECT
+    ak.id,
+    ak.owner_user_id,
+    p.email AS owner_email,
+    ak.name,
+    ak.key_prefix,
+    ak.scopes,
+    ak.tier,
+    ak.daily_limit,
+    ak.per_minute_limit,
+    ak.daily_usage,
+    ak.is_active,
+    ak.revoked_at,
+    ak.expires_at,
+    ak.last_used_at,
+    ak.created_at
+  FROM api_keys ak
+  LEFT JOIN profiles p ON p.id = ak.owner_user_id
+  ORDER BY ak.created_at DESC;
+END;
+$$;
+
+-- Admin: get usage stats for a specific key
+CREATE OR REPLACE FUNCTION get_api_key_stats(p_key_id uuid, p_days integer DEFAULT 7)
+RETURNS TABLE (
+  endpoint text,
+  request_count bigint,
+  avg_response_time_ms numeric,
+  error_count bigint,
+  day date
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+BEGIN
+  IF NOT is_rav_team(auth.uid()) THEN
+    RAISE EXCEPTION 'Unauthorized';
+  END IF;
+
+  RETURN QUERY
+  SELECT
+    arl.endpoint,
+    count(*)::bigint AS request_count,
+    round(avg(arl.response_time_ms)::numeric, 1) AS avg_response_time_ms,
+    count(*) FILTER (WHERE arl.status_code >= 400)::bigint AS error_count,
+    arl.created_at::date AS day
+  FROM api_request_log arl
+  WHERE arl.key_id = p_key_id
+    AND arl.created_at >= now() - (p_days || ' days')::interval
+  GROUP BY arl.endpoint, arl.created_at::date
+  ORDER BY arl.created_at::date DESC, arl.endpoint;
+END;
+$$;


### PR DESCRIPTION
## Summary
- **RAV Tools hub** (`/tools`) — 6 tool cards (2 built, 4 coming-soon) with JSON-LD ItemList
- **Public API layer** — `api-gateway` edge function, API key infra (migration 044), `/developers` Swagger UI, admin "API Keys" tab
- **Brand naming Phase 1** — surface brand names (RAV SmartFee, SmartPrice, PaySafe, etc.) across 13 UI components
- **SEO tune-up** — `usePageMeta()` on 7 pages + JSON-LD (Organization, HowTo, ItemList) on 3 pages
- **Flow manifests** updated with `rav_tools` step

## Test plan
- [x] `npm run build` — clean (0 errors)
- [x] `npm run test` — 731 tests passing (95 files)
- [x] `npx tsc --noEmit` — 0 type errors
- [ ] Navigate to `/tools` — 6 cards, 2 linked, 4 "Coming Soon"
- [ ] Header Explore dropdown shows "RAV Tools" + "RAV SmartFee"
- [ ] Footer "For Owners" shows "RAV Tools" + "RAV SmartFee"
- [ ] Spot-check `document.title` on updated pages
- [ ] Check JSON-LD scripts on `/tools`, `/calculator`, `/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)