### PR TITLE
Add global Header to 7 pages + header redesign

### DIFF
--- a/src/pages/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
+import Header from "@/components/Header";
 import Footer from "@/components/Footer";
 import { useAuth } from "@/contexts/AuthContext";
 import { supabase } from "@/lib/supabase";
@@ -148,8 +149,9 @@ const AdminDashboard = () => {
 
   return (
     <div className="min-h-screen bg-background">
-      {/* Header */}
-      <header className="border-b bg-card">
+      <Header />
+      {/* Page Header */}
+      <header className="border-b bg-card mt-16 md:mt-20">
         <div className="container mx-auto px-4 py-4">
           <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
             <div className="flex items-center gap-4">

--- a/src/pages/BookingSuccess.tsx
+++ b/src/pages/BookingSuccess.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
+import Header from "@/components/Header";
 import { useAuth } from "@/contexts/AuthContext";
 import { supabase } from "@/lib/supabase";
 import { Button } from "@/components/ui/button";
@@ -126,7 +127,9 @@ const BookingSuccess = () => {
   }
 
   return (
-    <div className="min-h-screen bg-background py-12 px-4">
+    <div className="min-h-screen bg-background">
+      <Header />
+      <div className="pt-16 md:pt-20 py-12 px-4">
       <div className="container max-w-2xl mx-auto">
         <div className="text-center mb-8">
           <CheckCircle2 className="h-16 w-16 text-green-500 mx-auto mb-4" />
@@ -251,6 +254,7 @@ const BookingSuccess = () => {
             onCancelled={() => navigate("/")}
           />
         )}
+      </div>
       </div>
     </div>
   );

--- a/src/pages/Documentation.tsx
+++ b/src/pages/Documentation.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
+import Header from "@/components/Header";
 import { useAuth } from "@/contexts/AuthContext";
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
@@ -163,8 +164,9 @@ const Documentation = () => {
 
   return (
     <div className="min-h-screen bg-background">
-      {/* Header */}
-      <header className="sticky top-0 z-50 border-b bg-card/95 backdrop-blur supports-[backdrop-filter]:bg-card/60 print:hidden">
+      <Header />
+      {/* Page Header */}
+      <header className="sticky top-16 md:top-20 z-40 border-b bg-card/95 backdrop-blur supports-[backdrop-filter]:bg-card/60 print:hidden">
         <div className="flex h-16 items-center px-4 md:px-6">
           <Button
             variant="ghost"

--- a/src/pages/OwnerDashboard.tsx
+++ b/src/pages/OwnerDashboard.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState, useCallback } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
+import Header from "@/components/Header";
 import { useAuth } from "@/contexts/AuthContext";
 import { supabase } from "@/lib/supabase";
 import { Button } from "@/components/ui/button";
@@ -297,8 +298,9 @@ const OwnerDashboard = () => {
 
   return (
     <div className="min-h-screen bg-background">
-      {/* Header */}
-      <header className="border-b bg-card">
+      <Header />
+      {/* Page Header */}
+      <header className="border-b bg-card mt-16 md:mt-20">
         <div className="container mx-auto px-4 py-4">
           <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
             <div className="flex items-center gap-4">

--- a/src/pages/PendingApproval.tsx
+++ b/src/pages/PendingApproval.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
+import Header from "@/components/Header";
 import { useAuth } from "@/contexts/AuthContext";
 import {
   Card,
@@ -39,7 +40,9 @@ export default function PendingApproval() {
   }, [user, profile, isRavTeam, navigate]);
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-muted/50 px-4">
+    <div className="min-h-screen flex flex-col bg-muted/50">
+      <Header />
+      <div className="flex-1 flex items-center justify-center px-4 pt-16 md:pt-20">
       <Card className="w-full max-w-md">
         <CardHeader className="text-center">
           <div className={`mx-auto w-12 h-12 ${isRejected ? "bg-destructive/10" : "bg-primary/10"} rounded-full flex items-center justify-center mb-4`}>
@@ -157,6 +160,7 @@ export default function PendingApproval() {
           </div>
         </CardContent>
       </Card>
+      </div>
     </div>
   );
 }

--- a/src/pages/TravelerCheckin.tsx
+++ b/src/pages/TravelerCheckin.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState, useCallback } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
+import Header from "@/components/Header";
 import { useAuth } from "@/contexts/AuthContext";
 import { supabase } from "@/lib/supabase";
 import { Button } from "@/components/ui/button";
@@ -257,8 +258,9 @@ const TravelerCheckin = () => {
 
   return (
     <div className="min-h-screen bg-background">
-      {/* Header */}
-      <header className="border-b bg-card">
+      <Header />
+      {/* Page Header */}
+      <header className="border-b bg-card mt-16 md:mt-20">
         <div className="container mx-auto px-4 py-4">
           <div className="flex items-center gap-4">
             <Button variant="ghost" size="icon" onClick={() => navigate("/")}>

--- a/src/pages/UserGuide.tsx
+++ b/src/pages/UserGuide.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import Header from "@/components/Header";
 import { Button } from "@/components/ui/button";
 import { usePageMeta } from "@/hooks/usePageMeta";
 import { ScrollArea } from "@/components/ui/scroll-area";
@@ -110,8 +111,9 @@ const UserGuide = () => {
 
   return (
     <div className="min-h-screen bg-background">
-      {/* Header */}
-      <header className="sticky top-0 z-50 border-b bg-card/95 backdrop-blur supports-[backdrop-filter]:bg-card/60 print:hidden">
+      <Header />
+      {/* Page Header */}
+      <header className="sticky top-16 md:top-20 z-40 border-b bg-card/95 backdrop-blur supports-[backdrop-filter]:bg-card/60 print:hidden">
         <div className="flex h-16 items-center px-4 md:px-6">
           <Button
             variant="ghost"


### PR DESCRIPTION
## Summary
- **Header consistency:** Added global Header to AdminDashboard, OwnerDashboard, BookingSuccess, Documentation, UserGuide, TravelerCheckin, PendingApproval — all previously had no site navigation
- **Header redesign (from prior commit):** Clean typography, active states, "Free Tools" top-level link
- **SEO:** Sitemap updated with 7 new URLs, JSON-LD on all tool pages

## Test plan
- [x] `npm run build` — clean
- [x] `npm run test` — 771 tests passing
- [ ] Navigate to `/admin` — verify Header visible above page header
- [ ] Navigate to `/owner-dashboard` — verify Header visible
- [ ] Navigate to `/booking-success` — verify Header visible
- [ ] Verify Documentation and UserGuide sticky sub-headers still work below global Header

🤖 Generated with [Claude Code](https://claude.com/claude-code)