### PR TITLE
docs: session 39 handoff + remaining brand refs

### DIFF
--- a/docs/PROJECT-HUB.md
+++ b/docs/PROJECT-HUB.md
@@ -96,7 +96,15 @@ gh issue create --repo rent-a-vacation/rav-website --title "..." --label "..." -
 - **Supabase CLI:** currently linked to DEV
 - **dev and main:** in sync (PRs #199-#205 merged)
 
-### Session Handoff (Sessions 25-38)
+### Session Handoff (Sessions 25-39)
+
+**Session 39 — RAV Smart Suite Rebrand + SmartEarn Merge (Mar 10):**
+- Rebranded all 6 free tools to consistent "RAV Smart___" naming: SmartFee→SmartEarn, Vacation Cost Comparator→SmartCompare, Resort Finder Quiz→SmartMatch, Trip Budget Planner→SmartBudget.
+- Merged standalone Rental Yield Estimator into SmartEarn as a toggle section on `/calculator` with region selector + projected income card.
+- Deleted `src/pages/YieldEstimator.tsx`. `/tools/yield-estimator` now redirects to `/calculator`.
+- Added breadcrumb navigation ("Back to Free Tools") and `font-display` h1 to all tool pages.
+- Updated: RavTools hub (6→5 cards), App.tsx routes, flow manifest, sitemap, tests, all docs.
+- PR #207 merged to main. 771 tests passing, build clean.
 
 **Session 38 — Public API, RAV Tools Hub & Brand Naming (Mar 10):**
 - Closed #173 (Schema Fixes): Added `x-sse-events`, `x-auth-note`, `x-internal` extensions to OpenAPI spec. Clarified dual-input (voice-search) and rate limit headers. Validated with Redocly (0 errors).

--- a/docs/brand-assets/MARKETING-PLAYBOOK.md
+++ b/docs/brand-assets/MARKETING-PLAYBOOK.md
@@ -206,7 +206,7 @@ The demo environment contains **seed data** — realistic but synthetic — to d
 | Travel Requests | **Vacation Wishes** | Post your dream trip; owners compete to fulfill it | BUILT |
 | Bidding System | **Name Your Price** | Bid on any open listing | BUILT |
 | Fair Value Score | **RAV SmartPrice** | AI-powered pricing recommendations for owners | BUILT |
-| Maintenance Calculator | **Fee Freedom Calculator** | Break-even tool — how many weeks to cover fees | BUILT |
+| Maintenance Calculator | **RAV SmartEarn** | Break-even tool — how many weeks to cover fees | BUILT |
 | Owner Verification | **TrustShield** | Multi-step identity and ownership verification | BUILT |
 | Escrow System | **PaySafe** | Funds held securely until confirmed check-in | BUILT |
 | Resort Master Data | **ResortIQ** | Professional resort profiles powering every listing | BUILT |
@@ -232,7 +232,7 @@ RENT-A-VACATION (Master Brand)
 ├── For Owners
 │   ├── Owner's Edge (dashboard & tools suite)
 │   ├── RAV SmartPrice (pricing AI)
-│   ├── Fee Freedom Calculator (maintenance fee tool)
+│   ├── RAV SmartEarn (maintenance fee tool)
 │   └── TrustShield (verification program)
 │
 └── For Business / Investors
@@ -276,7 +276,7 @@ RENT-A-VACATION (Master Brand)
 > "We don't dabble in timeshares — we're built for them. 117 resorts. 351 unit types. Professional data that auto-populates listing forms. Owner verification that builds real trust. Resort confirmation workflows that match how vacation clubs actually work."
 
 **Pillar 4: Owner Empowerment** *[BUILT]*
-> "Listing is designed to take minutes, not hours. RAV SmartPrice shows what to charge. The Fee Freedom Calculator shows exactly how many weeks cover your maintenance fees. You control pricing, you approve guests, you earn on your terms."
+> "Listing is designed to take minutes, not hours. RAV SmartPrice shows what to charge. The RAV SmartEarn shows exactly how many weeks cover your maintenance fees. You control pricing, you approve guests, you earn on your terms."
 
 **Pillar 5: Ironclad Trust** *[BUILT]*
 > "Every owner goes through TrustShield verification. Every payment is protected through PaySafe escrow. Every stay is backed by our satisfaction guarantee. We've removed the risk so you can focus on the vacation."
@@ -335,9 +335,9 @@ RENT-A-VACATION (Master Brand)
 - "What If Your Timeshare Made You Money?"
 
 **Supporting Copy:**
-> "You're paying $1,800 a year for weeks you don't use. List those weeks on Rent-A-Vacation and let them earn for you. Our Fee Freedom Calculator shows you exactly how many weeks you need to rent. Try it free — no account required."
+> "You're paying $1,800 a year for weeks you don't use. List those weeks on Rent-A-Vacation and let them earn for you. Our RAV SmartEarn shows you exactly how many weeks you need to rent. Try it free — no account required."
 
-**Lead Magnet:** Fee Freedom Calculator (live, no account required, instant results, CTA to list).
+**Lead Magnet:** RAV SmartEarn (live, no account required, instant results, CTA to list).
 
 ---
 
@@ -405,7 +405,7 @@ RENT-A-VACATION (Master Brand)
 **Owner Welcome (5 emails):**
 1. Welcome + verification steps (Day 0)
 2. "List in Minutes" — listing tutorial with ResortIQ (Day 1)
-3. "Use the Fee Freedom Calculator" — maintenance fee tool (Day 3)
+3. "Use the RAV SmartEarn" — maintenance fee tool (Day 3)
 4. "Meet RAV SmartPrice" — pricing help (Day 7)
 5. "What to Expect from Your First Booking" — workflow guide (Day 14)
 
@@ -475,7 +475,7 @@ RENT-A-VACATION (Master Brand)
 
 ### Phase 3: Public Launch (Target: Q3 2026)
 - "Ask RAVIO" campaign launch
-- Fee Freedom Calculator SEO push
+- RAV SmartEarn SEO push
 - PR outreach
 - Paid social (Facebook/Instagram targeted to timeshare owners + travelers)
 - Google Search (high-intent keywords)
@@ -548,7 +548,7 @@ RENT-A-VACATION (Master Brand)
 | **Vacation Wishes** | Feature | Post travel requests; owners compete | BUILT |
 | **Name Your Price** | Feature | Bid on open listings | BUILT |
 | **RAV SmartPrice** | Feature | AI-powered pricing recommendations | BUILT |
-| **Fee Freedom Calculator** | Tool | Maintenance fee break-even calculator | BUILT |
+| **RAV SmartEarn** | Tool | Maintenance fee break-even calculator | BUILT |
 | **TrustShield** | Program | Owner verification system | BUILT |
 | **PaySafe** | Program | Escrow payment protection | BUILT |
 | **ResortIQ** | Data Layer | 117-resort professional database | BUILT |

--- a/docs/brand-assets/PITCH-DECK-SCRIPT.md
+++ b/docs/brand-assets/PITCH-DECK-SCRIPT.md
@@ -147,7 +147,7 @@ for vacation club owners and travelers.
 ✓ TrustShield — owner verification           [BUILT]
 ✓ PaySafe — escrow payment protection        [BUILT]
 ✓ RAV SmartPrice — AI pricing guidance       [BUILT]
-✓ Fee Freedom Calculator — public tool       [BUILT]
+✓ RAV SmartEarn — public tool       [BUILT]
 
 Everything listed above is deployed and demonstrable today.
 ```
@@ -330,7 +330,7 @@ PAYSAFE (Payment Protection):
 
 ---
 
-## SLIDE 12: Deep Dive — Owner's Edge (RAV SmartPrice + Fee Freedom Calculator)
+## SLIDE 12: Deep Dive — Owner's Edge (RAV SmartPrice + RAV SmartEarn)
 
 **Visual:** Split screen. Left: SmartPrice badge on a listing. Right: Calculator results showing break-even.
 
@@ -359,7 +359,7 @@ OWNER DASHBOARD:
 ```
 
 **Speaker Notes:**
-> "We don't just acquire owners — we empower them. RAV SmartPrice is our proprietary pricing AI that analyzes comparable properties and tells owners exactly what to charge. Fair Value badges appear on every listing, helping owners price competitively. The Fee Freedom Calculator is a free public tool — no account required — that shows any timeshare owner exactly how many weeks they need to rent to cover their annual maintenance fees. It's a lead generation engine that converts directly into owner signups. And the Owner Dashboard gives them a complete command center for their rental business — earnings, bookings, bids, and verification all in one place."
+> "We don't just acquire owners — we empower them. RAV SmartPrice is our proprietary pricing AI that analyzes comparable properties and tells owners exactly what to charge. Fair Value badges appear on every listing, helping owners price competitively. The RAV SmartEarn is a free public tool — no account required — that shows any timeshare owner exactly how many weeks they need to rent to cover their annual maintenance fees. It's a lead generation engine that converts directly into owner signups. And the Owner Dashboard gives them a complete command center for their rental business — earnings, bookings, bids, and verification all in one place."
 
 ---
 
@@ -474,7 +474,7 @@ Q2:   BETA LAUNCH
       Real-world validation + feedback loops
 
 Q3:   PUBLIC LAUNCH
-      "Ask RAVIO" campaign | Fee Freedom Calculator SEO
+      "Ask RAVIO" campaign | RAV SmartEarn SEO
       PR outreach | Paid social (targeted)
       Google Search (high-intent keywords)
 
@@ -485,7 +485,7 @@ Q4:   SCALE
 ```
 
 **Speaker Notes:**
-> "Here's our go-to-market plan. We're currently in pre-launch — the platform is fully built and we're using this time to prepare marketing assets, refine workflows with our team, and build our initial pipeline. In Q2, we open to a controlled beta — inviting owners from timeshare communities and travelers from our waitlist. Q3 is our public launch, led by the Ask RAVIO campaign and the Fee Freedom Calculator as our primary SEO and owner acquisition tools. By Q4, we're scaling with mobile apps, brand partnerships, and content marketing. The key point: we're not starting from scratch in Q2. The product is built. We're launching, not building."
+> "Here's our go-to-market plan. We're currently in pre-launch — the platform is fully built and we're using this time to prepare marketing assets, refine workflows with our team, and build our initial pipeline. In Q2, we open to a controlled beta — inviting owners from timeshare communities and travelers from our waitlist. Q3 is our public launch, led by the Ask RAVIO campaign and the RAV SmartEarn as our primary SEO and owner acquisition tools. By Q4, we're scaling with mobile apps, brand partnerships, and content marketing. The key point: we're not starting from scratch in Q2. The product is built. We're launching, not building."
 
 ---
 


### PR DESCRIPTION
## Summary
- Replace all "Fee Freedom Calculator" refs in MARKETING-PLAYBOOK.md and PITCH-DECK-SCRIPT.md with "RAV SmartEarn"
- Add Session 39 handoff entry to PROJECT-HUB.md

Docs-only change, no code modifications.

🤖 Generated with [Claude Code](https://claude.com/claude-code)