### PR TITLE
fix(ci): fix daily status report crash

### DIFF
--- a/.github/workflows/daily-summary.yml
+++ b/.github/workflows/daily-summary.yml
@@ -15,7 +15,7 @@ jobs:
           RESEND_API_KEY: ${{ secrets.RESEND_GITHUB_NOTIFICATIONS_KEY }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          set -eo pipefail
+          set -o pipefail
           REPO="rent-a-vacation/rav-website"
           SINCE=$(date -u -d '24 hours ago' '+%Y-%m-%dT%H:%M:%SZ')
           REPORT_DATE=$(date -u -d '5 hours ago' '+%B %d, %Y')
@@ -35,12 +35,12 @@ jobs:
           # Issues closed today
           CLOSED_TODAY=$(gh api "repos/${REPO}/issues?state=closed&since=${SINCE}&per_page=50&sort=updated&direction=desc" \
             --jq '[.[] | select(.pull_request == null and (.closed_at >= "'"${SINCE}"'"))]' 2>/dev/null || echo "[]")
-          CLOSED_COUNT=$(echo "$CLOSED_TODAY" | jq 'length')
+          CLOSED_COUNT=$(echo "$CLOSED_TODAY" | jq 'length' 2>/dev/null || echo "0")
 
           # Issues opened today
           OPENED_TODAY=$(gh api "repos/${REPO}/issues?state=all&since=${SINCE}&per_page=50&sort=created&direction=desc" \
             --jq '[.[] | select(.pull_request == null and (.created_at >= "'"${SINCE}"'"))]' 2>/dev/null || echo "[]")
-          OPENED_COUNT=$(echo "$OPENED_TODAY" | jq 'length')
+          OPENED_COUNT=$(echo "$OPENED_TODAY" | jq 'length' 2>/dev/null || echo "0")
 
           # Open by label
           OPEN_PRELAUNCH=$(gh api -X GET "search/issues?q=repo:${REPO}+is:issue+is:open+label:pre-launch&per_page=1" --jq '.total_count' 2>/dev/null || echo "0")
@@ -322,7 +322,7 @@ jobs:
           TEXT_JSON=$(echo "$TEXT_BODY" | jq -Rs '.')
           HTML_JSON=$(echo "$HTML_BODY" | jq -Rs '.')
 
-          RESULT=$(curl -s -X POST https://api.resend.com/emails \
+          RESULT=$(curl -s -w "\nHTTP_STATUS:%{http_code}" -X POST https://api.resend.com/emails \
             -H "Authorization: Bearer ${RESEND_API_KEY}" \
             -H "Content-Type: application/json" \
             -d "{
@@ -336,7 +336,7 @@ jobs:
               \"subject\": \"${SUBJECT}\",
               \"text\": ${TEXT_JSON},
               \"html\": ${HTML_JSON}
-            }")
+            }" || echo "CURL_FAILED")
 
           echo "Status report sent for ${REPORT_DATE}"
           echo "Resend response: ${RESULT}"


### PR DESCRIPTION
Remove set -e, add jq/curl fallbacks. Workflow has been failing since March 19.