### PR TITLE
fix(seo): remove 70% claim from static HTML, PWA manifest, README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 
 ## Overview
 
-Rent-A-Vacation (RAV) is a full-stack marketplace platform for the **$10.5 billion vacation ownership industry**. Timeshare owners list unused weeks at their price. Travelers search, bid, and book luxury resort stays at **50-70% below resort-direct pricing**. Every owner is verified, every payment is escrowed, and every search can be done by voice.
+Rent-A-Vacation (RAV) is a full-stack marketplace platform for the **$10.5 billion vacation ownership industry**. Timeshare owners list unused weeks at their price. Travelers search, bid, and book luxury resort stays at **20-40% below resort-direct pricing**. Every owner is verified, every payment is escrowed, and every search can be done by voice.
 
 ### The Problem
 

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <meta name="apple-mobile-web-app-title" content="RAV" />
     <title>Rent-A-Vacation | Where Luxury Becomes Affordable</title>
-    <meta name="description" content="Name Your Price. Book Your Paradise. Rent vacation club and timeshare weeks directly from owners at up to 70% off." />
+    <meta name="description" content="Name Your Price. Book Your Paradise. Rent vacation club and timeshare weeks directly from owners at 20-40% off resort rates." />
     <meta name="author" content="Rent-A-Vacation - A Techsilon Group Company" />
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
@@ -17,7 +17,7 @@
 
 
     <meta property="og:title" content="Rent-A-Vacation | Where Luxury Becomes Affordable" />
-    <meta property="og:description" content="Name Your Price. Book Your Paradise. Rent vacation club and timeshare weeks directly from owners at up to 70% off." />
+    <meta property="og:description" content="Name Your Price. Book Your Paradise. Rent vacation club and timeshare weeks directly from owners at 20-40% off resort rates." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://rent-a-vacation.com/" />
     <meta property="og:image" content="https://rent-a-vacation.com/android-chrome-512x512.png" />
@@ -36,7 +36,7 @@
       "alternateName": "RAV",
       "url": "https://rent-a-vacation.com",
       "logo": "https://rent-a-vacation.com/android-chrome-512x512.png",
-      "description": "Name Your Price. Book Your Paradise. A marketplace connecting vacation club and timeshare owners directly with travelers for luxury resort stays at up to 70% off.",
+      "description": "Name Your Price. Book Your Paradise. A marketplace connecting vacation club and timeshare owners directly with travelers for luxury resort stays at 20-40% off resort rates.",
       "foundingDate": "2024",
       "slogan": "Name Your Price. Book Your Paradise.",
       "parentOrganization": {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -85,7 +85,7 @@ export default defineConfig(({ mode }) => {
         manifest: {
           name: "Rent-A-Vacation",
           short_name: "RAV",
-          description: "Name Your Price. Book Your Paradise. Rent vacation club and timeshare weeks directly from owners at up to 70% off.",
+          description: "Name Your Price. Book Your Paradise. Rent vacation club and timeshare weeks directly from owners at 20-40% off resort rates.",
           theme_color: "#1C7268",
           background_color: "#F8F6F3",
           display: "standalone",


### PR DESCRIPTION
## Summary
- Fixed the root cause of external tools picking up the retired "70% off" claim
- `index.html` meta description, OG tags, and JSON-LD still had the old claim — this is what crawlers read before JS executes
- `vite.config.ts` PWA manifest description had the same
- `README.md` had "50-70%"
- All now say "20-40% off resort rates" per Brand Lock

## Test plan
- [x] 825 tests passing
- [x] Clean build
- [x] `grep -rn "70%" index.html vite.config.ts README.md src/` — zero results

🤖 Generated with [Claude Code](https://claude.com/claude-code)