### PR TITLE
fix(security): remove personal home address from all public pages

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -66,7 +66,7 @@ const Footer = () => {
               </li>
               <li className="flex items-start gap-3">
                 <MapPin className="w-5 h-5 mt-0.5 text-primary" />
-                <span>7874 Chase Meadows Dr W<br />Jacksonville, FL 32256</span>
+                <span>Jacksonville, FL, United States</span>
               </li>
               <li>
                 <Link to="/contact" className="inline-flex items-center gap-2 text-primary hover:text-white transition-colors text-sm font-medium mt-2">

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -223,10 +223,9 @@ const Contact = () => {
                       <MapPin className="w-5 h-5 text-primary" />
                     </div>
                     <div>
-                      <p className="font-medium text-foreground">Address</p>
+                      <p className="font-medium text-foreground">Location</p>
                       <p className="text-sm text-muted-foreground">
-                        7874 Chase Meadows Dr W<br />
-                        Jacksonville, FL 32256
+                        Jacksonville, FL, United States
                       </p>
                     </div>
                   </li>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -102,10 +102,8 @@ const Index = () => {
       },
       address: {
         '@type': 'PostalAddress',
-        streetAddress: '7874 Chase Meadows Dr W',
         addressLocality: 'Jacksonville',
         addressRegion: 'FL',
-        postalCode: '32256',
         addressCountry: 'US',
       },
     };

--- a/src/pages/Privacy.tsx
+++ b/src/pages/Privacy.tsx
@@ -197,8 +197,6 @@ const Privacy = () => {
                 </p>
                 <p className="text-muted-foreground">
                   Email: privacy@rentavacation.com
-                  <br />
-                  Address: 7874 Chase Meadows Dr W, Jacksonville, FL 32256
                 </p>
               </section>
             </div>

--- a/src/pages/Terms.tsx
+++ b/src/pages/Terms.tsx
@@ -152,8 +152,6 @@ const Terms = () => {
                 </p>
                 <p className="text-muted-foreground">
                   Email: legal@rentavacation.com
-                  <br />
-                  Address: 7874 Chase Meadows Dr W, Jacksonville, FL 32256
                 </p>
               </section>
             </div>


### PR DESCRIPTION
## Summary
- Removed personal street address from 5 source files (Footer, Contact, Privacy, Terms, JSON-LD)
- Replaced with city/state only ("Jacksonville, FL") where location context is needed
- Full street address will be added back with a registered business address after LLC formation (#127)

## Files changed
- `src/pages/Index.tsx` — removed streetAddress and postalCode from JSON-LD PostalAddress
- `src/components/Footer.tsx` — replaced street address with "Jacksonville, FL, United States"
- `src/pages/Contact.tsx` — replaced "Address" with "Location", city/state only
- `src/pages/Privacy.tsx` — removed address line from privacy contact
- `src/pages/Terms.tsx` — removed address line from terms contact

## Test plan
- [x] 825 tests passing
- [x] `grep -rn "7874\|Chase Meadows" src/` — zero results

🤖 Generated with [Claude Code](https://claude.com/claude-code)