### PR TITLE
feat: Stripe subscription system — tier monetization (Phases 1-4)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -55,6 +55,7 @@ const ResortQuiz = lazy(() => import("./pages/ResortQuiz"));
 const BudgetPlanner = lazy(() => import("./pages/BudgetPlanner"));
 const Notifications = lazy(() => import("./pages/Notifications"));
 const NotificationPreferences = lazy(() => import("./pages/settings/NotificationPreferences"));
+const SubscriptionSuccess = lazy(() => import("./pages/SubscriptionSuccess"));
 
 import { PWAInstallBanner } from "@/components/PWAInstallBanner";
 import { OfflineBanner } from "@/components/OfflineBanner";
@@ -203,6 +204,7 @@ const App = () => (
             <Route path="/notifications" element={<ProtectedRoute><Notifications /></ProtectedRoute>} />
             <Route path="/settings/notifications" element={<ProtectedRoute><NotificationPreferences /></ProtectedRoute>} />
             <Route path="/checkin" element={<ProtectedRoute><TravelerCheckin /></ProtectedRoute>} />
+            <Route path="/subscription-success" element={<ProtectedRoute><SubscriptionSuccess /></ProtectedRoute>} />
 
             {/* Developer & internal tools */}
             <Route path="/developers" element={<Developers />} />

--- a/src/components/MembershipPlans.tsx
+++ b/src/components/MembershipPlans.tsx
@@ -2,6 +2,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { MembershipTierCard } from "@/components/MembershipTierCard";
 import { MembershipBadge } from "@/components/MembershipBadge";
 import { useMyMembership, useRenterTiers, useOwnerTiers } from "@/hooks/useMembership";
+import { useCreateSubscription, useUpdateSubscription } from "@/hooks/useSubscription";
 import { useAuth } from "@/hooks/useAuth";
 import type { MembershipTier } from "@/types/database";
 
@@ -17,10 +18,27 @@ export function MembershipPlans({ category }: MembershipPlansProps) {
   const { data: ownerTiers, isLoading: loadingOwner } = useOwnerTiers();
   const { data: membership, isLoading: loadingMembership } = useMyMembership();
 
+  const createSubscription = useCreateSubscription();
+  const updateSubscription = useUpdateSubscription();
+
   const tiers: MembershipTier[] =
     resolvedCategory === "owner" ? ownerTiers || [] : renterTiers || [];
   const isLoading =
     resolvedCategory === "owner" ? loadingOwner : loadingRenter;
+
+  const currentTierLevel = membership?.tier?.tier_level ?? 0;
+  const hasActiveSubscription = !!membership?.stripe_subscription_id;
+  const isMutating = createSubscription.isPending || updateSubscription.isPending;
+
+  const handleSelectTier = (tierKey: string) => {
+    if (hasActiveSubscription) {
+      // Already subscribed — upgrade/downgrade/cancel via update
+      updateSubscription.mutate(tierKey);
+    } else {
+      // New subscription — redirect to Stripe Checkout
+      createSubscription.mutate(tierKey);
+    }
+  };
 
   if (isLoading || loadingMembership) {
     return (
@@ -39,6 +57,17 @@ export function MembershipPlans({ category }: MembershipPlansProps) {
         <div className="flex items-center gap-3 p-4 rounded-lg bg-muted/50">
           <span className="text-sm text-muted-foreground">Your current plan:</span>
           <MembershipBadge tier={membership.tier} />
+          {membership.status === "cancelled" && membership.expires_at && (
+            <span className="text-sm text-amber-600">
+              — cancelling, active until{" "}
+              {new Date(membership.expires_at).toLocaleDateString()}
+            </span>
+          )}
+          {membership.status === "pending" && (
+            <span className="text-sm text-red-600">
+              — payment issue, please update your card
+            </span>
+          )}
         </div>
       )}
 
@@ -50,6 +79,10 @@ export function MembershipPlans({ category }: MembershipPlansProps) {
             tier={tier}
             isCurrent={membership?.tier_id === tier.id}
             highlighted={tier.tier_level === 1}
+            currentTierLevel={currentTierLevel}
+            hasActiveSubscription={hasActiveSubscription}
+            onSelectTier={handleSelectTier}
+            isLoading={isMutating}
           />
         ))}
       </div>

--- a/src/components/MembershipTierCard.tsx
+++ b/src/components/MembershipTierCard.tsx
@@ -1,25 +1,36 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Check, Mic, Crown, Infinity as InfinityIcon } from "lucide-react";
+import { Check, Mic, Crown, Infinity as InfinityIcon, ArrowUp, ArrowDown, Loader2 } from "lucide-react";
 import type { MembershipTier } from "@/types/database";
 
 interface MembershipTierCardProps {
   tier: MembershipTier;
   isCurrent?: boolean;
   highlighted?: boolean;
+  currentTierLevel?: number;
+  hasActiveSubscription?: boolean;
+  onSelectTier?: (tierKey: string) => void;
+  isLoading?: boolean;
 }
 
 export function MembershipTierCard({
   tier,
   isCurrent = false,
   highlighted = false,
+  currentTierLevel = 0,
+  hasActiveSubscription = false,
+  onSelectTier,
+  isLoading = false,
 }: MembershipTierCardProps) {
   const features = Array.isArray(tier.features) ? tier.features : [];
   const priceDisplay =
     tier.monthly_price_cents === 0
       ? "Free"
       : `$${(tier.monthly_price_cents / 100).toFixed(0)}`;
+
+  const isUpgrade = tier.tier_level > currentTierLevel;
+  const isDowngrade = tier.tier_level < currentTierLevel;
 
   return (
     <Card
@@ -123,13 +134,42 @@ export function MembershipTierCard({
             <Button variant="outline" className="w-full" disabled>
               Current Plan
             </Button>
+          ) : isUpgrade && onSelectTier ? (
+            <Button
+              className="w-full"
+              onClick={() => onSelectTier(tier.tier_key)}
+              disabled={isLoading}
+            >
+              {isLoading ? (
+                <Loader2 className="h-4 w-4 animate-spin mr-2" />
+              ) : (
+                <ArrowUp className="h-4 w-4 mr-2" />
+              )}
+              Upgrade to {tier.tier_name}
+            </Button>
+          ) : isDowngrade && onSelectTier ? (
+            <Button
+              variant="outline"
+              className="w-full"
+              onClick={() => onSelectTier(tier.tier_key)}
+              disabled={isLoading}
+            >
+              {isLoading ? (
+                <Loader2 className="h-4 w-4 animate-spin mr-2" />
+              ) : (
+                <ArrowDown className="h-4 w-4 mr-2" />
+              )}
+              {tier.monthly_price_cents === 0 && hasActiveSubscription
+                ? "Downgrade to Free"
+                : `Switch to ${tier.tier_name}`}
+            </Button>
           ) : tier.monthly_price_cents === 0 ? (
             <Button variant="outline" className="w-full" disabled>
               Free Tier
             </Button>
           ) : (
             <Button variant="outline" className="w-full" disabled>
-              Coming Soon
+              Free Tier
             </Button>
           )}
         </div>

--- a/src/components/SubscriptionManagement.tsx
+++ b/src/components/SubscriptionManagement.tsx
@@ -1,0 +1,121 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { CreditCard, ExternalLink, AlertTriangle, Loader2, CalendarDays } from "lucide-react";
+import { MembershipBadge } from "@/components/MembershipBadge";
+import { useMyMembership } from "@/hooks/useMembership";
+import { useManageBilling } from "@/hooks/useSubscription";
+
+export function SubscriptionManagement() {
+  const { data: membership, isLoading } = useMyMembership();
+  const manageBilling = useManageBilling();
+
+  if (isLoading) {
+    return (
+      <Card>
+        <CardContent className="p-6">
+          <div className="h-24 flex items-center justify-center text-muted-foreground">
+            Loading subscription...
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (!membership) return null;
+
+  const isPaid = !!membership.stripe_subscription_id;
+  const isCancelling = membership.status === "cancelled";
+  const isPaymentFailed = membership.status === "pending";
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-lg">
+          <CreditCard className="h-5 w-5" />
+          Subscription & Billing
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {/* Current plan */}
+        <div className="flex items-center justify-between">
+          <div className="space-y-1">
+            <div className="flex items-center gap-2">
+              <span className="text-sm font-medium">Current Plan</span>
+              <MembershipBadge tier={membership.tier} />
+              {isPaid && !isCancelling && !isPaymentFailed && (
+                <Badge variant="outline" className="text-green-600 border-green-200 bg-green-50">
+                  Active
+                </Badge>
+              )}
+              {isCancelling && (
+                <Badge variant="outline" className="text-amber-600 border-amber-200 bg-amber-50">
+                  Cancelling
+                </Badge>
+              )}
+              {isPaymentFailed && (
+                <Badge variant="outline" className="text-red-600 border-red-200 bg-red-50">
+                  Payment Issue
+                </Badge>
+              )}
+            </div>
+            {isPaid && membership.expires_at && (
+              <p className="text-sm text-muted-foreground flex items-center gap-1">
+                <CalendarDays className="h-3.5 w-3.5" />
+                {isCancelling
+                  ? `Access until ${new Date(membership.expires_at).toLocaleDateString()}`
+                  : `Next billing: ${new Date(membership.expires_at).toLocaleDateString()}`}
+              </p>
+            )}
+            {!isPaid && (
+              <p className="text-sm text-muted-foreground">
+                Upgrade below to unlock premium features
+              </p>
+            )}
+          </div>
+
+          {isPaid && (
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => manageBilling.mutate()}
+              disabled={manageBilling.isPending}
+            >
+              {manageBilling.isPending ? (
+                <Loader2 className="h-4 w-4 animate-spin mr-2" />
+              ) : (
+                <ExternalLink className="h-4 w-4 mr-2" />
+              )}
+              Manage Billing
+            </Button>
+          )}
+        </div>
+
+        {/* Warning banners */}
+        {isCancelling && (
+          <Alert className="border-amber-200 bg-amber-50">
+            <AlertTriangle className="h-4 w-4 text-amber-600" />
+            <AlertDescription className="text-amber-800">
+              Your subscription is set to cancel on{" "}
+              <strong>{new Date(membership.expires_at!).toLocaleDateString()}</strong>.
+              You&apos;ll keep your current benefits until then, after which you&apos;ll be
+              moved to the Free plan. You can resubscribe anytime.
+            </AlertDescription>
+          </Alert>
+        )}
+
+        {isPaymentFailed && (
+          <Alert className="border-red-200 bg-red-50">
+            <AlertTriangle className="h-4 w-4 text-red-600" />
+            <AlertDescription className="text-red-800">
+              Your last payment failed. Please update your payment method to keep your
+              subscription active. Stripe will retry automatically, but you can resolve
+              this now by clicking &quot;Manage Billing&quot; above.
+            </AlertDescription>
+          </Alert>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/hooks/useMembership.ts
+++ b/src/hooks/useMembership.ts
@@ -69,7 +69,7 @@ export function useMyMembership() {
         .from("user_memberships")
         .select("*, tier:membership_tiers(*)")
         .eq("user_id", user.id)
-        .eq("status", "active")
+        .in("status", ["active", "cancelled", "pending"])
         .maybeSingle();
 
       if (error) throw error;

--- a/src/hooks/useSubscription.ts
+++ b/src/hooks/useSubscription.ts
@@ -1,0 +1,103 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { supabase } from "@/lib/supabase";
+import { useAuth } from "./useAuth";
+import { useToast } from "./use-toast";
+
+/**
+ * Create a new subscription via Stripe Checkout.
+ * Redirects the user to Stripe's hosted checkout page.
+ */
+export function useCreateSubscription() {
+  const { toast } = useToast();
+
+  return useMutation({
+    mutationFn: async (tierKey: string) => {
+      const { data, error } = await supabase.functions.invoke(
+        "create-subscription-checkout",
+        { body: { tierKey } }
+      );
+      if (error) throw new Error(error.message);
+      if (data?.error) throw new Error(data.error);
+      return data as { url: string };
+    },
+    onSuccess: (data) => {
+      window.location.href = data.url;
+    },
+    onError: (error: Error) => {
+      toast({
+        title: "Subscription Error",
+        description: error.message,
+        variant: "destructive",
+      });
+    },
+  });
+}
+
+/**
+ * Update an existing subscription (upgrade/downgrade/cancel to free).
+ * Upgrades are immediate with proration; downgrades take effect at next billing cycle.
+ */
+export function useUpdateSubscription() {
+  const queryClient = useQueryClient();
+  const { user } = useAuth();
+  const { toast } = useToast();
+
+  return useMutation({
+    mutationFn: async (newTierKey: string) => {
+      const { data, error } = await supabase.functions.invoke(
+        "update-subscription",
+        { body: { newTierKey } }
+      );
+      if (error) throw new Error(error.message);
+      if (data?.error) throw new Error(data.error);
+      return data as { success: boolean; effective: string; message?: string };
+    },
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: ["my-membership", user?.id] });
+      toast({
+        title: "Plan Updated",
+        description:
+          data.effective === "immediate"
+            ? "Your plan has been upgraded. New benefits are active now."
+            : "Your plan change will take effect at the end of your current billing period.",
+      });
+    },
+    onError: (error: Error) => {
+      toast({
+        title: "Update Failed",
+        description: error.message,
+        variant: "destructive",
+      });
+    },
+  });
+}
+
+/**
+ * Open Stripe Customer Portal for billing management.
+ * Redirects the user to Stripe's hosted portal (invoices, card updates, cancellation).
+ */
+export function useManageBilling() {
+  const { toast } = useToast();
+
+  return useMutation({
+    mutationFn: async () => {
+      const { data, error } = await supabase.functions.invoke(
+        "manage-subscription",
+        { body: {} }
+      );
+      if (error) throw new Error(error.message);
+      if (data?.error) throw new Error(data.error);
+      return data as { url: string };
+    },
+    onSuccess: (data) => {
+      window.location.href = data.url;
+    },
+    onError: (error: Error) => {
+      toast({
+        title: "Billing Error",
+        description: error.message,
+        variant: "destructive",
+      });
+    },
+  });
+}

--- a/src/pages/AccountSettings.tsx
+++ b/src/pages/AccountSettings.tsx
@@ -25,7 +25,9 @@ import {
   useCancelDeletion,
   useExportUserData,
 } from "@/hooks/useAccountDeletion";
-import { User, Mail, Phone, Lock, Shield, Calendar, Save, Loader2, Bell, Download, Trash2, AlertTriangle, XCircle } from "lucide-react";
+import { User, Mail, Phone, Lock, Shield, Calendar, Save, Loader2, Bell, Download, Trash2, AlertTriangle, XCircle, CreditCard } from "lucide-react";
+import { SubscriptionManagement } from "@/components/SubscriptionManagement";
+import { MembershipPlans } from "@/components/MembershipPlans";
 import { Textarea } from "@/components/ui/textarea";
 
 const AccountSettings = () => {
@@ -290,7 +292,25 @@ const AccountSettings = () => {
               </CardContent>
             </Card>
 
-            {/* ─── Section 2: Security ─── */}
+            {/* ─── Section 2: Subscription & Billing ─── */}
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2">
+                  <CreditCard className="h-5 w-5 text-primary" />
+                  Subscription & Billing
+                </CardTitle>
+                <CardDescription>
+                  Manage your membership plan and billing details.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-6">
+                <SubscriptionManagement />
+                <Separator />
+                <MembershipPlans />
+              </CardContent>
+            </Card>
+
+            {/* ─── Section 3: Security ─── */}
             <Card>
               <CardHeader>
                 <CardTitle className="flex items-center gap-2">

--- a/src/pages/OwnerDashboard.tsx
+++ b/src/pages/OwnerDashboard.tsx
@@ -47,6 +47,7 @@ import { OwnerProposals } from "@/components/owner/OwnerProposals";
 import { OwnerVerification } from "@/components/owner/OwnerVerification";
 import { OwnerPayouts } from "@/components/owner/OwnerPayouts";
 import { MembershipPlans } from "@/components/MembershipPlans";
+import { SubscriptionManagement } from "@/components/SubscriptionManagement";
 import { ReferralDashboard } from "@/components/owner/ReferralDashboard";
 import { useOwnerCommission } from "@/hooks/useOwnerCommission";
 import { useOwnerDashboardStats } from "@/hooks/owner/useOwnerDashboardStats";
@@ -643,6 +644,7 @@ const OwnerDashboard = () => {
                 <ChevronDown className="h-4 w-4 text-muted-foreground transition-transform [[data-state=open]>&]:rotate-180" />
               </CollapsibleTrigger>
               <CollapsibleContent>
+                <SubscriptionManagement />
                 <MembershipPlans category="owner" />
               </CollapsibleContent>
             </Collapsible>

--- a/src/pages/SubscriptionSuccess.tsx
+++ b/src/pages/SubscriptionSuccess.tsx
@@ -1,0 +1,84 @@
+import { useEffect } from "react";
+import { useSearchParams, Link } from "react-router-dom";
+import { useQueryClient } from "@tanstack/react-query";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { CheckCircle2, ArrowRight } from "lucide-react";
+import { useAuth } from "@/hooks/useAuth";
+import { useMyMembership } from "@/hooks/useMembership";
+import { MembershipBadge } from "@/components/MembershipBadge";
+import Header from "@/components/Header";
+import { usePageMeta } from "@/hooks/usePageMeta";
+
+const SubscriptionSuccess = () => {
+  const [searchParams] = useSearchParams();
+  const sessionId = searchParams.get("session_id");
+  const queryClient = useQueryClient();
+  const { user, isPropertyOwner } = useAuth();
+  const { data: membership } = useMyMembership();
+
+  usePageMeta({
+    title: "Subscription Activated",
+    noindex: true,
+  });
+
+  // Invalidate membership cache to pick up the new tier from webhook
+  useEffect(() => {
+    if (sessionId && user) {
+      // Poll a few times to catch the webhook update
+      const interval = setInterval(() => {
+        queryClient.invalidateQueries({ queryKey: ["my-membership", user.id] });
+      }, 2000);
+      // Stop polling after 15 seconds
+      const timeout = setTimeout(() => clearInterval(interval), 15000);
+      return () => {
+        clearInterval(interval);
+        clearTimeout(timeout);
+      };
+    }
+  }, [sessionId, user, queryClient]);
+
+  const dashboardLink = isPropertyOwner()
+    ? "/owner-dashboard?tab=account"
+    : "/account";
+
+  return (
+    <>
+      <Header />
+      <main className="min-h-screen bg-background pt-20 pb-16">
+        <div className="max-w-lg mx-auto px-4">
+          <Card className="text-center">
+            <CardHeader className="pb-2">
+              <div className="mx-auto mb-4">
+                <CheckCircle2 className="h-16 w-16 text-green-500" />
+              </div>
+              <CardTitle className="text-2xl">Subscription Activated!</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <p className="text-muted-foreground">
+                Your subscription is now active. All premium features are available immediately.
+              </p>
+
+              {membership?.tier && (
+                <div className="flex justify-center">
+                  <MembershipBadge tier={membership.tier} />
+                </div>
+              )}
+
+              <div className="pt-4">
+                <Button asChild>
+                  <Link to={dashboardLink}>
+                    Go to Dashboard
+                    <ArrowRight className="h-4 w-4 ml-2" />
+                  </Link>
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      </main>
+    </>
+  );
+};
+
+export default SubscriptionSuccess;

--- a/src/test/fixtures/memberships.ts
+++ b/src/test/fixtures/memberships.ts
@@ -14,6 +14,7 @@ export function mockMembershipTier(overrides: Partial<MembershipTier> = {}): Mem
     features: ["Browse listings", "Book properties", "Voice search (5/day)"],
     description: "Basic traveler access",
     is_default: true,
+    stripe_price_id: null,
     created_at: "2026-01-01T00:00:00Z",
     updated_at: "2026-01-01T00:00:00Z",
     ...overrides,
@@ -50,6 +51,7 @@ export function mockOwnerProTier(): MembershipTier {
     features: ["List up to 10 properties", "2% commission discount"],
     description: "Professional owner tools",
     is_default: false,
+    stripe_price_id: "price_test_owner_pro",
   });
 }
 
@@ -67,6 +69,7 @@ export function mockOwnerBusinessTier(): MembershipTier {
     features: ["Unlimited listings", "5% commission discount"],
     description: "Unlimited owner access",
     is_default: false,
+    stripe_price_id: "price_test_owner_business",
   });
 }
 
@@ -81,6 +84,7 @@ export function mockTravelerTiers(): MembershipTier[] {
       monthly_price_cents: 500,
       voice_quota_daily: 25,
       is_default: false,
+      stripe_price_id: "price_test_traveler_plus",
     }),
     mockMembershipTier({
       id: "tier-premium-traveler",
@@ -90,6 +94,7 @@ export function mockTravelerTiers(): MembershipTier[] {
       monthly_price_cents: 1500,
       voice_quota_daily: -1,
       is_default: false,
+      stripe_price_id: "price_test_traveler_premium",
     }),
   ];
 }
@@ -109,6 +114,8 @@ export function mockUserMembership(overrides: Partial<UserMembership> = {}): Use
     stripe_subscription_id: null,
     stripe_customer_id: null,
     cancelled_at: null,
+    admin_override: false,
+    admin_notes: null,
     created_at: "2026-01-01T00:00:00Z",
     updated_at: "2026-01-01T00:00:00Z",
     ...overrides,

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -676,6 +676,7 @@ export type Database = {
           max_active_listings: number | null
           monthly_price_cents: number
           role_category: string
+          stripe_price_id: string | null
           tier_key: string
           tier_level: number
           tier_name: string
@@ -692,6 +693,7 @@ export type Database = {
           max_active_listings?: number | null
           monthly_price_cents?: number
           role_category: string
+          stripe_price_id?: string | null
           tier_key: string
           tier_level?: number
           tier_name: string
@@ -708,6 +710,7 @@ export type Database = {
           max_active_listings?: number | null
           monthly_price_cents?: number
           role_category?: string
+          stripe_price_id?: string | null
           tier_key?: string
           tier_level?: number
           tier_name?: string
@@ -1565,6 +1568,8 @@ export type Database = {
       }
       user_memberships: {
         Row: {
+          admin_notes: string | null
+          admin_override: boolean
           cancelled_at: string | null
           created_at: string | null
           expires_at: string | null
@@ -1578,6 +1583,8 @@ export type Database = {
           user_id: string
         }
         Insert: {
+          admin_notes?: string | null
+          admin_override?: boolean
           cancelled_at?: string | null
           created_at?: string | null
           expires_at?: string | null
@@ -1591,6 +1598,8 @@ export type Database = {
           user_id: string
         }
         Update: {
+          admin_notes?: string | null
+          admin_override?: boolean
           cancelled_at?: string | null
           created_at?: string | null
           expires_at?: string | null

--- a/supabase/functions/_shared/rate-limit.ts
+++ b/supabase/functions/_shared/rate-limit.ts
@@ -87,4 +87,8 @@ export const RATE_LIMITS = {
   ACCOUNT_DELETION: { endpoint: "delete-user-account", maxRequests: 3, windowSeconds: 60 },
   /** Data export: 3 requests per 5 minutes */
   DATA_EXPORT: { endpoint: "export-user-data", maxRequests: 3, windowSeconds: 300 },
+  /** Subscription checkout: 5 requests per minute */
+  SUBSCRIPTION_CHECKOUT: { endpoint: "create-subscription-checkout", maxRequests: 5, windowSeconds: 60 },
+  /** Manage subscription (billing portal): 10 requests per minute */
+  MANAGE_SUBSCRIPTION: { endpoint: "manage-subscription", maxRequests: 10, windowSeconds: 60 },
 } as const;

--- a/supabase/functions/create-subscription-checkout/index.ts
+++ b/supabase/functions/create-subscription-checkout/index.ts
@@ -1,0 +1,138 @@
+import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
+import Stripe from "https://esm.sh/stripe@18.5.0";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { checkRateLimit, rateLimitResponse, RATE_LIMITS } from "../_shared/rate-limit.ts";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type, x-supabase-client-platform, x-supabase-client-platform-version, x-supabase-client-runtime, x-supabase-client-runtime-version",
+};
+
+const logStep = (step: string, details?: Record<string, unknown>) => {
+  const detailsStr = details ? ` - ${JSON.stringify(details)}` : '';
+  console.log(`[CREATE-SUBSCRIPTION-CHECKOUT] ${step}${detailsStr}`);
+};
+
+serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response(null, { headers: corsHeaders });
+  }
+
+  const supabaseClient = createClient(
+    Deno.env.get("SUPABASE_URL") ?? "",
+    Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? "",
+    { auth: { persistSession: false } }
+  );
+
+  try {
+    logStep("Function started");
+
+    const stripeKey = Deno.env.get("STRIPE_SECRET_KEY");
+    if (!stripeKey) throw new Error("STRIPE_SECRET_KEY is not set");
+    logStep("Stripe key verified");
+
+    const authHeader = req.headers.get("Authorization");
+    if (!authHeader) throw new Error("No authorization header provided");
+    logStep("Authorization header found");
+
+    const token = authHeader.replace("Bearer ", "");
+    const { data: userData, error: userError } = await supabaseClient.auth.getUser(token);
+    if (userError) throw new Error(`Authentication error: ${userError.message}`);
+    const user = userData.user;
+    if (!user?.email) throw new Error("User not authenticated or email not available");
+    logStep("User authenticated", { userId: user.id, email: user.email });
+
+    // Rate limit check
+    const rateCheck = await checkRateLimit(supabaseClient, user.id, RATE_LIMITS.SUBSCRIPTION_CHECKOUT);
+    if (!rateCheck.allowed) {
+      logStep("Rate limited", { userId: user.id });
+      return rateLimitResponse(rateCheck.retryAfterSeconds);
+    }
+
+    // Parse the request body
+    const { tierKey } = await req.json();
+    if (!tierKey) throw new Error("tierKey is required");
+    logStep("Request body parsed", { tierKey });
+
+    // Fetch target tier
+    const { data: tier, error: tierError } = await supabaseClient
+      .from("membership_tiers")
+      .select("*")
+      .eq("tier_key", tierKey)
+      .single();
+
+    if (tierError || !tier) {
+      throw new Error("Membership tier not found");
+    }
+    logStep("Target tier fetched", { tierKey: tier.tier_key, stripePriceId: tier.stripe_price_id });
+
+    // Validate tier has a Stripe price (reject free tiers)
+    if (!tier.stripe_price_id) {
+      throw new Error("This tier does not require a subscription. No Stripe price configured.");
+    }
+
+    // Fetch current membership
+    const { data: currentMembership } = await supabaseClient
+      .from("user_memberships")
+      .select("*, tier:membership_tiers(*)")
+      .eq("user_id", user.id)
+      .eq("status", "active")
+      .single();
+
+    // If already on a paid tier with active subscription, reject
+    if (currentMembership?.stripe_subscription_id) {
+      throw new Error("Already subscribed. Use upgrade instead.");
+    }
+    logStep("Current membership checked", {
+      hasMembership: !!currentMembership,
+      hasSubscription: !!currentMembership?.stripe_subscription_id,
+    });
+
+    // Initialize Stripe
+    const stripe = new Stripe(stripeKey, { apiVersion: "2025-08-27.basil" });
+
+    // Check if customer exists
+    const customers = await stripe.customers.list({ email: user.email, limit: 1 });
+    let customerId: string | undefined;
+    if (customers.data.length > 0) {
+      customerId = customers.data[0].id;
+      logStep("Existing Stripe customer found", { customerId });
+    }
+
+    const origin = req.headers.get("origin") || "https://rent-a-vacation.com";
+
+    // Create Stripe checkout session for subscription
+    const session = await stripe.checkout.sessions.create({
+      customer: customerId,
+      customer_email: !customerId ? user.email : undefined,
+      mode: "subscription",
+      line_items: [{ price: tier.stripe_price_id, quantity: 1 }],
+      success_url: `${origin}/subscription-success?session_id={CHECKOUT_SESSION_ID}`,
+      cancel_url: `${origin}/owner-dashboard?tab=account&cancelled=true`,
+      metadata: { user_id: user.id, tier_key: tierKey },
+      subscription_data: {
+        metadata: { user_id: user.id, tier_key: tierKey },
+      },
+    });
+
+    logStep("Checkout session created", { sessionId: session.id, url: session.url });
+
+    return new Response(
+      JSON.stringify({ url: session.url }),
+      {
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+        status: 200,
+      }
+    );
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    logStep("ERROR", { message: errorMessage });
+    return new Response(
+      JSON.stringify({ error: errorMessage }),
+      {
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+        status: 500,
+      }
+    );
+  }
+});

--- a/supabase/functions/manage-subscription/index.ts
+++ b/supabase/functions/manage-subscription/index.ts
@@ -1,0 +1,96 @@
+import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
+import Stripe from "https://esm.sh/stripe@18.5.0";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { checkRateLimit, rateLimitResponse, RATE_LIMITS } from "../_shared/rate-limit.ts";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type, x-supabase-client-platform, x-supabase-client-platform-version, x-supabase-client-runtime, x-supabase-client-runtime-version",
+};
+
+const logStep = (step: string, details?: Record<string, unknown>) => {
+  const detailsStr = details ? ` - ${JSON.stringify(details)}` : '';
+  console.log(`[MANAGE-SUBSCRIPTION] ${step}${detailsStr}`);
+};
+
+serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response(null, { headers: corsHeaders });
+  }
+
+  const supabaseClient = createClient(
+    Deno.env.get("SUPABASE_URL") ?? "",
+    Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? "",
+    { auth: { persistSession: false } }
+  );
+
+  try {
+    logStep("Function started");
+
+    const stripeKey = Deno.env.get("STRIPE_SECRET_KEY");
+    if (!stripeKey) throw new Error("STRIPE_SECRET_KEY is not set");
+    logStep("Stripe key verified");
+
+    const authHeader = req.headers.get("Authorization");
+    if (!authHeader) throw new Error("No authorization header provided");
+    logStep("Authorization header found");
+
+    const token = authHeader.replace("Bearer ", "");
+    const { data: userData, error: userError } = await supabaseClient.auth.getUser(token);
+    if (userError) throw new Error(`Authentication error: ${userError.message}`);
+    const user = userData.user;
+    if (!user?.email) throw new Error("User not authenticated or email not available");
+    logStep("User authenticated", { userId: user.id, email: user.email });
+
+    // Rate limit check
+    const rateCheck = await checkRateLimit(supabaseClient, user.id, RATE_LIMITS.MANAGE_SUBSCRIPTION);
+    if (!rateCheck.allowed) {
+      logStep("Rate limited", { userId: user.id });
+      return rateLimitResponse(rateCheck.retryAfterSeconds);
+    }
+
+    // Fetch user membership with stripe_customer_id
+    const { data: membership, error: membershipError } = await supabaseClient
+      .from("user_memberships")
+      .select("stripe_customer_id")
+      .eq("user_id", user.id)
+      .in("status", ["active", "cancelled"])
+      .single();
+
+    if (membershipError || !membership?.stripe_customer_id) {
+      throw new Error("No active subscription found");
+    }
+    logStep("Membership found", { stripeCustomerId: membership.stripe_customer_id });
+
+    // Initialize Stripe
+    const stripe = new Stripe(stripeKey, { apiVersion: "2025-08-27.basil" });
+
+    const origin = req.headers.get("origin") || "https://rent-a-vacation.com";
+
+    // Create Stripe Customer Portal session
+    const session = await stripe.billingPortal.sessions.create({
+      customer: membership.stripe_customer_id,
+      return_url: `${origin}/owner-dashboard?tab=account`,
+    });
+
+    logStep("Portal session created", { url: session.url });
+
+    return new Response(
+      JSON.stringify({ url: session.url }),
+      {
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+        status: 200,
+      }
+    );
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    logStep("ERROR", { message: errorMessage });
+    return new Response(
+      JSON.stringify({ error: errorMessage }),
+      {
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+        status: 500,
+      }
+    );
+  }
+});

--- a/supabase/functions/stripe-webhook/index.ts
+++ b/supabase/functions/stripe-webhook/index.ts
@@ -79,6 +79,27 @@ serve(async (req) => {
         await handleTransferReversed(supabase, event.data.object);
         break;
 
+      // ── Subscription lifecycle events ──────────────────────────
+      case "customer.subscription.created":
+        await handleSubscriptionCreated(supabase, event.data.object);
+        break;
+
+      case "customer.subscription.updated":
+        await handleSubscriptionUpdated(supabase, event.data.object);
+        break;
+
+      case "customer.subscription.deleted":
+        await handleSubscriptionDeleted(supabase, event.data.object);
+        break;
+
+      case "invoice.paid":
+        await handleInvoicePaid(supabase, event.data.object);
+        break;
+
+      case "invoice.payment_failed":
+        await handleInvoicePaymentFailed(supabase, event.data.object);
+        break;
+
       default:
         logStep("Unhandled event type", { type: event.type });
     }
@@ -586,4 +607,348 @@ async function handleTransferReversed(
     .eq("id", booking.id);
 
   logStep("Booking payout marked as failed due to reversal", { bookingId: booking.id });
+}
+
+// ══════════════════════════════════════════════════════════════
+// SUBSCRIPTION LIFECYCLE HANDLERS
+// ══════════════════════════════════════════════════════════════
+
+/**
+ * Handle customer.subscription.created
+ * Fired when a new subscription is successfully created via Stripe Checkout.
+ * Updates user_memberships with Stripe IDs and new tier.
+ */
+// deno-lint-ignore no-explicit-any
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+async function handleSubscriptionCreated(supabase: any, subscription: any) {
+  const userId = subscription.metadata?.user_id;
+  const tierKey = subscription.metadata?.tier_key;
+  logStep("Subscription created", { subscriptionId: subscription.id, userId, tierKey });
+
+  if (!userId || !tierKey) {
+    logStep("Missing metadata on subscription — skipping", { subscriptionId: subscription.id });
+    return;
+  }
+
+  // Look up the tier
+  const { data: tier } = await supabase
+    .from("membership_tiers")
+    .select("id, tier_name")
+    .eq("tier_key", tierKey)
+    .single();
+
+  if (!tier) {
+    logStep("Tier not found for tier_key", { tierKey });
+    return;
+  }
+
+  // Update user membership
+  const { error: updateError } = await supabase
+    .from("user_memberships")
+    .update({
+      tier_id: tier.id,
+      stripe_subscription_id: subscription.id,
+      stripe_customer_id: subscription.customer,
+      status: "active",
+      started_at: new Date().toISOString(),
+      expires_at: new Date(subscription.current_period_end * 1000).toISOString(),
+      cancelled_at: null,
+    })
+    .eq("user_id", userId);
+
+  if (updateError) {
+    logStep("Failed to update membership", { error: updateError.message });
+    return;
+  }
+
+  logStep("Membership upgraded", { userId, tier: tier.tier_name });
+
+  // Send welcome email
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("full_name, email")
+    .eq("id", userId)
+    .single();
+
+  if (profile?.email) {
+    const html = buildEmailHtml({
+      recipientName: profile.full_name || "there",
+      heading: `Welcome to ${tier.tier_name}!`,
+      body: `
+        <p>Your subscription to the <strong>${tier.tier_name}</strong> plan is now active.</p>
+        ${detailRow("Plan", tier.tier_name)}
+        ${detailRow("Status", "Active")}
+        ${detailRow("Next billing date", new Date(subscription.current_period_end * 1000).toLocaleDateString())}
+        <p>You now have access to all ${tier.tier_name} features. Enjoy!</p>
+      `,
+      cta: { label: "Go to Dashboard", url: "https://rent-a-vacation.com/owner-dashboard?tab=account" },
+    });
+
+    await resend.emails.send({
+      from: "Rent-A-Vacation <notifications@updates.rent-a-vacation.com>",
+      to: profile.email,
+      subject: `Welcome to ${tier.tier_name} — Rent-A-Vacation`,
+      html,
+    });
+    logStep("Welcome email sent", { email: profile.email });
+  }
+}
+
+/**
+ * Handle customer.subscription.updated
+ * Fired on: tier changes, cancellation scheduling, payment method updates, renewals.
+ * Checks cancel_at_period_end and price changes.
+ */
+// deno-lint-ignore no-explicit-any
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+async function handleSubscriptionUpdated(supabase: any, subscription: any) {
+  const userId = subscription.metadata?.user_id;
+  logStep("Subscription updated", { subscriptionId: subscription.id, userId, cancelAtPeriodEnd: subscription.cancel_at_period_end });
+
+  if (!userId) {
+    logStep("Missing user_id in subscription metadata — skipping");
+    return;
+  }
+
+  // Check if admin override — skip if so
+  const { data: membership } = await supabase
+    .from("user_memberships")
+    .select("id, admin_override, tier_id, status")
+    .eq("user_id", userId)
+    .single();
+
+  if (membership?.admin_override) {
+    logStep("Skipping webhook update — admin override active", { userId });
+    return;
+  }
+
+  // Build update payload
+  // deno-lint-ignore no-explicit-any
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const updates: Record<string, any> = {
+    expires_at: new Date(subscription.current_period_end * 1000).toISOString(),
+  };
+
+  // Handle cancellation scheduling
+  if (subscription.cancel_at_period_end && membership?.status !== "cancelled") {
+    updates.status = "cancelled";
+    updates.cancelled_at = new Date().toISOString();
+    logStep("Subscription cancellation scheduled", { userId });
+  } else if (!subscription.cancel_at_period_end && membership?.status === "cancelled") {
+    // Reactivation (user un-cancelled)
+    updates.status = "active";
+    updates.cancelled_at = null;
+    logStep("Subscription reactivated", { userId });
+  }
+
+  // Check for price/tier change
+  const currentPriceId = subscription.items?.data?.[0]?.price?.id;
+  if (currentPriceId) {
+    const { data: newTier } = await supabase
+      .from("membership_tiers")
+      .select("id, tier_name")
+      .eq("stripe_price_id", currentPriceId)
+      .single();
+
+    if (newTier && newTier.id !== membership?.tier_id) {
+      updates.tier_id = newTier.id;
+      logStep("Tier changed via subscription update", { userId, newTier: newTier.tier_name });
+    }
+  }
+
+  await supabase
+    .from("user_memberships")
+    .update(updates)
+    .eq("user_id", userId);
+
+  logStep("Membership updated from webhook", { userId, updates: Object.keys(updates) });
+}
+
+/**
+ * Handle customer.subscription.deleted
+ * Fired when subscription ends (cancellation took effect or payment retries exhausted).
+ * Downgrades user to the default free tier for their role category.
+ */
+// deno-lint-ignore no-explicit-any
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+async function handleSubscriptionDeleted(supabase: any, subscription: any) {
+  const userId = subscription.metadata?.user_id;
+  logStep("Subscription deleted", { subscriptionId: subscription.id, userId });
+
+  if (!userId) {
+    logStep("Missing user_id in subscription metadata — skipping");
+    return;
+  }
+
+  // Check admin override
+  const { data: membership } = await supabase
+    .from("user_memberships")
+    .select("id, admin_override, tier:membership_tiers(role_category)")
+    .eq("user_id", userId)
+    .single();
+
+  if (membership?.admin_override) {
+    logStep("Skipping deletion — admin override active", { userId });
+    return;
+  }
+
+  // Find the default free tier for this user's role category
+  const roleCategory = membership?.tier?.role_category || "traveler";
+  const { data: freeTier } = await supabase
+    .from("membership_tiers")
+    .select("id, tier_name")
+    .eq("role_category", roleCategory)
+    .eq("is_default", true)
+    .single();
+
+  if (!freeTier) {
+    logStep("Could not find default free tier", { roleCategory });
+    return;
+  }
+
+  // Downgrade to free tier
+  await supabase
+    .from("user_memberships")
+    .update({
+      tier_id: freeTier.id,
+      status: "active",
+      stripe_subscription_id: null,
+      expires_at: null,
+      cancelled_at: null,
+    })
+    .eq("user_id", userId);
+
+  logStep("User downgraded to free tier", { userId, tier: freeTier.tier_name });
+
+  // Send notification email
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("full_name, email")
+    .eq("id", userId)
+    .single();
+
+  if (profile?.email) {
+    const html = buildEmailHtml({
+      recipientName: profile.full_name || "there",
+      heading: "Your Subscription Has Ended",
+      body: `
+        <p>Your paid subscription has ended and your account has been moved to the <strong>Free</strong> plan.</p>
+        <p>You can re-subscribe at any time from your account settings to regain access to premium features.</p>
+      `,
+      cta: { label: "View Plans", url: "https://rent-a-vacation.com/owner-dashboard?tab=account" },
+    });
+
+    await resend.emails.send({
+      from: "Rent-A-Vacation <notifications@updates.rent-a-vacation.com>",
+      to: profile.email,
+      subject: "Your subscription has ended — Rent-A-Vacation",
+      html,
+    });
+    logStep("Subscription ended email sent", { email: profile.email });
+  }
+}
+
+/**
+ * Handle invoice.paid
+ * Fired on successful subscription renewal payments.
+ * Updates expires_at to the new period end.
+ */
+// deno-lint-ignore no-explicit-any
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+async function handleInvoicePaid(supabase: any, invoice: any) {
+  // Only process subscription renewal invoices (skip initial payment — handled by subscription.created)
+  if (invoice.billing_reason !== "subscription_cycle") {
+    logStep("Skipping non-renewal invoice", { billingReason: invoice.billing_reason });
+    return;
+  }
+
+  const subscriptionId = invoice.subscription;
+  logStep("Renewal invoice paid", { subscriptionId, invoiceId: invoice.id });
+
+  if (!subscriptionId) return;
+
+  // Find the membership by stripe_subscription_id
+  const { data: membership } = await supabase
+    .from("user_memberships")
+    .select("id, user_id")
+    .eq("stripe_subscription_id", subscriptionId)
+    .single();
+
+  if (!membership) {
+    logStep("No membership found for subscription", { subscriptionId });
+    return;
+  }
+
+  // Update expiry to new period end
+  const periodEnd = invoice.lines?.data?.[0]?.period?.end;
+  if (periodEnd) {
+    await supabase
+      .from("user_memberships")
+      .update({
+        expires_at: new Date(periodEnd * 1000).toISOString(),
+        status: "active",
+      })
+      .eq("id", membership.id);
+
+    logStep("Membership renewed", { userId: membership.user_id, newExpiresAt: new Date(periodEnd * 1000).toISOString() });
+  }
+}
+
+/**
+ * Handle invoice.payment_failed
+ * Fired when a subscription payment attempt fails.
+ * Sets membership to pending (grace period) and sends notification email.
+ */
+// deno-lint-ignore no-explicit-any
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+async function handleInvoicePaymentFailed(supabase: any, invoice: any) {
+  const subscriptionId = invoice.subscription;
+  logStep("Invoice payment failed", { subscriptionId, invoiceId: invoice.id, attemptCount: invoice.attempt_count });
+
+  if (!subscriptionId) return;
+
+  const { data: membership } = await supabase
+    .from("user_memberships")
+    .select("id, user_id, stripe_customer_id")
+    .eq("stripe_subscription_id", subscriptionId)
+    .single();
+
+  if (!membership) {
+    logStep("No membership found for failed invoice", { subscriptionId });
+    return;
+  }
+
+  // Set status to pending (grace period — Stripe will retry)
+  await supabase
+    .from("user_memberships")
+    .update({ status: "pending" })
+    .eq("id", membership.id);
+
+  // Send payment failed email
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("full_name, email")
+    .eq("id", membership.user_id)
+    .single();
+
+  if (profile?.email) {
+    const html = buildEmailHtml({
+      recipientName: profile.full_name || "there",
+      heading: "Payment Failed — Action Required",
+      body: `
+        <p>We were unable to process your subscription payment. Your account is currently in a grace period.</p>
+        <p>Please update your payment method to avoid losing access to your premium features. Stripe will automatically retry the payment, but you can update your card now to resolve this immediately.</p>
+      `,
+      cta: { label: "Update Payment Method", url: "https://rent-a-vacation.com/owner-dashboard?tab=account" },
+      footerNote: "If you believe this is an error, please contact support@rent-a-vacation.com.",
+    });
+
+    await resend.emails.send({
+      from: "Rent-A-Vacation <notifications@updates.rent-a-vacation.com>",
+      to: profile.email,
+      subject: "Payment failed — update your card — Rent-A-Vacation",
+      html,
+    });
+    logStep("Payment failed email sent", { email: profile.email });
+  }
 }

--- a/supabase/functions/update-subscription/index.ts
+++ b/supabase/functions/update-subscription/index.ts
@@ -1,0 +1,178 @@
+import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
+import Stripe from "https://esm.sh/stripe@18.5.0";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { checkRateLimit, rateLimitResponse, RATE_LIMITS } from "../_shared/rate-limit.ts";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type, x-supabase-client-platform, x-supabase-client-platform-version, x-supabase-client-runtime, x-supabase-client-runtime-version",
+};
+
+const logStep = (step: string, details?: Record<string, unknown>) => {
+  const detailsStr = details ? ` - ${JSON.stringify(details)}` : '';
+  console.log(`[UPDATE-SUBSCRIPTION] ${step}${detailsStr}`);
+};
+
+serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response(null, { headers: corsHeaders });
+  }
+
+  const supabaseClient = createClient(
+    Deno.env.get("SUPABASE_URL") ?? "",
+    Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? "",
+    { auth: { persistSession: false } }
+  );
+
+  try {
+    logStep("Function started");
+
+    const stripeKey = Deno.env.get("STRIPE_SECRET_KEY");
+    if (!stripeKey) throw new Error("STRIPE_SECRET_KEY is not set");
+    logStep("Stripe key verified");
+
+    const authHeader = req.headers.get("Authorization");
+    if (!authHeader) throw new Error("No authorization header provided");
+    logStep("Authorization header found");
+
+    const token = authHeader.replace("Bearer ", "");
+    const { data: userData, error: userError } = await supabaseClient.auth.getUser(token);
+    if (userError) throw new Error(`Authentication error: ${userError.message}`);
+    const user = userData.user;
+    if (!user?.email) throw new Error("User not authenticated or email not available");
+    logStep("User authenticated", { userId: user.id, email: user.email });
+
+    // Rate limit check
+    const rateCheck = await checkRateLimit(supabaseClient, user.id, RATE_LIMITS.SUBSCRIPTION_CHECKOUT);
+    if (!rateCheck.allowed) {
+      logStep("Rate limited", { userId: user.id });
+      return rateLimitResponse(rateCheck.retryAfterSeconds);
+    }
+
+    // Parse the request body
+    const { newTierKey } = await req.json();
+    if (!newTierKey) throw new Error("newTierKey is required");
+    logStep("Request body parsed", { newTierKey });
+
+    // Fetch current membership with tier join
+    const { data: membership, error: membershipError } = await supabaseClient
+      .from("user_memberships")
+      .select("*, tier:membership_tiers(*)")
+      .eq("user_id", user.id)
+      .eq("status", "active")
+      .single();
+
+    if (membershipError || !membership) {
+      throw new Error("No active membership found");
+    }
+
+    // Must have an active Stripe subscription to update
+    if (!membership.stripe_subscription_id) {
+      throw new Error("No active Stripe subscription. Use checkout to subscribe first.");
+    }
+    logStep("Current membership found", {
+      currentTier: membership.tier?.tier_key,
+      tierLevel: membership.tier?.tier_level,
+      subscriptionId: membership.stripe_subscription_id,
+    });
+
+    // Fetch target tier
+    const { data: targetTier, error: targetTierError } = await supabaseClient
+      .from("membership_tiers")
+      .select("*")
+      .eq("tier_key", newTierKey)
+      .single();
+
+    if (targetTierError || !targetTier) {
+      throw new Error("Target membership tier not found");
+    }
+    logStep("Target tier fetched", {
+      tierKey: targetTier.tier_key,
+      tierLevel: targetTier.tier_level,
+      monthlyPriceCents: targetTier.monthly_price_cents,
+    });
+
+    // Initialize Stripe
+    const stripe = new Stripe(stripeKey, { apiVersion: "2025-08-27.basil" });
+
+    // If target is a free tier, cancel at period end
+    if (targetTier.monthly_price_cents === 0) {
+      logStep("Downgrading to free tier — cancelling at period end");
+      await stripe.subscriptions.update(membership.stripe_subscription_id, {
+        cancel_at_period_end: true,
+      });
+      return new Response(
+        JSON.stringify({
+          success: true,
+          effective: "period_end",
+          message: "Subscription will cancel at end of billing period",
+        }),
+        {
+          headers: { ...corsHeaders, "Content-Type": "application/json" },
+          status: 200,
+        }
+      );
+    }
+
+    // Validate target tier has a Stripe price
+    if (!targetTier.stripe_price_id) {
+      throw new Error("Target tier does not have a Stripe price configured");
+    }
+
+    // Get current subscription from Stripe to find the subscription item ID
+    const subscription = await stripe.subscriptions.retrieve(membership.stripe_subscription_id);
+    const itemId = subscription.items.data[0].id;
+    logStep("Stripe subscription retrieved", { itemId });
+
+    const currentTierLevel = membership.tier?.tier_level ?? 0;
+    const targetTierLevel = targetTier.tier_level ?? 0;
+
+    if (targetTierLevel > currentTierLevel) {
+      // UPGRADE: prorate immediately
+      logStep("Upgrading subscription", {
+        from: membership.tier?.tier_key,
+        to: targetTier.tier_key,
+      });
+      await stripe.subscriptions.update(membership.stripe_subscription_id, {
+        items: [{ id: itemId, price: targetTier.stripe_price_id }],
+        proration_behavior: "create_prorations",
+        metadata: { user_id: user.id, tier_key: newTierKey },
+      });
+      return new Response(
+        JSON.stringify({ success: true, effective: "immediate" }),
+        {
+          headers: { ...corsHeaders, "Content-Type": "application/json" },
+          status: 200,
+        }
+      );
+    } else {
+      // DOWNGRADE: no proration, effective next cycle
+      logStep("Downgrading subscription", {
+        from: membership.tier?.tier_key,
+        to: targetTier.tier_key,
+      });
+      await stripe.subscriptions.update(membership.stripe_subscription_id, {
+        items: [{ id: itemId, price: targetTier.stripe_price_id }],
+        proration_behavior: "none",
+        metadata: { user_id: user.id, tier_key: newTierKey },
+      });
+      return new Response(
+        JSON.stringify({ success: true, effective: "next_cycle" }),
+        {
+          headers: { ...corsHeaders, "Content-Type": "application/json" },
+          status: 200,
+        }
+      );
+    }
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    logStep("ERROR", { message: errorMessage });
+    return new Response(
+      JSON.stringify({ error: errorMessage }),
+      {
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+        status: 500,
+      }
+    );
+  }
+});

--- a/supabase/migrations/047_membership_stripe_prices.sql
+++ b/supabase/migrations/047_membership_stripe_prices.sql
@@ -1,0 +1,94 @@
+-- Migration 047: Membership Stripe Prices + Admin Override
+-- Part of Epic #263: Stripe Subscription System
+--
+-- Adds stripe_price_id to membership_tiers for Stripe subscription integration.
+-- Adds admin_override and admin_notes to user_memberships for manual tier management.
+-- Stripe Price IDs must be populated after creating Products/Prices in Stripe Dashboard.
+
+-- 1. Add stripe_price_id to membership_tiers
+ALTER TABLE membership_tiers ADD COLUMN IF NOT EXISTS stripe_price_id TEXT;
+
+-- 2. Add admin override fields to user_memberships
+ALTER TABLE user_memberships ADD COLUMN IF NOT EXISTS admin_override BOOLEAN DEFAULT FALSE;
+ALTER TABLE user_memberships ADD COLUMN IF NOT EXISTS admin_notes TEXT;
+
+-- 3. Placeholder UPDATEs for Stripe Price IDs
+-- These will be updated with real price_XXX IDs after creating Products in Stripe Dashboard.
+-- For now, use placeholder values that indicate they need to be set.
+--
+-- To update after Stripe setup:
+--   UPDATE membership_tiers SET stripe_price_id = 'price_XXXX' WHERE tier_key = 'traveler_plus';
+--   UPDATE membership_tiers SET stripe_price_id = 'price_XXXX' WHERE tier_key = 'traveler_premium';
+--   UPDATE membership_tiers SET stripe_price_id = 'price_XXXX' WHERE tier_key = 'owner_pro';
+--   UPDATE membership_tiers SET stripe_price_id = 'price_XXXX' WHERE tier_key = 'owner_business';
+
+-- 4. Index for stripe_price_id lookups (used in webhook handlers)
+CREATE INDEX IF NOT EXISTS idx_membership_tiers_stripe_price
+  ON membership_tiers(stripe_price_id)
+  WHERE stripe_price_id IS NOT NULL;
+
+-- 5. Index for admin override lookups (used in webhook to skip overridden memberships)
+CREATE INDEX IF NOT EXISTS idx_user_memberships_admin_override
+  ON user_memberships(admin_override)
+  WHERE admin_override = TRUE;
+
+-- 6. RPC: Look up tier by Stripe Price ID (used by webhook handlers)
+CREATE OR REPLACE FUNCTION get_tier_by_stripe_price(_stripe_price_id TEXT)
+RETURNS TABLE(
+  id UUID,
+  tier_key TEXT,
+  role_category TEXT,
+  tier_name TEXT,
+  tier_level INTEGER,
+  monthly_price_cents INTEGER,
+  voice_quota_daily INTEGER,
+  commission_discount_pct NUMERIC(5,2),
+  max_active_listings INTEGER
+)
+LANGUAGE plpgsql STABLE SECURITY DEFINER SET search_path = public
+AS $$
+BEGIN
+  RETURN QUERY
+  SELECT
+    mt.id, mt.tier_key, mt.role_category, mt.tier_name, mt.tier_level,
+    mt.monthly_price_cents, mt.voice_quota_daily, mt.commission_discount_pct,
+    mt.max_active_listings
+  FROM membership_tiers mt
+  WHERE mt.stripe_price_id = _stripe_price_id
+  LIMIT 1;
+END;
+$$;
+
+-- 7. RPC: Check listing limit for a given owner
+-- Returns TRUE if owner can create another listing, FALSE if at limit
+CREATE OR REPLACE FUNCTION check_listing_limit(_owner_id UUID)
+RETURNS BOOLEAN
+LANGUAGE plpgsql STABLE SECURITY DEFINER SET search_path = public
+AS $$
+DECLARE
+  _max_listings INTEGER;
+  _current_count INTEGER;
+BEGIN
+  -- Get max_active_listings from active membership tier
+  SELECT mt.max_active_listings INTO _max_listings
+  FROM user_memberships um
+  JOIN membership_tiers mt ON mt.id = um.tier_id
+  WHERE um.user_id = _owner_id AND um.status = 'active';
+
+  -- NULL means unlimited
+  IF _max_listings IS NULL THEN
+    RETURN TRUE;
+  END IF;
+
+  -- Count current active + pending listings
+  SELECT COUNT(*) INTO _current_count
+  FROM listings
+  WHERE owner_id = _owner_id AND status IN ('active', 'pending_approval');
+
+  RETURN _current_count < _max_listings;
+END;
+$$;
+
+-- Grant execute permissions
+GRANT EXECUTE ON FUNCTION get_tier_by_stripe_price(TEXT) TO authenticated;
+GRANT EXECUTE ON FUNCTION check_listing_limit(UUID) TO authenticated;


### PR DESCRIPTION
## Summary
Complete Stripe subscription lifecycle enabling paid membership tiers. Replaces all "Coming Soon" buttons with live upgrade/downgrade actions.

- **Migration 047:** `stripe_price_id` on tiers, `admin_override` + `admin_notes` on memberships, `check_listing_limit` + `get_tier_by_stripe_price` RPCs
- **3 new edge functions:** `create-subscription-checkout`, `manage-subscription` (Stripe Portal), `update-subscription` (upgrade/downgrade/cancel)
- **5 new webhook handlers:** subscription created/updated/deleted, invoice paid/failed — with admin override protection and free-tier auto-downgrade
- **Frontend:** `useSubscription` hooks, live tier buttons, `SubscriptionManagement` component, `SubscriptionSuccess` page, integrated into AccountSettings + OwnerDashboard

## Related Issues
Epic: #263 | Stories: #264-#271

## Remaining (next session)
- Phase 5: Listing limit frontend enforcement (#270)
- Phase 6: Admin MRR metrics + manual override (#271)
- Phase 7: Documentation updates

## Test plan
- [x] 825 tests passing (104 files)
- [x] Clean build
- [x] "Coming Soon" removed from MembershipTierCard
- [ ] Stripe Products/Prices need to be created in Stripe Dashboard before testing live
- [ ] Migration 047 needs to be deployed to DEV

🤖 Generated with [Claude Code](https://claude.com/claude-code)