### PR TITLE
fix(admin): resolve ambiguous FK join in AdminProperties

### DIFF
--- a/src/components/admin/AdminProperties.tsx
+++ b/src/components/admin/AdminProperties.tsx
@@ -54,7 +54,7 @@ const AdminProperties = ({ initialSearch = "", onNavigateToEntity }: AdminNaviga
         .from("properties")
         .select(`
           *,
-          owner:profiles(*)
+          owner:profiles!properties_owner_id_fkey(*)
         `)
         .order("created_at", { ascending: false });
 


### PR DESCRIPTION
Properties tab showed 'no properties found' due to PostgREST PGRST201 error — two FKs from properties to profiles (owner_id + last_edited_by). Added explicit FK hint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)