### PR TITLE
feat(messaging): unified inbox + thread UI (#299, #300)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -56,6 +56,7 @@ const BudgetPlanner = lazy(() => import("./pages/BudgetPlanner"));
 const Notifications = lazy(() => import("./pages/Notifications"));
 const NotificationPreferences = lazy(() => import("./pages/settings/NotificationPreferences"));
 const SubscriptionSuccess = lazy(() => import("./pages/SubscriptionSuccess"));
+const Messages = lazy(() => import("./pages/Messages"));
 
 import { PWAInstallBanner } from "@/components/PWAInstallBanner";
 import { OfflineBanner } from "@/components/OfflineBanner";
@@ -201,6 +202,8 @@ const App = () => (
             <Route path="/my-bids" element={<Navigate to="/my-trips?tab=offers" replace />} />
             <Route path="/my-bookings" element={<Navigate to="/my-trips?tab=bookings" replace />} />
             <Route path="/account" element={<ProtectedRoute><AccountSettings /></ProtectedRoute>} />
+            <Route path="/messages" element={<ProtectedRoute><Messages /></ProtectedRoute>} />
+            <Route path="/messages/:conversationId" element={<ProtectedRoute><Messages /></ProtectedRoute>} />
             <Route path="/notifications" element={<ProtectedRoute><Notifications /></ProtectedRoute>} />
             <Route path="/settings/notifications" element={<ProtectedRoute><NotificationPreferences /></ProtectedRoute>} />
             <Route path="/checkin" element={<ProtectedRoute><TravelerCheckin /></ProtectedRoute>} />

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,9 +1,10 @@
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
-import { Menu, X, ChevronDown, LogOut, LayoutDashboard, ShieldCheck, BarChart3, Settings, GitBranch, Plane, Sparkles } from "lucide-react";
+import { Menu, X, ChevronDown, LogOut, LayoutDashboard, ShieldCheck, BarChart3, Settings, GitBranch, Plane, Sparkles, MessageSquare } from "lucide-react";
 import { Link, useNavigate, useLocation } from "react-router-dom";
 import { useAuth } from "@/contexts/AuthContext";
 import { NotificationBell } from "@/components/bidding/NotificationBell";
+import { useUnreadConversationCount } from "@/hooks/useConversations";
 import { RoleBadge, getDisplayRole } from "@/components/RoleBadge";
 import {
   DropdownMenu,
@@ -21,6 +22,7 @@ const Header = () => {
   const { user, profile, roles, isPropertyOwner, isRavTeam, signOut, isLoading } = useAuth();
   const displayRole = getDisplayRole(roles);
   const firstName = profile?.full_name?.split(" ")[0];
+  const { data: unreadMessages = 0 } = useUnreadConversationCount();
 
   const isActive = (path: string) => location.pathname === path || location.pathname.startsWith(path + "/");
 
@@ -160,6 +162,16 @@ const Header = () => {
               <div className="w-20 h-9 bg-muted animate-pulse rounded-md" />
             ) : user ? (
               <div className="flex items-center gap-2">
+                <Button variant="ghost" size="icon" asChild className="relative">
+                  <Link to="/messages">
+                    <MessageSquare className="h-5 w-5" />
+                    {unreadMessages > 0 && (
+                      <Badge variant="destructive" className="absolute -top-1 -right-1 h-5 w-5 p-0 flex items-center justify-center text-[10px]">
+                        {unreadMessages > 99 ? '99+' : unreadMessages}
+                      </Badge>
+                    )}
+                  </Link>
+                </Button>
                 <NotificationBell />
                 <DropdownMenu>
                   <DropdownMenuTrigger asChild>
@@ -260,6 +272,16 @@ const Header = () => {
             )}
             {user && !isLoading && (
               <div className="flex items-center gap-2">
+                <Button variant="ghost" size="icon" asChild className="relative h-8 w-8">
+                  <Link to="/messages">
+                    <MessageSquare className="h-4 w-4" />
+                    {unreadMessages > 0 && (
+                      <Badge variant="destructive" className="absolute -top-1 -right-1 h-4 w-4 p-0 flex items-center justify-center text-[9px]">
+                        {unreadMessages > 99 ? '99+' : unreadMessages}
+                      </Badge>
+                    )}
+                  </Link>
+                </Button>
                 <NotificationBell />
                 <button
                   className="flex items-center gap-1.5 px-2 py-1 rounded-full bg-primary/10 hover:bg-primary/15 transition-colors"

--- a/src/components/messaging/ConversationEventBubble.tsx
+++ b/src/components/messaging/ConversationEventBubble.tsx
@@ -1,0 +1,21 @@
+import { formatConversationEvent } from '@/lib/conversations';
+
+interface ConversationEventBubbleProps {
+  eventType: string;
+  eventData: Record<string, unknown>;
+  createdAt: string;
+}
+
+export function ConversationEventBubble({ eventType, eventData, createdAt }: ConversationEventBubbleProps) {
+  const text = formatConversationEvent(eventType, eventData);
+  const time = new Date(createdAt).toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
+
+  return (
+    <div className="flex justify-center my-3">
+      <div className="bg-muted/50 rounded-full px-4 py-1.5 text-sm text-muted-foreground italic flex items-center gap-2">
+        <span>{text}</span>
+        <span className="text-[10px] opacity-60">{time}</span>
+      </div>
+    </div>
+  );
+}

--- a/src/components/messaging/ConversationInbox.test.tsx
+++ b/src/components/messaging/ConversationInbox.test.tsx
@@ -1,0 +1,126 @@
+// @vitest-environment jsdom
+// @p0
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
+
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: vi.fn().mockReturnValue({
+    user: { id: 'user-1', email: 'test@example.com' },
+  }),
+}));
+
+const mockConversations = vi.hoisted(() => [
+  {
+    id: 'conv-1',
+    owner_id: 'user-1',
+    traveler_id: 'traveler-1',
+    context_type: 'booking',
+    status: 'active',
+    last_message_at: new Date().toISOString(),
+    owner_unread_count: 2,
+    traveler_unread_count: 0,
+    owner: { id: 'user-1', full_name: 'Alice Owner' },
+    traveler: { id: 'traveler-1', full_name: 'Bob Traveler' },
+    property: { id: 'prop-1', resort_name: 'Tuscany Village', location: 'Orlando' },
+  },
+  {
+    id: 'conv-2',
+    owner_id: 'owner-2',
+    traveler_id: 'user-1',
+    context_type: 'bid',
+    status: 'active',
+    last_message_at: new Date(Date.now() - 3600000).toISOString(),
+    owner_unread_count: 0,
+    traveler_unread_count: 1,
+    owner: { id: 'owner-2', full_name: 'Carol Owner' },
+    traveler: { id: 'user-1', full_name: 'Alice Traveler' },
+    property: { id: 'prop-2', resort_name: 'MarBrisa Resort', location: 'Carlsbad' },
+  },
+]);
+
+vi.mock('@/hooks/useConversations', () => ({
+  useMyConversations: vi.fn().mockReturnValue({
+    data: mockConversations,
+    isLoading: false,
+  }),
+}));
+
+vi.mock('@/hooks/useRealtimeSubscription', () => ({
+  useRealtimeSubscription: vi.fn(),
+}));
+
+import { ConversationInbox } from './ConversationInbox';
+
+function renderInbox(props = {}) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const defaultProps = {
+    onSelect: vi.fn(),
+    filter: 'all',
+    onFilterChange: vi.fn(),
+    ...props,
+  };
+  return {
+    ...render(
+      <QueryClientProvider client={qc}>
+        <MemoryRouter>
+          <ConversationInbox {...defaultProps} />
+        </MemoryRouter>
+      </QueryClientProvider>
+    ),
+    onSelect: defaultProps.onSelect,
+    onFilterChange: defaultProps.onFilterChange,
+  };
+}
+
+describe('ConversationInbox', () => {
+  it('renders the inbox container', () => {
+    renderInbox();
+    expect(screen.getByTestId('conversation-inbox')).toBeInTheDocument();
+  });
+
+  it('shows Messages heading', () => {
+    renderInbox();
+    expect(screen.getByText('Messages')).toBeInTheDocument();
+  });
+
+  it('renders filter tabs', () => {
+    renderInbox();
+    expect(screen.getByText('All')).toBeInTheDocument();
+    expect(screen.getByText('Bookings')).toBeInTheDocument();
+    expect(screen.getByText('Bids')).toBeInTheDocument();
+    expect(screen.getByText('Inquiries')).toBeInTheDocument();
+    expect(screen.getByText('Requests')).toBeInTheDocument();
+  });
+
+  it('displays conversation items with participant names', () => {
+    renderInbox();
+    expect(screen.getByText('Bob Traveler')).toBeInTheDocument();
+    expect(screen.getByText('Carol Owner')).toBeInTheDocument();
+  });
+
+  it('displays property names', () => {
+    renderInbox();
+    expect(screen.getByText('Tuscany Village')).toBeInTheDocument();
+    expect(screen.getByText('MarBrisa Resort')).toBeInTheDocument();
+  });
+
+  it('displays context badges', () => {
+    renderInbox();
+    expect(screen.getByText('Booking')).toBeInTheDocument();
+    expect(screen.getByText('Bid')).toBeInTheDocument();
+  });
+
+  it('calls onSelect when clicking a conversation', () => {
+    const { onSelect } = renderInbox();
+    fireEvent.click(screen.getByTestId('inbox-item-conv-1'));
+    expect(onSelect).toHaveBeenCalledWith('conv-1');
+  });
+
+  it('highlights the selected conversation', () => {
+    renderInbox({ selectedId: 'conv-1' });
+    const item = screen.getByTestId('inbox-item-conv-1');
+    expect(item.className).toContain('bg-muted');
+  });
+});

--- a/src/components/messaging/ConversationInbox.tsx
+++ b/src/components/messaging/ConversationInbox.tsx
@@ -1,0 +1,132 @@
+import { useMemo } from 'react';
+import { Badge } from '@/components/ui/badge';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { useAuth } from '@/contexts/AuthContext';
+import { useMyConversations } from '@/hooks/useConversations';
+import { getContextBadge, getOtherParticipant } from '@/lib/conversations';
+import type { ConversationContextType } from '@/lib/conversations';
+
+interface ConversationInboxProps {
+  selectedId?: string;
+  onSelect: (conversationId: string) => void;
+  filter: string;
+  onFilterChange: (filter: string) => void;
+}
+
+const FILTER_TABS = [
+  { value: 'all', label: 'All' },
+  { value: 'booking', label: 'Bookings' },
+  { value: 'bid', label: 'Bids' },
+  { value: 'inquiry', label: 'Inquiries' },
+  { value: 'travel_request', label: 'Requests' },
+] as const;
+
+function formatRelativeTime(dateStr: string | null): string {
+  if (!dateStr) return '';
+  const diff = Date.now() - new Date(dateStr).getTime();
+  const mins = Math.floor(diff / 60000);
+  if (mins < 1) return 'now';
+  if (mins < 60) return `${mins}m`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h`;
+  const days = Math.floor(hrs / 24);
+  if (days < 7) return `${days}d`;
+  return new Date(dateStr).toLocaleDateString([], { month: 'short', day: 'numeric' });
+}
+
+export function ConversationInbox({ selectedId, onSelect, filter, onFilterChange }: ConversationInboxProps) {
+  const { user } = useAuth();
+  const { data: conversations, isLoading } = useMyConversations();
+
+  const filtered = useMemo(() => {
+    if (!conversations) return [];
+    if (filter === 'all') return conversations;
+    return conversations.filter((c: { context_type: string }) => c.context_type === filter);
+  }, [conversations, filter]);
+
+  return (
+    <div className="flex flex-col h-full" data-testid="conversation-inbox">
+      <div className="p-3 border-b">
+        <h2 className="text-lg font-semibold mb-2">Messages</h2>
+        <Tabs value={filter} onValueChange={onFilterChange}>
+          <TabsList className="w-full">
+            {FILTER_TABS.map(tab => (
+              <TabsTrigger key={tab.value} value={tab.value} className="text-xs flex-1">
+                {tab.label}
+              </TabsTrigger>
+            ))}
+          </TabsList>
+        </Tabs>
+      </div>
+
+      <ScrollArea className="flex-1">
+        {isLoading && (
+          <div className="p-4 text-center text-muted-foreground text-sm">Loading...</div>
+        )}
+
+        {!isLoading && filtered.length === 0 && (
+          <div className="p-4 text-center text-muted-foreground text-sm">
+            No conversations yet
+          </div>
+        )}
+
+        {filtered.map((conversation: Record<string, unknown>) => {
+          const conv = conversation as {
+            id: string;
+            owner_id: string;
+            traveler_id: string;
+            context_type: string;
+            last_message_at: string | null;
+            owner_unread_count: number;
+            traveler_unread_count: number;
+            owner?: { id: string; full_name?: string; avatar_url?: string };
+            traveler?: { id: string; full_name?: string; avatar_url?: string };
+            property?: { id: string; resort_name?: string; location?: string };
+          };
+
+          const other = getOtherParticipant(conv, user?.id ?? '');
+          const badge = getContextBadge(conv.context_type);
+          const isSelected = conv.id === selectedId;
+          const unreadCount = conv.owner_id === user?.id
+            ? conv.owner_unread_count
+            : conv.traveler_unread_count;
+          const hasUnread = unreadCount > 0;
+
+          return (
+            <button
+              key={conv.id}
+              onClick={() => onSelect(conv.id)}
+              className={`w-full text-left px-3 py-3 border-b transition-colors hover:bg-muted/50 ${
+                isSelected ? 'bg-muted' : ''
+              }`}
+              data-testid={`inbox-item-${conv.id}`}
+            >
+              <div className="flex items-start justify-between gap-2">
+                <div className="flex items-center gap-2 min-w-0">
+                  {hasUnread && (
+                    <div className="w-2 h-2 rounded-full bg-destructive flex-shrink-0" />
+                  )}
+                  <span className="font-medium text-sm truncate">
+                    {other.full_name ?? 'Unknown User'}
+                  </span>
+                </div>
+                <span className="text-[11px] text-muted-foreground flex-shrink-0">
+                  {formatRelativeTime(conv.last_message_at)}
+                </span>
+              </div>
+              <div className="flex items-center gap-2 mt-0.5 ml-4">
+                <span className="text-xs text-muted-foreground truncate">
+                  {conv.property?.resort_name ?? 'Unknown Property'}
+                </span>
+                <Badge variant={badge.variant as 'default' | 'secondary' | 'outline' | 'destructive'} className="text-[10px] px-1.5 py-0 h-4">
+                  {badge.label}
+                </Badge>
+              </div>
+            </button>
+          );
+        })}
+      </ScrollArea>
+    </div>
+  );
+}

--- a/src/components/messaging/ConversationThread.test.tsx
+++ b/src/components/messaging/ConversationThread.test.tsx
@@ -1,0 +1,135 @@
+// @vitest-environment jsdom
+// @p0
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
+
+const mockMarkRead = vi.hoisted(() => vi.fn());
+
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: vi.fn().mockReturnValue({
+    user: { id: 'user-1', email: 'test@example.com' },
+  }),
+}));
+
+vi.mock('@/hooks/useConversations', () => ({
+  useConversation: vi.fn().mockReturnValue({
+    data: {
+      id: 'conv-1',
+      owner_id: 'user-1',
+      traveler_id: 'traveler-1',
+      property_id: 'prop-1',
+      listing_id: 'lst-1',
+      context_type: 'booking',
+      status: 'active',
+      owner: { id: 'user-1', full_name: 'Alice Owner' },
+      traveler: { id: 'traveler-1', full_name: 'Bob Traveler' },
+      property: { id: 'prop-1', resort_name: 'Tuscany Village' },
+    },
+  }),
+  useConversationThread: vi.fn().mockReturnValue({
+    data: [
+      {
+        id: 'msg-1',
+        item_type: 'message',
+        sender_id: 'traveler-1',
+        body: 'Is the unit ocean-view?',
+        event_type: null,
+        event_data: null,
+        read_at: null,
+        created_at: '2026-06-01T10:31:00Z',
+      },
+      {
+        id: 'msg-2',
+        item_type: 'message',
+        sender_id: 'user-1',
+        body: 'Yes, Building 3 faces the ocean',
+        event_type: null,
+        event_data: null,
+        read_at: null,
+        created_at: '2026-06-01T10:45:00Z',
+      },
+      {
+        id: 'evt-1',
+        item_type: 'event',
+        sender_id: null,
+        body: null,
+        event_type: 'booking_confirmed',
+        event_data: { booking_id: 'bk-1', total: 1850, check_in: '2026-06-01' },
+        read_at: null,
+        created_at: '2026-06-01T11:00:00Z',
+      },
+    ],
+    isLoading: false,
+  }),
+  useMarkConversationRead: vi.fn().mockReturnValue({
+    mutate: mockMarkRead,
+  }),
+  useSendMessage: vi.fn().mockReturnValue({
+    mutate: vi.fn(),
+    isPending: false,
+  }),
+}));
+
+vi.mock('@/hooks/useRealtimeSubscription', () => ({
+  useRealtimeSubscription: vi.fn(),
+}));
+
+import { ConversationThread } from './ConversationThread';
+
+function renderThread(props = {}) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter>
+        <ConversationThread conversationId="conv-1" {...props} />
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+describe('ConversationThread', () => {
+  it('renders the thread container', () => {
+    renderThread();
+    expect(screen.getByTestId('conversation-thread')).toBeInTheDocument();
+  });
+
+  it('displays the other participant name in header', () => {
+    renderThread();
+    expect(screen.getByText('Bob Traveler')).toBeInTheDocument();
+  });
+
+  it('displays property name and context label in header', () => {
+    renderThread();
+    expect(screen.getByText(/Tuscany Village/)).toBeInTheDocument();
+    expect(screen.getByText(/· Booking/)).toBeInTheDocument();
+  });
+
+  it('renders message bubbles', () => {
+    renderThread();
+    expect(screen.getByText('Is the unit ocean-view?')).toBeInTheDocument();
+    expect(screen.getByText('Yes, Building 3 faces the ocean')).toBeInTheDocument();
+  });
+
+  it('renders system events', () => {
+    renderThread();
+    expect(screen.getByText(/Booking confirmed/)).toBeInTheDocument();
+  });
+
+  it('calls markConversationRead on mount', () => {
+    renderThread();
+    expect(mockMarkRead).toHaveBeenCalledWith('conv-1');
+  });
+
+  it('shows context link for booking', () => {
+    renderThread();
+    expect(screen.getByText('View Booking')).toBeInTheDocument();
+  });
+
+  it('shows message composer', () => {
+    renderThread();
+    expect(screen.getByPlaceholderText('Type a message...')).toBeInTheDocument();
+    expect(screen.getByLabelText('Send message')).toBeInTheDocument();
+  });
+});

--- a/src/components/messaging/ConversationThread.tsx
+++ b/src/components/messaging/ConversationThread.tsx
@@ -1,0 +1,197 @@
+import { useEffect, useRef } from 'react';
+import { Link } from 'react-router-dom';
+import { Button } from '@/components/ui/button';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { ArrowLeft, ExternalLink } from 'lucide-react';
+import { useAuth } from '@/contexts/AuthContext';
+import {
+  useConversation,
+  useConversationThread,
+  useMarkConversationRead,
+} from '@/hooks/useConversations';
+import { getOtherParticipant, getContextBadge } from '@/lib/conversations';
+import { ConversationEventBubble } from './ConversationEventBubble';
+import { MessageComposer } from './MessageComposer';
+
+interface ConversationThreadProps {
+  conversationId: string;
+  onBack?: () => void;
+}
+
+function formatDateSeparator(dateStr: string): string {
+  const date = new Date(dateStr);
+  const today = new Date();
+  const yesterday = new Date(today);
+  yesterday.setDate(yesterday.getDate() - 1);
+
+  if (date.toDateString() === today.toDateString()) return 'Today';
+  if (date.toDateString() === yesterday.toDateString()) return 'Yesterday';
+  return date.toLocaleDateString([], { month: 'short', day: 'numeric', year: 'numeric' });
+}
+
+function getContextLink(contextType: string, conversation: Record<string, unknown>): { label: string; to: string } | null {
+  const propertyId = conversation.property_id as string | undefined;
+  const listingId = conversation.listing_id as string | undefined;
+
+  switch (contextType) {
+    case 'booking':
+      return { label: 'View Booking', to: '/my-trips?tab=bookings' };
+    case 'bid':
+      return listingId
+        ? { label: 'View Listing', to: `/rentals/${listingId}` }
+        : null;
+    case 'inquiry':
+      return listingId
+        ? { label: 'View Property', to: `/rentals/${listingId}` }
+        : null;
+    case 'travel_request':
+      return { label: 'View Requests', to: '/my-trips?tab=offers' };
+    default:
+      return propertyId ? { label: 'View Property', to: `/rentals/${propertyId}` } : null;
+  }
+}
+
+export function ConversationThread({ conversationId, onBack }: ConversationThreadProps) {
+  const { user } = useAuth();
+  const { data: conversation } = useConversation(conversationId);
+  const { data: thread, isLoading } = useConversationThread(conversationId);
+  const markRead = useMarkConversationRead();
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  // Mark conversation read on mount
+  useEffect(() => {
+    if (conversationId) {
+      markRead.mutate(conversationId);
+    }
+  }, [conversationId]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Auto-scroll to bottom on new messages
+  useEffect(() => {
+    if (scrollRef.current) {
+      scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+    }
+  }, [thread?.length]);
+
+  if (!conversation) {
+    return (
+      <div className="flex items-center justify-center h-full text-muted-foreground">
+        Loading conversation...
+      </div>
+    );
+  }
+
+  const other = getOtherParticipant(
+    conversation as { owner_id: string; traveler_id: string; owner?: { id: string; full_name?: string }; traveler?: { id: string; full_name?: string } },
+    user?.id ?? ''
+  );
+  const badge = getContextBadge(conversation.context_type);
+  const contextLink = getContextLink(conversation.context_type, conversation);
+  const propertyName = (conversation as Record<string, unknown> & { property?: { resort_name?: string } }).property?.resort_name;
+
+  let lastDateStr = '';
+
+  return (
+    <div className="flex flex-col h-full" data-testid="conversation-thread">
+      {/* Header */}
+      <div className="border-b px-3 py-2 flex items-center gap-2">
+        {onBack && (
+          <Button variant="ghost" size="icon" onClick={onBack} className="md:hidden" aria-label="Back to inbox">
+            <ArrowLeft className="h-4 w-4" />
+          </Button>
+        )}
+        <div className="flex-1 min-w-0">
+          <div className="font-medium text-sm truncate">
+            {other.full_name ?? 'Unknown User'}
+          </div>
+          <div className="text-xs text-muted-foreground truncate">
+            {propertyName ?? 'Unknown Property'} · {badge.label}
+          </div>
+        </div>
+        {contextLink && (
+          <Button variant="ghost" size="sm" asChild>
+            <Link to={contextLink.to}>
+              {contextLink.label}
+              <ExternalLink className="h-3 w-3 ml-1" />
+            </Link>
+          </Button>
+        )}
+      </div>
+
+      {/* Thread */}
+      <ScrollArea className="flex-1 px-3" ref={scrollRef}>
+        <div className="py-3 space-y-1">
+          {isLoading && (
+            <div className="text-center text-muted-foreground text-sm py-8">
+              Loading messages...
+            </div>
+          )}
+
+          {!isLoading && (!thread || thread.length === 0) && (
+            <div className="text-center text-muted-foreground text-sm py-8">
+              No messages yet. Start the conversation!
+            </div>
+          )}
+
+          {thread?.map((item) => {
+            const itemDate = new Date(item.created_at).toDateString();
+            const showDateSeparator = itemDate !== lastDateStr;
+            lastDateStr = itemDate;
+
+            return (
+              <div key={item.id}>
+                {showDateSeparator && (
+                  <div className="flex items-center gap-3 my-4">
+                    <div className="flex-1 border-t" />
+                    <span className="text-[11px] text-muted-foreground font-medium">
+                      {formatDateSeparator(item.created_at)}
+                    </span>
+                    <div className="flex-1 border-t" />
+                  </div>
+                )}
+
+                {item.item_type === 'event' ? (
+                  <ConversationEventBubble
+                    eventType={item.event_type ?? ''}
+                    eventData={(item.event_data as Record<string, unknown>) ?? {}}
+                    createdAt={item.created_at}
+                  />
+                ) : (
+                  <div
+                    className={`flex mb-2 ${
+                      item.sender_id === user?.id ? 'justify-end' : 'justify-start'
+                    }`}
+                  >
+                    <div
+                      className={`max-w-[75%] rounded-lg px-3 py-2 ${
+                        item.sender_id === user?.id
+                          ? 'bg-primary text-primary-foreground'
+                          : 'bg-muted'
+                      }`}
+                    >
+                      <p className="text-sm whitespace-pre-wrap break-words">{item.body}</p>
+                      <p
+                        className={`text-[10px] mt-1 ${
+                          item.sender_id === user?.id
+                            ? 'text-primary-foreground/60'
+                            : 'text-muted-foreground'
+                        }`}
+                      >
+                        {new Date(item.created_at).toLocaleTimeString([], {
+                          hour: 'numeric',
+                          minute: '2-digit',
+                        })}
+                      </p>
+                    </div>
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      </ScrollArea>
+
+      {/* Composer */}
+      <MessageComposer conversationId={conversationId} />
+    </div>
+  );
+}

--- a/src/components/messaging/MessageComposer.tsx
+++ b/src/components/messaging/MessageComposer.tsx
@@ -1,0 +1,52 @@
+import { useState, useCallback } from 'react';
+import { Button } from '@/components/ui/button';
+import { Textarea } from '@/components/ui/textarea';
+import { Send } from 'lucide-react';
+import { useSendMessage } from '@/hooks/useConversations';
+
+interface MessageComposerProps {
+  conversationId: string;
+}
+
+export function MessageComposer({ conversationId }: MessageComposerProps) {
+  const [body, setBody] = useState('');
+  const sendMessage = useSendMessage();
+
+  const handleSend = useCallback(() => {
+    const trimmed = body.trim();
+    if (!trimmed || sendMessage.isPending) return;
+
+    sendMessage.mutate(
+      { conversationId, body: trimmed },
+      { onSuccess: () => setBody('') }
+    );
+  }, [body, conversationId, sendMessage]);
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      handleSend();
+    }
+  };
+
+  return (
+    <div className="border-t p-3 flex gap-2 items-end">
+      <Textarea
+        value={body}
+        onChange={(e) => setBody(e.target.value)}
+        onKeyDown={handleKeyDown}
+        placeholder="Type a message..."
+        className="min-h-[40px] max-h-[120px] resize-none"
+        rows={1}
+      />
+      <Button
+        size="icon"
+        onClick={handleSend}
+        disabled={!body.trim() || sendMessage.isPending}
+        aria-label="Send message"
+      >
+        <Send className="h-4 w-4" />
+      </Button>
+    </div>
+  );
+}

--- a/src/pages/Messages.test.tsx
+++ b/src/pages/Messages.test.tsx
@@ -1,0 +1,79 @@
+// @vitest-environment jsdom
+// @p0
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: vi.fn().mockReturnValue({
+    user: { id: 'user-1', email: 'test@example.com' },
+  }),
+}));
+
+vi.mock('@/hooks/useConversations', () => ({
+  useMyConversations: vi.fn().mockReturnValue({ data: [], isLoading: false }),
+  useConversation: vi.fn().mockReturnValue({ data: null }),
+  useConversationThread: vi.fn().mockReturnValue({ data: [], isLoading: false }),
+  useMarkConversationRead: vi.fn().mockReturnValue({ mutate: vi.fn() }),
+  useSendMessage: vi.fn().mockReturnValue({ mutate: vi.fn(), isPending: false }),
+  useUnreadConversationCount: vi.fn().mockReturnValue({ data: 0 }),
+}));
+
+vi.mock('@/hooks/useRealtimeSubscription', () => ({
+  useRealtimeSubscription: vi.fn(),
+}));
+
+vi.mock('@/hooks/usePageMeta', () => ({
+  usePageMeta: vi.fn(),
+}));
+
+import Messages from './Messages';
+
+function renderPage(path = '/messages') {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter initialEntries={[path]}>
+        <Routes>
+          <Route path="/messages" element={<Messages />} />
+          <Route path="/messages/:conversationId" element={<Messages />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+describe('Messages page', () => {
+  it('renders the messages page container', () => {
+    renderPage();
+    expect(screen.getByTestId('messages-page')).toBeInTheDocument();
+  });
+
+  it('shows inbox with Messages heading', () => {
+    renderPage();
+    expect(screen.getByText('Messages')).toBeInTheDocument();
+  });
+
+  it('shows empty state when no conversation selected', () => {
+    renderPage();
+    expect(screen.getByText('Select a conversation to start messaging')).toBeInTheDocument();
+  });
+
+  it('shows no conversations message when list is empty', () => {
+    renderPage();
+    expect(screen.getByText('No conversations yet')).toBeInTheDocument();
+  });
+
+  it('renders filter tabs', () => {
+    renderPage();
+    expect(screen.getByText('All')).toBeInTheDocument();
+    expect(screen.getByText('Bookings')).toBeInTheDocument();
+    expect(screen.getByText('Bids')).toBeInTheDocument();
+  });
+
+  it('renders inbox component', () => {
+    renderPage();
+    expect(screen.getByTestId('conversation-inbox')).toBeInTheDocument();
+  });
+});

--- a/src/pages/Messages.tsx
+++ b/src/pages/Messages.tsx
@@ -1,0 +1,64 @@
+import { useState, useCallback } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import { usePageMeta } from '@/hooks/usePageMeta';
+import { ConversationInbox } from '@/components/messaging/ConversationInbox';
+import { ConversationThread } from '@/components/messaging/ConversationThread';
+import { MessageSquare } from 'lucide-react';
+
+export default function Messages() {
+  usePageMeta('Messages', 'Manage your conversations with owners and travelers');
+
+  const { conversationId } = useParams<{ conversationId: string }>();
+  const navigate = useNavigate();
+  const [filter, setFilter] = useState('all');
+
+  const handleSelect = useCallback(
+    (id: string) => {
+      navigate(`/messages/${id}`);
+    },
+    [navigate]
+  );
+
+  const handleBack = useCallback(() => {
+    navigate('/messages');
+  }, [navigate]);
+
+  return (
+    <div className="pt-16 md:pt-20 min-h-screen bg-background" data-testid="messages-page">
+      <div className="max-w-7xl mx-auto h-[calc(100vh-4rem)] md:h-[calc(100vh-5rem)] flex flex-col md:flex-row">
+        {/* Inbox panel — hidden on mobile when conversation is selected */}
+        <div
+          className={`w-full md:w-[360px] md:flex-shrink-0 border-r h-full ${
+            conversationId ? 'hidden md:flex md:flex-col' : 'flex flex-col'
+          }`}
+        >
+          <ConversationInbox
+            selectedId={conversationId}
+            onSelect={handleSelect}
+            filter={filter}
+            onFilterChange={setFilter}
+          />
+        </div>
+
+        {/* Thread panel — full screen on mobile, fills remainder on desktop */}
+        <div
+          className={`flex-1 h-full ${
+            conversationId ? 'flex flex-col' : 'hidden md:flex md:flex-col'
+          }`}
+        >
+          {conversationId ? (
+            <ConversationThread
+              conversationId={conversationId}
+              onBack={handleBack}
+            />
+          ) : (
+            <div className="flex flex-col items-center justify-center h-full text-muted-foreground gap-3">
+              <MessageSquare className="h-12 w-12 opacity-30" />
+              <p className="text-sm">Select a conversation to start messaging</p>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Two-panel Messages page: 360px inbox + conversation thread
- ConversationInbox with filter tabs, unread dots, context badges
- ConversationThread with message bubbles, system events, date separators, mark-read-on-mount
- MessageComposer with Enter-to-send
- Header messages icon with unread badge (desktop + mobile)
- `/messages` and `/messages/:conversationId` routes
- 22 new tests (900 total, 113 files)

## Test plan
- [x] All 900 tests pass (113 files)
- [x] Build clean, 0 type errors, 0 lint errors
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)