### PR TITLE
feat(messaging): wire all interaction systems to conversation layer (#301-#305)

### DIFF
--- a/src/components/InquiryDialog.test.tsx
+++ b/src/components/InquiryDialog.test.tsx
@@ -16,6 +16,15 @@ vi.mock('@/hooks/useListingInquiries', () => ({
   }),
 }));
 
+vi.mock('@/hooks/useConversations', () => ({
+  useGetOrCreateConversation: vi.fn().mockReturnValue({
+    mutate: vi.fn(),
+  }),
+  useInsertConversationEvent: vi.fn().mockReturnValue({
+    mutate: vi.fn(),
+  }),
+}));
+
 import { InquiryDialog } from './InquiryDialog';
 
 function renderDialog(open = true) {
@@ -27,6 +36,7 @@ function renderDialog(open = true) {
         onOpenChange={vi.fn()}
         listingId="lst-1"
         ownerId="owner-1"
+        propertyId="prop-1"
         propertyName="Maui Beachfront"
       />
     </QueryClientProvider>

--- a/src/components/InquiryDialog.tsx
+++ b/src/components/InquiryDialog.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { useAuth } from '@/contexts/AuthContext';
 import { useCreateInquiry } from '@/hooks/useListingInquiries';
+import { useGetOrCreateConversation, useInsertConversationEvent } from '@/hooks/useConversations';
 import {
   Dialog,
   DialogContent,
@@ -35,6 +36,7 @@ interface InquiryDialogProps {
   onOpenChange: (open: boolean) => void;
   listingId: string;
   ownerId: string;
+  propertyId: string;
   propertyName: string;
 }
 
@@ -43,10 +45,13 @@ export function InquiryDialog({
   onOpenChange,
   listingId,
   ownerId,
+  propertyId,
   propertyName,
 }: InquiryDialogProps) {
   const { user } = useAuth();
   const createInquiry = useCreateInquiry();
+  const getOrCreateConversation = useGetOrCreateConversation();
+  const insertEvent = useInsertConversationEvent();
   const [subject, setSubject] = useState('');
   const [message, setMessage] = useState('');
   const [sent, setSent] = useState(false);
@@ -55,12 +60,31 @@ export function InquiryDialog({
     if (!subject || !message.trim()) return;
 
     try {
-      await createInquiry.mutateAsync({
+      const inquiry = await createInquiry.mutateAsync({
         listing_id: listingId,
         owner_id: ownerId,
         subject,
         message: message.trim(),
       });
+
+      // Wire to unified conversation layer (fire-and-forget)
+      getOrCreateConversation.mutate({
+        ownerId,
+        travelerId: user!.id,
+        propertyId,
+        listingId,
+        contextType: 'inquiry',
+        contextId: inquiry?.id,
+      }, {
+        onSuccess: (conversationId) => {
+          insertEvent.mutate({
+            conversationId,
+            eventType: 'inquiry_started',
+            eventData: { subject },
+          });
+        },
+      });
+
       setSent(true);
       toast.success('Question sent to the owner!');
     } catch {

--- a/src/components/InquiryThread.tsx
+++ b/src/components/InquiryThread.tsx
@@ -1,3 +1,7 @@
+// @deprecated — Replaced by ConversationThread (src/components/messaging/ConversationThread.tsx)
+// This component is kept for backward compatibility. Not actively imported in any page.
+// New writes go to conversation_messages via the unified conversation layer.
+
 import { useEffect, useRef, useState } from 'react';
 import { useAuth } from '@/contexts/AuthContext';
 import { useInquiryMessages, useSendInquiryMessage } from '@/hooks/useListingInquiries';

--- a/src/components/bidding/BidFormDialog.test.tsx
+++ b/src/components/bidding/BidFormDialog.test.tsx
@@ -18,6 +18,11 @@ vi.mock('@/hooks/useBidding', () => ({
   }),
 }));
 
+vi.mock('@/hooks/useConversations', () => ({
+  useGetOrCreateConversation: () => ({ mutate: vi.fn() }),
+  useInsertConversationEvent: () => ({ mutate: vi.fn() }),
+}));
+
 vi.mock('react-router-dom', () => ({
   Link: ({ children, ...props }: { children: React.ReactNode; to: string }) => (
     <a {...props}>{children}</a>

--- a/src/components/bidding/BidFormDialog.tsx
+++ b/src/components/bidding/BidFormDialog.tsx
@@ -23,6 +23,7 @@ import { Link } from 'react-router-dom';
 import type { ListingWithBidding } from '@/types/bidding';
 import { calculateNights, computeListingPricing } from '@/lib/pricing';
 import { trackEvent } from '@/lib/posthog';
+import { useGetOrCreateConversation, useInsertConversationEvent } from '@/hooks/useConversations';
 
 type BidMode = 'bid' | 'date-proposal';
 
@@ -36,6 +37,8 @@ interface BidFormDialogProps {
 export function BidFormDialog({ listing, open, onOpenChange, mode = 'bid' }: BidFormDialogProps) {
   const { user } = useAuth();
   const createBid = useCreateBid();
+  const getOrCreateConversation = useGetOrCreateConversation();
+  const insertEvent = useInsertConversationEvent();
 
   const [bidAmount, setBidAmount] = useState<number>(listing.min_bid_amount || listing.owner_price);
   const [guestCount, setGuestCount] = useState<number>(1);
@@ -84,6 +87,28 @@ export function BidFormDialog({ listing, open, onOpenChange, mode = 'bid' }: Bid
 
       setSubmittedBidAmount(bidAmount);
       setBidSuccess(true);
+
+      // Wire to unified conversation layer (fire-and-forget)
+      getOrCreateConversation.mutate({
+        ownerId: listing.owner_id,
+        travelerId: user.id,
+        propertyId: listing.property_id,
+        listingId: listing.id,
+        contextType: 'bid',
+      }, {
+        onSuccess: (conversationId) => {
+          insertEvent.mutate({
+            conversationId,
+            eventType: 'bid_placed',
+            eventData: {
+              amount: bidAmount,
+              check_in: proposedCheckIn || listing.check_in_date,
+              check_out: proposedCheckOut || listing.check_out_date,
+            },
+          });
+        },
+      });
+
       trackEvent("bid_placed", {
         listing_id: listing.id,
         bid_amount: bidAmount,

--- a/src/components/booking/BookingMessageThread.tsx
+++ b/src/components/booking/BookingMessageThread.tsx
@@ -1,3 +1,8 @@
+// @deprecated — Replaced by ConversationThread (src/components/messaging/ConversationThread.tsx)
+// This component is kept for backward compatibility during the transition.
+// New writes go to conversation_messages via the unified conversation layer.
+// TODO: Remove this file and update MyBookings + OwnerBookings to use /messages links.
+
 import { useEffect, useRef, useState } from "react";
 import { useAuth } from "@/contexts/AuthContext";
 import {

--- a/src/hooks/useBidding.ts
+++ b/src/hooks/useBidding.ts
@@ -174,14 +174,43 @@ export function useUpdateBidStatus() {
         .from('listing_bids')
         .update(updateData as never)
         .eq('id', bidId)
-        .select()
+        .select('*, listing:listings(owner_id, property_id)')
         .single();
 
       if (error) throw error;
       return data;
     },
-    onSuccess: (_, variables) => {
+    onSuccess: (data, variables) => {
       queryClient.invalidateQueries({ queryKey: ['bids'] });
+
+      // Insert conversation event for bid status change (fire-and-forget)
+      const listing = (data as Record<string, unknown>).listing as { owner_id: string; property_id: string } | null;
+      if (listing) {
+        const eventType = variables.status === 'accepted' ? 'bid_accepted'
+          : variables.status === 'rejected' ? 'bid_rejected'
+          : variables.counterOfferAmount ? 'bid_countered'
+          : null;
+        if (eventType) {
+          supabase.rpc('get_or_create_conversation', {
+            p_owner_id: listing.owner_id,
+            p_traveler_id: (data as Record<string, unknown>).bidder_id as string,
+            p_property_id: listing.property_id,
+            p_context_type: 'bid',
+          }).then(({ data: convId }) => {
+            if (convId) {
+              supabase.rpc('insert_conversation_event', {
+                p_conversation_id: convId,
+                p_event_type: eventType,
+                p_event_data: {
+                  amount: (data as Record<string, unknown>).bid_amount,
+                  counter: variables.counterOfferAmount ?? null,
+                },
+              });
+            }
+          });
+        }
+      }
+
       const message = variables.status === 'accepted'
         ? 'Bid accepted!'
         : variables.status === 'rejected'
@@ -414,8 +443,40 @@ export function useCreateProposal() {
       if (error) throw error;
       return data;
     },
-    onSuccess: () => {
+    onSuccess: (data, variables) => {
       queryClient.invalidateQueries({ queryKey: ['proposals'] });
+
+      // Wire to unified conversation layer (fire-and-forget)
+      // Look up traveler_id from the travel request
+      const proposal = data as Record<string, unknown>;
+      if (proposal.request_id && proposal.property_id) {
+        supabase
+          .from('travel_requests')
+          .select('traveler_id')
+          .eq('id', proposal.request_id as string)
+          .single()
+          .then(({ data: request }) => {
+            if (request?.traveler_id) {
+              supabase.rpc('get_or_create_conversation', {
+                p_owner_id: user!.id,
+                p_traveler_id: request.traveler_id,
+                p_property_id: proposal.property_id as string,
+                p_listing_id: (proposal.listing_id as string) ?? null,
+                p_context_type: 'travel_request',
+                p_context_id: proposal.request_id as string,
+              }).then(({ data: convId }) => {
+                if (convId) {
+                  supabase.rpc('insert_conversation_event', {
+                    p_conversation_id: convId,
+                    p_event_type: 'proposal_sent',
+                    p_event_data: { proposal_id: proposal.id },
+                  });
+                }
+              });
+            }
+          });
+      }
+
       toast.success('Proposal submitted!');
     },
     onError: (error: Error) => {
@@ -491,10 +552,40 @@ export function useUpdateProposalStatus() {
 
       return proposal;
     },
-    onSuccess: (_, variables) => {
+    onSuccess: (data, variables) => {
       queryClient.invalidateQueries({ queryKey: ['proposals'] });
       queryClient.invalidateQueries({ queryKey: ['travel-requests'] });
       queryClient.invalidateQueries({ queryKey: ['listings'] });
+
+      // Insert conversation event for proposal status change (fire-and-forget)
+      const proposal = data as Record<string, unknown>;
+      if (proposal.property_id && proposal.owner_id && proposal.request_id) {
+        supabase
+          .from('travel_requests')
+          .select('traveler_id')
+          .eq('id', proposal.request_id as string)
+          .single()
+          .then(({ data: request }) => {
+            if (request?.traveler_id) {
+              supabase.rpc('get_or_create_conversation', {
+                p_owner_id: proposal.owner_id as string,
+                p_traveler_id: request.traveler_id,
+                p_property_id: proposal.property_id as string,
+                p_context_type: 'travel_request',
+              }).then(({ data: convId }) => {
+                if (convId) {
+                  const eventType = variables.status === 'accepted' ? 'proposal_accepted' : 'proposal_rejected';
+                  supabase.rpc('insert_conversation_event', {
+                    p_conversation_id: convId,
+                    p_event_type: eventType,
+                    p_event_data: { proposal_id: proposal.id },
+                  });
+                }
+              });
+            }
+          });
+      }
+
       const message = variables.status === 'accepted'
         ? 'Proposal accepted! You can now proceed to checkout.'
         : 'Proposal updated';

--- a/src/pages/PropertyDetail.tsx
+++ b/src/pages/PropertyDetail.tsx
@@ -891,6 +891,7 @@ const PropertyDetail = () => {
           onOpenChange={setInquiryDialogOpen}
           listingId={listing.id}
           ownerId={listing.owner_id}
+          propertyId={listing.property_id}
           propertyName={displayName}
         />
       )}

--- a/supabase/functions/verify-booking-payment/index.ts
+++ b/supabase/functions/verify-booking-payment/index.ts
@@ -146,6 +146,43 @@ serve(async (req) => {
         logStep("Warning: Failed to update listing status", { error: listingError.message });
       }
 
+      // Wire to unified conversation layer
+      try {
+        const listingData = booking.listing as Record<string, unknown>;
+        const ownerId = listingData?.owner_id as string;
+        const propertyId = listingData?.property_id as string;
+        if (ownerId && propertyId) {
+          const { data: convId } = await supabaseClient.rpc("get_or_create_conversation", {
+            p_owner_id: ownerId,
+            p_traveler_id: booking.renter_id,
+            p_property_id: propertyId,
+            p_listing_id: booking.listing_id,
+            p_context_type: "booking",
+            p_context_id: booking.id,
+          });
+          if (convId) {
+            // Update booking with conversation_id
+            await supabaseClient
+              .from("bookings")
+              .update({ conversation_id: convId })
+              .eq("id", bookingId);
+            // Insert booking_confirmed event
+            await supabaseClient.rpc("insert_conversation_event", {
+              p_conversation_id: convId,
+              p_event_type: "booking_confirmed",
+              p_event_data: {
+                booking_id: booking.id,
+                total: session.amount_total ? session.amount_total / 100 : booking.total_amount,
+                check_in: (listingData as Record<string, unknown>).check_in_date,
+              },
+            });
+          }
+          logStep("Conversation created for booking", { convId });
+        }
+      } catch (convError) {
+        logStep("Warning: Failed to create conversation", { error: String(convError) });
+      }
+
       // Read owner confirmation window from system_settings
       let ownerConfirmationWindowMinutes = 60; // default
       try {


### PR DESCRIPTION
## Summary
- Wire inquiries, bookings, bids, and travel proposals to auto-create conversations
- System events inserted for all status changes (confirmed, accepted, rejected, countered)
- verify-booking-payment edge function creates conversation + sets conversation_id FK
- BookingMessageThread + InquiryThread marked @deprecated
- message_received already in notification_catalog

## Test plan
- [x] All 900 tests pass (113 files)
- [x] Build clean, 0 type errors, 0 lint errors
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)