### PR TITLE
fix(messaging): Messages page layout + navigation discoverability

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -162,16 +162,15 @@ const Header = () => {
               <div className="w-20 h-9 bg-muted animate-pulse rounded-md" />
             ) : user ? (
               <div className="flex items-center gap-2">
-                <Button variant="ghost" size="icon" asChild className="relative">
-                  <Link to="/messages">
-                    <MessageSquare className="h-5 w-5" />
-                    {unreadMessages > 0 && (
-                      <Badge variant="destructive" className="absolute -top-1 -right-1 h-5 w-5 p-0 flex items-center justify-center text-[10px]">
-                        {unreadMessages > 99 ? '99+' : unreadMessages}
-                      </Badge>
-                    )}
-                  </Link>
-                </Button>
+                <Link to="/messages" className="relative flex items-center gap-1.5 px-3 py-2 rounded-lg text-sm font-medium transition-colors text-muted-foreground hover:text-foreground hover:bg-muted/30">
+                  <MessageSquare className="h-4 w-4" />
+                  Messages
+                  {unreadMessages > 0 && (
+                    <Badge variant="destructive" className="h-5 min-w-5 px-1 flex items-center justify-center text-[10px]">
+                      {unreadMessages > 99 ? '99+' : unreadMessages}
+                    </Badge>
+                  )}
+                </Link>
                 <NotificationBell />
                 <DropdownMenu>
                   <DropdownMenuTrigger asChild>
@@ -272,16 +271,14 @@ const Header = () => {
             )}
             {user && !isLoading && (
               <div className="flex items-center gap-2">
-                <Button variant="ghost" size="icon" asChild className="relative h-8 w-8">
-                  <Link to="/messages">
-                    <MessageSquare className="h-4 w-4" />
-                    {unreadMessages > 0 && (
-                      <Badge variant="destructive" className="absolute -top-1 -right-1 h-4 w-4 p-0 flex items-center justify-center text-[9px]">
-                        {unreadMessages > 99 ? '99+' : unreadMessages}
-                      </Badge>
-                    )}
-                  </Link>
-                </Button>
+                <Link to="/messages" className="relative flex items-center p-1.5 rounded-lg text-muted-foreground hover:text-foreground">
+                  <MessageSquare className="h-5 w-5" />
+                  {unreadMessages > 0 && (
+                    <Badge variant="destructive" className="absolute -top-1.5 -right-1.5 h-4 min-w-4 px-0.5 flex items-center justify-center text-[9px]">
+                      {unreadMessages > 99 ? '99+' : unreadMessages}
+                    </Badge>
+                  )}
+                </Link>
                 <NotificationBell />
                 <button
                   className="flex items-center gap-1.5 px-2 py-1 rounded-full bg-primary/10 hover:bg-primary/15 transition-colors"
@@ -393,6 +390,19 @@ const Header = () => {
                   >
                     <Plane className="h-4 w-4" />
                     My Trips
+                  </Link>
+                  <Link
+                    to="/messages"
+                    className="flex items-center gap-2 text-foreground py-2"
+                    onClick={() => setIsMenuOpen(false)}
+                  >
+                    <MessageSquare className="h-4 w-4" />
+                    Messages
+                    {unreadMessages > 0 && (
+                      <Badge variant="destructive" className="h-5 min-w-5 px-1 text-[10px]">
+                        {unreadMessages}
+                      </Badge>
+                    )}
                   </Link>
                   {isRavTeam() && (
                     <Link

--- a/src/pages/Messages.test.tsx
+++ b/src/pages/Messages.test.tsx
@@ -28,6 +28,14 @@ vi.mock('@/hooks/usePageMeta', () => ({
   usePageMeta: vi.fn(),
 }));
 
+vi.mock('@/components/Header', () => ({
+  default: () => <div data-testid="header">Header</div>,
+}));
+
+vi.mock('@/components/Footer', () => ({
+  default: () => <div data-testid="footer">Footer</div>,
+}));
+
 import Messages from './Messages';
 
 function renderPage(path = '/messages') {
@@ -50,9 +58,10 @@ describe('Messages page', () => {
     expect(screen.getByTestId('messages-page')).toBeInTheDocument();
   });
 
-  it('shows inbox with Messages heading', () => {
+  it('shows page heading', () => {
     renderPage();
-    expect(screen.getByText('Messages')).toBeInTheDocument();
+    const headings = screen.getAllByRole('heading', { name: /Messages/ });
+    expect(headings.length).toBeGreaterThanOrEqual(1);
   });
 
   it('shows empty state when no conversation selected', () => {

--- a/src/pages/Messages.tsx
+++ b/src/pages/Messages.tsx
@@ -1,6 +1,8 @@
 import { useState, useCallback } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { usePageMeta } from '@/hooks/usePageMeta';
+import Header from '@/components/Header';
+import Footer from '@/components/Footer';
 import { ConversationInbox } from '@/components/messaging/ConversationInbox';
 import { ConversationThread } from '@/components/messaging/ConversationThread';
 import { MessageSquare } from 'lucide-react';
@@ -24,41 +26,61 @@ export default function Messages() {
   }, [navigate]);
 
   return (
-    <div className="pt-16 md:pt-20 min-h-screen bg-background" data-testid="messages-page">
-      <div className="max-w-7xl mx-auto h-[calc(100vh-4rem)] md:h-[calc(100vh-5rem)] flex flex-col md:flex-row">
-        {/* Inbox panel — hidden on mobile when conversation is selected */}
-        <div
-          className={`w-full md:w-[360px] md:flex-shrink-0 border-r h-full ${
-            conversationId ? 'hidden md:flex md:flex-col' : 'flex flex-col'
-          }`}
-        >
-          <ConversationInbox
-            selectedId={conversationId}
-            onSelect={handleSelect}
-            filter={filter}
-            onFilterChange={setFilter}
-          />
-        </div>
+    <div className="min-h-screen flex flex-col" data-testid="messages-page">
+      <Header />
 
-        {/* Thread panel — full screen on mobile, fills remainder on desktop */}
-        <div
-          className={`flex-1 h-full ${
-            conversationId ? 'flex flex-col' : 'hidden md:flex md:flex-col'
-          }`}
-        >
-          {conversationId ? (
-            <ConversationThread
-              conversationId={conversationId}
-              onBack={handleBack}
-            />
-          ) : (
-            <div className="flex flex-col items-center justify-center h-full text-muted-foreground gap-3">
-              <MessageSquare className="h-12 w-12 opacity-30" />
-              <p className="text-sm">Select a conversation to start messaging</p>
+      <main id="main-content" className="flex-1 pt-16 md:pt-20">
+        <div className="container mx-auto px-4 py-6 max-w-7xl">
+          {/* Page heading */}
+          <div className="mb-4">
+            <h1 className="text-2xl font-bold flex items-center gap-2">
+              <MessageSquare className="h-6 w-6 text-primary" />
+              Messages
+            </h1>
+            <p className="text-sm text-muted-foreground mt-1">
+              Your conversations with owners and travelers
+            </p>
+          </div>
+
+          {/* Two-panel layout */}
+          <div className="border rounded-lg overflow-hidden bg-card h-[calc(100vh-14rem)] md:h-[calc(100vh-16rem)] flex flex-col md:flex-row">
+            {/* Inbox panel — hidden on mobile when conversation is selected */}
+            <div
+              className={`w-full md:w-[360px] md:flex-shrink-0 md:border-r ${
+                conversationId ? 'hidden md:flex md:flex-col' : 'flex flex-col'
+              }`}
+            >
+              <ConversationInbox
+                selectedId={conversationId}
+                onSelect={handleSelect}
+                filter={filter}
+                onFilterChange={setFilter}
+              />
             </div>
-          )}
+
+            {/* Thread panel — full screen on mobile, fills remainder on desktop */}
+            <div
+              className={`flex-1 ${
+                conversationId ? 'flex flex-col' : 'hidden md:flex md:flex-col'
+              }`}
+            >
+              {conversationId ? (
+                <ConversationThread
+                  conversationId={conversationId}
+                  onBack={handleBack}
+                />
+              ) : (
+                <div className="flex flex-col items-center justify-center h-full text-muted-foreground gap-3">
+                  <MessageSquare className="h-12 w-12 opacity-30" />
+                  <p className="text-sm">Select a conversation to start messaging</p>
+                </div>
+              )}
+            </div>
+          </div>
         </div>
-      </div>
+      </main>
+
+      <Footer />
     </div>
   );
 }

--- a/src/pages/OwnerDashboard.tsx
+++ b/src/pages/OwnerDashboard.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useCallback } from "react";
-import { useNavigate, useSearchParams } from "react-router-dom";
+import { useNavigate, useSearchParams, Link } from "react-router-dom";
 import Header from "@/components/Header";
 import { useAuth } from "@/contexts/AuthContext";
 import { supabase } from "@/lib/supabase";
@@ -32,6 +32,7 @@ import {
   Pencil,
   ChevronDown,
   Share2,
+  ChevronRight,
 } from "lucide-react";
 import { usePublishDraft, loadDraft, clearDraft, type ListPropertyDraft } from "@/hooks/usePublishDraft";
 import { useToast } from "@/hooks/use-toast";
@@ -399,6 +400,23 @@ const OwnerDashboard = () => {
                 </div>
               </div>
             )}
+
+            {/* Messages Quick Access */}
+            <Link
+              to="/messages"
+              className="flex items-center justify-between p-4 rounded-lg border bg-card hover:bg-muted/50 transition-colors group"
+            >
+              <div className="flex items-center gap-3">
+                <div className="h-10 w-10 rounded-full bg-primary/10 flex items-center justify-center">
+                  <MessageSquare className="h-5 w-5 text-primary" />
+                </div>
+                <div>
+                  <p className="font-medium text-sm">Messages</p>
+                  <p className="text-xs text-muted-foreground">View conversations with travelers</p>
+                </div>
+              </div>
+              <ChevronRight className="h-4 w-4 text-muted-foreground group-hover:text-foreground transition-colors" />
+            </Link>
 
             {/* Headline Stats */}
             <OwnerHeadlineStats stats={dashStats} isLoading={dashStatsLoading} />


### PR DESCRIPTION
## Summary
Fixes QA-reported issues with the Messages page:
- Add Header + Footer (were missing — page looked "lost")
- Proper container layout with bordered card panel
- Page heading with icon and description text
- Header: replace subtle icon-only button with visible "Messages" text link + unread badge
- Mobile menu: add Messages link with unread count
- Owner Dashboard: Messages quick-access card on overview tab

## Test plan
- [x] All 907 tests pass (114 files)
- [x] Build clean, 0 type errors
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)