### PR TITLE
feat(messaging): complete Phase 21 DoD — notification wiring

### DIFF
--- a/src/hooks/useConversations.ts
+++ b/src/hooks/useConversations.ts
@@ -210,6 +210,32 @@ export function useSendMessage() {
         .single();
 
       if (error) throw error;
+
+      // Fire notification to the other participant (fire-and-forget)
+      // Look up the conversation to find the recipient
+      supabase
+        .from('conversations')
+        .select('owner_id, traveler_id')
+        .eq('id', conversationId)
+        .single()
+        .then(({ data: conv }) => {
+          if (!conv) return;
+          const recipientId = conv.owner_id === user!.id ? conv.traveler_id : conv.owner_id;
+          const preview = body.length > 80 ? `${body.slice(0, 80)}…` : body;
+          supabase.functions.invoke('notification-dispatcher', {
+            body: {
+              type_key: 'message_received',
+              user_id: recipientId,
+              payload: {
+                title: 'New message',
+                message: preview,
+              },
+            },
+          }).catch(() => {
+            // Notification dispatch is best-effort; don't fail the send
+          });
+        });
+
       return data;
     },
     onMutate: async ({ conversationId, body }) => {

--- a/src/hooks/useNotifications.test.ts
+++ b/src/hooks/useNotifications.test.ts
@@ -101,13 +101,13 @@ describe("getNotificationLink", () => {
     ).toBe("/my-trips?tab=overview");
   });
 
-  it("returns my-trips bookings for message_received", () => {
+  it("returns /messages for message_received", () => {
     expect(
       getNotificationLink({
         type: "message_received",
         booking_id: "book-3",
       }),
-    ).toBe("/my-trips?tab=bookings");
+    ).toBe("/messages");
   });
 
   it("returns null for unknown notification type", () => {

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -57,8 +57,10 @@ export function getNotificationLink(notification: {
 
     case "booking_confirmed":
     case "payment_received":
-    case "message_received":
       return booking_id ? "/my-trips?tab=bookings" : "/my-trips";
+
+    case "message_received":
+      return "/messages";
 
     case "new_proposal_received":
     case "proposal_accepted":


### PR DESCRIPTION
## Summary
Closes the last gap in the Unified Conversation Layer Definition of Done:

- `useSendMessage` now fires `notification-dispatcher` for the recipient after each new message (fire-and-forget, doesn't block the send)
- `getNotificationLink` routes `message_received` → `/messages` (was the outdated `/my-trips?tab=bookings`)
- Test updated

## DoD Verification (RAV-Unified-Conversation-Layer.md Part 11)
- [x] Migration 051 applied, tables/triggers/RPCs working
- [x] Backfill ran (100 conversations, 124 events)
- [x] /messages route accessible
- [x] Inbox + Thread + Realtime working
- [x] All 4 interaction types auto-create conversations
- [x] Notifications fire for new messages (SMS in test mode only)
- [x] Seed data includes conversations (messages populate on next reseed)
- [x] Documentation updated
- [x] 917 tests pass (115 files), 0 type errors, build clean
- [x] `npm run test:p0` — 100 P0 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)