### PR TITLE
feat(auth): WS2 Story 1 — T&C audit trail + Signup rewrite (#318)

### DIFF
--- a/src/components/admin/AdminUsers.tsx
+++ b/src/components/admin/AdminUsers.tsx
@@ -328,6 +328,8 @@ const AdminUsers = ({ initialSearch = "" }: { initialSearch?: string }) => {
                   <TableHead>User</TableHead>
                   <TableHead>Roles</TableHead>
                   <TableHead>Registered</TableHead>
+                  <TableHead>T&amp;C Accepted</TableHead>
+                  <TableHead>Onboarding</TableHead>
                   {isRavTeam && <TableHead>Notes</TableHead>}
                   {isRavTeam && <TableHead className="text-right">Actions</TableHead>}
                 </TableRow>
@@ -363,6 +365,22 @@ const AdminUsers = ({ initialSearch = "" }: { initialSearch?: string }) => {
                     </TableCell>
                     <TableCell className="text-sm text-muted-foreground">
                       {format(new Date(user.created_at), "MMM d, yyyy")}
+                    </TableCell>
+                    <TableCell className="text-sm">
+                      {user.current_terms_version ? (
+                        <span className="text-muted-foreground">
+                          v{user.current_terms_version}
+                        </span>
+                      ) : (
+                        <span className="text-yellow-600 text-xs">⚠️ Not recorded</span>
+                      )}
+                    </TableCell>
+                    <TableCell className="text-sm text-muted-foreground">
+                      {user.onboarding_completed_at ? (
+                        format(new Date(user.onboarding_completed_at), "MMM d, yyyy")
+                      ) : (
+                        <span className="text-yellow-600 text-xs">Pending</span>
+                      )}
                     </TableCell>
                     {isRavTeam && (
                       <TableCell>

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -152,11 +152,12 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
 
   // Auth methods
   const signUp = async (email: string, password: string, fullName?: string, accountType?: string, referralCode?: string) => {
+    // Note: T&C acceptance is now recorded in the terms_acceptance_log table
+    // via Signup.tsx after signUp() succeeds. We no longer store it in auth
+    // metadata (which was hardcoded to true regardless of user consent).
     const metadata: Record<string, unknown> = {
       full_name: fullName,
       account_type: accountType || 'renter',
-      terms_accepted_at: new Date().toISOString(),
-      age_verified: true,
     };
     if (referralCode) {
       metadata.referral_code = referralCode;

--- a/src/lib/termsVersions.test.ts
+++ b/src/lib/termsVersions.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { CURRENT_TERMS_VERSION, CURRENT_PRIVACY_VERSION } from './termsVersions';
+
+describe('termsVersions', () => {
+  it('exports CURRENT_TERMS_VERSION as a non-empty string', () => {
+    expect(typeof CURRENT_TERMS_VERSION).toBe('string');
+    expect(CURRENT_TERMS_VERSION.length).toBeGreaterThan(0);
+  });
+
+  it('exports CURRENT_PRIVACY_VERSION as a non-empty string', () => {
+    expect(typeof CURRENT_PRIVACY_VERSION).toBe('string');
+    expect(CURRENT_PRIVACY_VERSION.length).toBeGreaterThan(0);
+  });
+
+  it('version strings match semver-ish format (digits and dots)', () => {
+    const semverish = /^\d+\.\d+(\.\d+)?$/;
+    expect(CURRENT_TERMS_VERSION).toMatch(semverish);
+    expect(CURRENT_PRIVACY_VERSION).toMatch(semverish);
+  });
+});

--- a/src/lib/termsVersions.ts
+++ b/src/lib/termsVersions.ts
@@ -1,0 +1,9 @@
+// Current Terms of Service and Privacy Policy versions.
+// Bump these when the legal documents change — a new version triggers
+// re-acceptance via the terms_update_prompt flow (future).
+//
+// When updating: also update the corresponding /terms and /privacy pages,
+// and consider whether existing users need to re-accept.
+
+export const CURRENT_TERMS_VERSION = '1.0';
+export const CURRENT_PRIVACY_VERSION = '1.0';

--- a/src/pages/Signup.test.tsx
+++ b/src/pages/Signup.test.tsx
@@ -1,0 +1,121 @@
+// @vitest-environment jsdom
+// @p0
+/**
+ * Tests for Signup form — controlled T&C state + audit log write.
+ * GitHub Issue: WS2 — Registration T&C Audit
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
+
+const mockSignUp = vi.hoisted(() => vi.fn().mockResolvedValue({ error: null }));
+
+vi.mock('@/hooks/useAuth', () => ({
+  useAuth: () => ({
+    signUp: mockSignUp,
+    signInWithGoogle: vi.fn(),
+    isConfigured: true,
+  }),
+}));
+
+vi.mock('@/lib/supabase', () => ({
+  supabase: {
+    from: vi.fn().mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          single: vi.fn().mockResolvedValue({ data: null }),
+        }),
+      }),
+      insert: vi.fn().mockResolvedValue({ error: null }),
+    }),
+    auth: {
+      getUser: vi.fn().mockResolvedValue({ data: { user: null } }),
+    },
+  },
+}));
+
+vi.mock('@/hooks/usePageMeta', () => ({
+  usePageMeta: vi.fn(),
+}));
+
+vi.mock('@/components/Header', () => ({
+  default: () => <div data-testid="header">Header</div>,
+}));
+
+vi.mock('@/components/Footer', () => ({
+  default: () => <div data-testid="footer">Footer</div>,
+}));
+
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => ({ user: null }),
+}));
+
+vi.mock('@/hooks/useRealtimeSubscription', () => ({
+  useRealtimeSubscription: vi.fn(),
+}));
+
+vi.mock('@/hooks/useConversations', () => ({
+  useUnreadConversationCount: vi.fn().mockReturnValue({ data: 0 }),
+}));
+
+vi.mock('@/components/bidding/NotificationBell', () => ({
+  NotificationBell: () => null,
+}));
+
+vi.mock('@/components/RoleBadge', () => ({
+  RoleBadge: () => null,
+  getDisplayRole: () => null,
+}));
+
+import Signup from './Signup';
+
+function renderSignup() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter>
+        <Signup />
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+describe('Signup form — T&C acceptance', () => {
+  beforeEach(() => {
+    mockSignUp.mockClear();
+    mockSignUp.mockResolvedValue({ error: null });
+  });
+
+  it('renders two separate checkboxes for age and terms', () => {
+    renderSignup();
+    expect(screen.getByLabelText('I am 18 years or older')).toBeInTheDocument();
+    expect(screen.getByLabelText('I accept the Terms of Service and Privacy Policy')).toBeInTheDocument();
+  });
+
+  it('submit button is disabled until both checkboxes are checked', () => {
+    renderSignup();
+    const submitButton = screen.getByRole('button', { name: /create account/i });
+    expect(submitButton).toBeDisabled();
+
+    fireEvent.click(screen.getByLabelText('I am 18 years or older'));
+    expect(submitButton).toBeDisabled();
+
+    fireEvent.click(screen.getByLabelText('I accept the Terms of Service and Privacy Policy'));
+    expect(submitButton).not.toBeDisabled();
+  });
+
+  it('submit button stays disabled if only age is checked', () => {
+    renderSignup();
+    fireEvent.click(screen.getByLabelText('I am 18 years or older'));
+    const submitButton = screen.getByRole('button', { name: /create account/i });
+    expect(submitButton).toBeDisabled();
+  });
+
+  it('submit button stays disabled if only terms is checked', () => {
+    renderSignup();
+    fireEvent.click(screen.getByLabelText('I accept the Terms of Service and Privacy Policy'));
+    const submitButton = screen.getByRole('button', { name: /create account/i });
+    expect(submitButton).toBeDisabled();
+  });
+});

--- a/src/pages/Signup.tsx
+++ b/src/pages/Signup.tsx
@@ -11,6 +11,7 @@ import { useToast } from "@/hooks/use-toast";
 import { ActionSuccessCard } from "@/components/ActionSuccessCard";
 import { supabase } from "@/lib/supabase";
 import { extractReferralCode } from "@/lib/referral";
+import { CURRENT_TERMS_VERSION, CURRENT_PRIVACY_VERSION } from "@/lib/termsVersions";
 
 const Signup = () => {
   usePageMeta('Sign Up', 'Create your free Rent-A-Vacation account to start booking or listing vacation properties.');
@@ -20,6 +21,8 @@ const Signup = () => {
     email: "",
     password: "",
     accountType: "renter",
+    ageVerified: false,
+    termsAccepted: false,
   });
   const [isLoading, setIsLoading] = useState(false);
   const [isSignupComplete, setIsSignupComplete] = useState(false);
@@ -75,11 +78,20 @@ const Signup = () => {
       });
       return;
     }
-    
+
+    if (!formData.ageVerified || !formData.termsAccepted) {
+      toast({
+        title: "Agreement required",
+        description: "You must confirm your age and accept the Terms of Service and Privacy Policy.",
+        variant: "destructive",
+      });
+      return;
+    }
+
     setIsLoading(true);
     const { error } = await signUp(formData.email, formData.password, formData.name, formData.accountType, referralCode || undefined);
     setIsLoading(false);
-    
+
     if (error) {
       toast({
         title: "Signup failed",
@@ -87,6 +99,26 @@ const Signup = () => {
         variant: "destructive",
       });
     } else {
+      // Best-effort audit log write — don't fail the signup if this errors.
+      // The profile exists at this point via the handle_new_user trigger.
+      try {
+        const { data: { user: newUser } } = await supabase.auth.getUser();
+        if (newUser) {
+          await supabase.from("terms_acceptance_log").insert({
+            user_id: newUser.id,
+            terms_version: CURRENT_TERMS_VERSION,
+            privacy_version: CURRENT_PRIVACY_VERSION,
+            terms_accepted: true,
+            privacy_accepted: true,
+            age_verified: formData.ageVerified,
+            acceptance_method: "signup_checkbox",
+            user_agent: navigator.userAgent,
+          });
+        }
+      } catch (auditError) {
+        // Audit write is best-effort; log but don't block signup success.
+        console.error("Failed to write terms_acceptance_log:", auditError);
+      }
       setIsSignupComplete(true);
     }
   };
@@ -291,21 +323,46 @@ const Signup = () => {
                   )}
                 </div>
 
-                <div className="flex items-start gap-2">
-                  <input type="checkbox" className="rounded border-border mt-1" required />
-                  <span className="text-sm text-muted-foreground">
-                    I am 18 years or older and agree to Rent-A-Vacation's{" "}
-                    <Link to="/terms" className="text-primary hover:underline">
-                      Terms of Service
-                    </Link>{" "}
-                    and{" "}
-                    <Link to="/privacy" className="text-primary hover:underline">
-                      Privacy Policy
-                    </Link>
-                  </span>
+                <div className="space-y-3">
+                  <label className="flex items-start gap-2 cursor-pointer">
+                    <input
+                      type="checkbox"
+                      className="rounded border-border mt-1"
+                      checked={formData.ageVerified}
+                      onChange={(e) => setFormData({ ...formData, ageVerified: e.target.checked })}
+                      aria-label="I am 18 years or older"
+                    />
+                    <span className="text-sm text-muted-foreground">
+                      I confirm that I am 18 years or older
+                    </span>
+                  </label>
+
+                  <label className="flex items-start gap-2 cursor-pointer">
+                    <input
+                      type="checkbox"
+                      className="rounded border-border mt-1"
+                      checked={formData.termsAccepted}
+                      onChange={(e) => setFormData({ ...formData, termsAccepted: e.target.checked })}
+                      aria-label="I accept the Terms of Service and Privacy Policy"
+                    />
+                    <span className="text-sm text-muted-foreground">
+                      I have read and accept the{" "}
+                      <Link to="/terms" className="text-primary hover:underline" target="_blank" rel="noopener noreferrer">
+                        Terms of Service
+                      </Link>{" "}
+                      and{" "}
+                      <Link to="/privacy" className="text-primary hover:underline" target="_blank" rel="noopener noreferrer">
+                        Privacy Policy
+                      </Link>
+                    </span>
+                  </label>
                 </div>
 
-                <Button type="submit" className="w-full" disabled={isLoading}>
+                <Button
+                  type="submit"
+                  className="w-full"
+                  disabled={isLoading || !formData.ageVerified || !formData.termsAccepted}
+                >
                   {isLoading ? (
                     <>
                       <Loader2 className="w-4 h-4 mr-2 animate-spin" />

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -1206,6 +1206,8 @@ export type Database = {
           approved_by: string | null
           avatar_url: string | null
           created_at: string
+          current_privacy_version: string | null
+          current_terms_version: string | null
           deletion_reason: string | null
           deletion_requested_at: string | null
           deletion_scheduled_for: string | null
@@ -1215,6 +1217,7 @@ export type Database = {
           is_anonymized: boolean
           is_seed_foundation: boolean | null
           maintenance_fee_updated_at: string | null
+          onboarding_completed_at: string | null
           phone: string | null
           rejection_reason: string | null
           stripe_account_id: string | null
@@ -1230,6 +1233,8 @@ export type Database = {
           approved_by?: string | null
           avatar_url?: string | null
           created_at?: string
+          current_privacy_version?: string | null
+          current_terms_version?: string | null
           deletion_reason?: string | null
           deletion_requested_at?: string | null
           deletion_scheduled_for?: string | null
@@ -1239,6 +1244,7 @@ export type Database = {
           is_anonymized?: boolean
           is_seed_foundation?: boolean | null
           maintenance_fee_updated_at?: string | null
+          onboarding_completed_at?: string | null
           phone?: string | null
           rejection_reason?: string | null
           stripe_account_id?: string | null
@@ -1254,6 +1260,8 @@ export type Database = {
           approved_by?: string | null
           avatar_url?: string | null
           created_at?: string
+          current_privacy_version?: string | null
+          current_terms_version?: string | null
           deletion_reason?: string | null
           deletion_requested_at?: string | null
           deletion_scheduled_for?: string | null
@@ -1263,6 +1271,7 @@ export type Database = {
           is_anonymized?: boolean
           is_seed_foundation?: boolean | null
           maintenance_fee_updated_at?: string | null
+          onboarding_completed_at?: string | null
           phone?: string | null
           rejection_reason?: string | null
           stripe_account_id?: string | null
@@ -1272,6 +1281,59 @@ export type Database = {
           updated_at?: string
         }
         Relationships: []
+      }
+      terms_acceptance_log: {
+        Row: {
+          id: string
+          user_id: string
+          terms_version: string
+          privacy_version: string
+          terms_accepted: boolean
+          privacy_accepted: boolean
+          age_verified: boolean
+          accepted_at: string
+          acceptance_method: string
+          user_agent: string | null
+          ip_address: string | null
+          created_at: string
+        }
+        Insert: {
+          id?: string
+          user_id: string
+          terms_version: string
+          privacy_version: string
+          terms_accepted?: boolean
+          privacy_accepted?: boolean
+          age_verified?: boolean
+          accepted_at?: string
+          acceptance_method: string
+          user_agent?: string | null
+          ip_address?: string | null
+          created_at?: string
+        }
+        Update: {
+          id?: string
+          user_id?: string
+          terms_version?: string
+          privacy_version?: string
+          terms_accepted?: boolean
+          privacy_accepted?: boolean
+          age_verified?: boolean
+          accepted_at?: string
+          acceptance_method?: string
+          user_agent?: string | null
+          ip_address?: string | null
+          created_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "terms_acceptance_log_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
       }
       properties: {
         Row: {

--- a/supabase/functions/send-approval-email/index.ts
+++ b/supabase/functions/send-approval-email/index.ts
@@ -82,14 +82,15 @@ const handler = async (req: Request): Promise<Response> => {
       heading = "Welcome to Rent-A-Vacation!";
       body = `
         <p><strong>Great news!</strong> Your account has been approved and you now have full access to Rent-A-Vacation.</p>
-        <p>You can now:</p>
+        <p>Log in to complete a quick welcome step and get started:</p>
         <ul style="line-height: 1.8; padding-left: 20px;">
           <li>Browse and book vacation rentals</li>
-          <li>Use voice search to find properties</li>
-          <li>Create bids and travel requests</li>
+          <li>Name Your Price on open listings</li>
+          <li>Post Vacation Wishes to get owner proposals</li>
           <li>List your own timeshare properties</li>
-        </ul>`;
-      cta = { label: "Start Browsing Rentals", url: "https://rent-a-vacation.com/rentals" };
+        </ul>
+        <p style="margin-top: 16px;">Click the button below to log in and begin.</p>`;
+      cta = { label: "Log In to Your Account", url: "https://rent-a-vacation.com/login" };
     } else {
       subject = "Update on your Rent-A-Vacation account";
       heading = "Account Update";

--- a/supabase/migrations/052_terms_acceptance_audit.sql
+++ b/supabase/migrations/052_terms_acceptance_audit.sql
@@ -1,0 +1,106 @@
+-- Migration 052: Terms & Conditions Acceptance Audit Trail
+-- Provides a permanent, queryable record of every T&C acceptance event.
+-- Replaces the (unreliable) hardcoded auth metadata approach with a proper audit table.
+
+-- ============================================================
+-- PART 1: terms_acceptance_log table
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS public.terms_acceptance_log (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+
+  -- Which version they accepted
+  terms_version TEXT NOT NULL,
+  privacy_version TEXT NOT NULL,
+
+  -- What they accepted
+  terms_accepted BOOLEAN NOT NULL DEFAULT false,
+  privacy_accepted BOOLEAN NOT NULL DEFAULT false,
+  age_verified BOOLEAN NOT NULL DEFAULT false,
+
+  -- When and how
+  accepted_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  acceptance_method TEXT NOT NULL CHECK (acceptance_method IN (
+    'signup_checkbox',      -- accepted at signup
+    'post_approval_gate',   -- accepted at first login after approval
+    'terms_update_prompt'   -- accepted after T&C version update (future)
+  )),
+
+  -- Audit context
+  user_agent TEXT,
+  ip_address INET,
+
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_terms_log_user ON public.terms_acceptance_log(user_id, accepted_at DESC);
+CREATE INDEX IF NOT EXISTS idx_terms_log_version ON public.terms_acceptance_log(terms_version);
+
+-- ============================================================
+-- PART 2: New columns on profiles
+-- ============================================================
+
+ALTER TABLE public.profiles
+  ADD COLUMN IF NOT EXISTS onboarding_completed_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS current_terms_version TEXT DEFAULT '1.0',
+  ADD COLUMN IF NOT EXISTS current_privacy_version TEXT DEFAULT '1.0';
+
+-- ============================================================
+-- PART 3: RLS policies
+-- ============================================================
+
+ALTER TABLE public.terms_acceptance_log ENABLE ROW LEVEL SECURITY;
+
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE policyname = 'terms_log_select_own') THEN
+    CREATE POLICY terms_log_select_own ON public.terms_acceptance_log
+      FOR SELECT TO authenticated
+      USING (user_id = auth.uid() OR public.is_rav_team(auth.uid()));
+  END IF;
+END $$;
+
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE policyname = 'terms_log_insert_own') THEN
+    CREATE POLICY terms_log_insert_own ON public.terms_acceptance_log
+      FOR INSERT TO authenticated
+      WITH CHECK (user_id = auth.uid());
+  END IF;
+END $$;
+
+-- ============================================================
+-- PART 4: Backfill existing approved users
+-- ============================================================
+
+-- Create acceptance records for all existing approved users.
+-- Use their signup timestamp as accepted_at (we don't have the exact moment).
+INSERT INTO public.terms_acceptance_log (
+  user_id, terms_version, privacy_version,
+  terms_accepted, privacy_accepted, age_verified,
+  accepted_at, acceptance_method
+)
+SELECT
+  id,
+  '1.0',
+  '1.0',
+  true,
+  true,
+  true,
+  created_at,
+  'signup_checkbox'
+FROM public.profiles
+WHERE approval_status = 'approved'
+  AND NOT EXISTS (
+    SELECT 1 FROM public.terms_acceptance_log
+    WHERE user_id = public.profiles.id
+  );
+
+-- Mark all existing approved users as onboarding complete.
+-- They pre-date this system; don't force them through the onboarding gate.
+UPDATE public.profiles
+SET
+  onboarding_completed_at = created_at,
+  current_terms_version = '1.0',
+  current_privacy_version = '1.0'
+WHERE approval_status = 'approved'
+  AND onboarding_completed_at IS NULL;


### PR DESCRIPTION
## Summary
Closes #318 (WS2 Story 1 of Epic #317)

- Migration 052: terms_acceptance_log + profile columns + backfill (60 existing approved users)
- Signup form rewritten with 2 controlled checkboxes (age + terms); submit disabled until both checked
- AuthContext: removed hardcoded terms_accepted_at that lied regardless of user consent
- send-approval-email: added explicit "Log In to Your Account" CTA
- AdminUsers: new T&C + Onboarding columns
- 7 new tests

## Test plan
- [x] 924 tests pass (117 files), 0 type errors, build clean
- [x] Migration deployed to DEV, backfill verified (60 rows)
- [x] Edge function send-approval-email redeployed

## Out of scope (Story 2 — #319)
- /welcome page and post-approval gate
- Route guard logic
- useOnboarding hook
- Flow manifests

🤖 Generated with [Claude Code](https://claude.com/claude-code)