### PR TITLE
docs: bring PROJECT-HUB, COMPLETED-PHASES, ARCHITECTURE, TEST-STRATEGY current

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 ---
-last_updated: "2026-04-10T19:18:28"
-change_ref: "cf233ec"
+last_updated: "2026-04-11T04:04:36"
+change_ref: "902990b"
 change_type: "session-39-docs-update"
 status: "active"
 ---
@@ -521,7 +521,7 @@ auth.users (Supabase managed)
 
 ### Migrations
 
-51 migrations deployed via Supabase CLI (`npx supabase db push`). Migrations 001-050 deployed to DEV; 051 (unified conversations) deployed to DEV.
+52 migrations deployed via Supabase CLI (`npx supabase db push`). Migrations 001-050 deployed to DEV; 051 (unified conversations) and 052 (terms acceptance audit) deployed to DEV.
 
 | # | File | What it creates |
 |---|------|----------------|
@@ -568,6 +568,13 @@ auth.users (Supabase managed)
 | 043 | `referral_program.sql` | `referral_codes` + `referrals` tables, 3 referral RPCs |
 | 044 | `api_keys.sql` | `api_keys` + `api_request_log` tables, 4 API management RPCs |
 | 045 | `api_key_ip_allowlist.sql` | `allowed_ips text[]` on api_keys + CIDR validation |
+| 046 | `notification_center.sql` | `notification_catalog`, `user_notification_preferences`, seasonal events, delivery log |
+| 047 | `membership_stripe_prices.sql` | Stripe price IDs on membership tiers |
+| 048 | `set_stripe_price_ids.sql` | Production Stripe price ID seeding |
+| 049 | `listing_limit_trigger.sql` | DB trigger enforcing per-tier listing limits |
+| 050 | `subscription_metrics_rpc.sql` | `get_subscription_metrics` RPC for admin MRR dashboard |
+| 051 | `unified_conversations.sql` | `conversations`, `conversation_messages`, `conversation_events` + 4 RPCs + 12-step backfill |
+| 052 | `terms_acceptance_audit.sql` | `terms_acceptance_log` + 3 profile columns (onboarding_completed_at, current_terms_version, current_privacy_version) + backfill of 60 approved users |
 
 Additional non-numbered migrations:
 - `20260211_resort_master_data.sql` — Resort master data seed
@@ -871,6 +878,22 @@ The public API provides read-only access to marketplace data for third-party int
 | `ConversationThread` | `src/components/messaging/` | Message bubbles, system events, date separators |
 
 **Auth model:** Dual authentication — API key (header `X-API-Key`) or JWT (Supabase session). Tiered rate limits based on membership.
+
+### Terms Acceptance Audit + Post-Approval Onboarding Gate (Migration 052 / WS2)
+
+| Component | Location | Purpose |
+|-----------|----------|---------|
+| `terms_acceptance_log` table | Migration 052 | Permanent audit trail of every T&C acceptance event (version, method, timestamp, user_agent, ip_address) |
+| `profiles.onboarding_completed_at` | Migration 052 | Timestamp when user completed the post-approval onboarding gate |
+| `profiles.current_terms_version` | Migration 052 | Latest T&C version accepted by the user |
+| `profiles.current_privacy_version` | Migration 052 | Latest Privacy Policy version accepted by the user |
+| `termsVersions.ts` | `src/lib/termsVersions.ts` | `CURRENT_TERMS_VERSION` / `CURRENT_PRIVACY_VERSION` constants (bump when legal docs change) |
+| `useOnboarding.ts` | `src/hooks/useOnboarding.ts` | Pure `needsOnboarding(profile, isRavTeam)` + `useCompleteOnboarding()` mutation |
+| `WelcomePage` | `src/pages/WelcomePage.tsx` | 2-step post-approval gate at `/welcome` — T&C reconfirm + role-specific CTAs |
+| `ProtectedRoute` onboarding gate | `src/App.tsx` | Redirects approved users with null `onboarding_completed_at` to `/welcome`; whitelists `/welcome`, `/terms`, `/privacy`; RAV team bypasses entirely |
+| `Signup` controlled form | `src/pages/Signup.tsx` | 2 separate checkboxes (age 18+, Terms + Privacy), submit disabled until both checked, writes audit row with `signup_checkbox` method |
+
+**Acceptance methods:** `signup_checkbox` | `post_approval_gate` | `terms_update_prompt` (future, for when T&C versions change and we need re-acceptance).
 
 ---
 

--- a/docs/COMPLETED-PHASES.md
+++ b/docs/COMPLETED-PHASES.md
@@ -1,6 +1,6 @@
 ---
-last_updated: "2026-04-11T02:29:56"
-change_ref: "0d4a4e5"
+last_updated: "2026-04-11T04:04:36"
+change_ref: "902990b"
 change_type: "session-39-docs-update"
 status: "active"
 ---
@@ -8,6 +8,53 @@ status: "active"
 
 > Detailed records of completed project phases, moved from [PROJECT-HUB.md](PROJECT-HUB.md) to keep the hub concise.
 > **Last Archived:** March 10, 2026
+
+---
+
+## WS2: Registration T&C Audit & Post-Approval Onboarding Gate
+
+**Completed:** April 10-11, 2026
+**Epic:** #317 (closed) — 2 sessions across 2 PRs (#320, #321)
+**Milestone:** WS2: Registration, T&C & Onboarding
+
+### Problem closed
+Users were signing up with a single combined "age + T&C" checkbox that had NO controlled state — `terms_accepted_at` was hardcoded to `true` in auth metadata regardless of what the user actually did. No queryable audit trail existed. The approval email had no login link. There was no post-approval reconfirmation of the current T&C version.
+
+### Story 1 (PR #320) — Migration + Signup rewrite + Admin column
+- **Migration 052** — new `terms_acceptance_log` table (user_id, terms/privacy version, terms/privacy/age flags, accepted_at, acceptance_method, user_agent, ip_address), 2 indexes, RLS (user-scoped insert, participants + RAV team select)
+- **Profile columns added** — `onboarding_completed_at`, `current_terms_version`, `current_privacy_version`
+- **Backfill** — 60 existing approved users got audit rows + were marked onboarding complete
+- **`src/lib/termsVersions.ts`** — `CURRENT_TERMS_VERSION` and `CURRENT_PRIVACY_VERSION` constants (both 1.0)
+- **`src/pages/Signup.tsx`** — rewritten with 2 controlled checkboxes (age 18+, Terms + Privacy), submit disabled until both checked, audit log write after signup
+- **`src/contexts/AuthContext.tsx`** — removed hardcoded `terms_accepted_at`/`age_verified` from auth metadata
+- **`supabase/functions/send-approval-email/index.ts`** — added explicit "Log In to Your Account" CTA pointing to `/login` (was `/rentals` with no login link)
+- **`src/components/admin/AdminUsers.tsx`** — new "T&C Accepted" and "Onboarding" columns showing version + date or "⚠️ Not recorded" / "Pending"
+- **Tests:** 7 new (3 termsVersions + 4 Signup)
+
+### Story 2 (PR #321) — /welcome post-approval onboarding gate
+- **`src/hooks/useOnboarding.ts`** — pure `needsOnboarding(profile, isRavTeam)` guard + `useCompleteOnboarding()` mutation that writes audit row (`post_approval_gate` method) and updates profile (onboarding_completed_at + versions)
+- **`src/pages/WelcomePage.tsx`** — 2-step post-approval flow:
+  - Step 1: T&C reconfirm with 2 controlled checkboxes, Continue disabled until both checked
+  - Step 2: role-specific CTAs — Owner sees List First Property, Owner's Edge, Browse Vacation Wishes; Traveler sees Start Exploring, Name Your Price, Post a Vacation Wish
+  - Skip-for-now button navigates away (onboarding already marked complete)
+- **`src/App.tsx` ProtectedRoute** — onboarding gate: redirects approved users with null `onboarding_completed_at` to `/welcome`; whitelists `/welcome`, `/terms`, `/privacy` so users can read before accepting; RAV team bypasses entirely; already-onboarded users redirected away
+- **Flow manifests** — `welcome_onboarding` step inserted between `pending_approval` and first role action in both `traveler-lifecycle.ts` and `owner-lifecycle.ts`
+- **Tests:** 16 new (6 useOnboarding + 10 WelcomePage)
+
+### End-to-end flow now
+1. Signup with 2 controlled checkboxes → audit log row with `signup_checkbox` method
+2. User sits on `/pending-approval` until admin approves
+3. Approval email fires with "Log In to Your Account" CTA
+4. First login detects `onboarding_completed_at IS NULL` → redirects to `/welcome`
+5. Step 1 reconfirm → audit log row with `post_approval_gate` method, profile updated
+6. Step 2 role-specific CTAs → navigate into the app
+7. Admin Users list shows T&C version + onboarding date per user
+8. Gate never triggers again for that user
+
+### Test count
+- Before WS2: 917 (115 files)
+- After WS2 Story 1: 924 (117 files)
+- After WS2 Story 2: **940 (119 files)**
 
 ---
 

--- a/docs/PROJECT-HUB.md
+++ b/docs/PROJECT-HUB.md
@@ -1,6 +1,6 @@
 ---
-last_updated: "2026-04-10T19:18:28"
-change_ref: "cf233ec"
+last_updated: "2026-04-11T04:04:36"
+change_ref: "902990b"
 change_type: "session-39-docs-update"
 status: "active"
 ---
@@ -104,7 +104,20 @@ gh issue create --repo rent-a-vacation/rav-website --title "..." --label "..." -
 - **dev and main:** in sync (PRs #287-#292 merged Apr 5)
 - **GitHub Project:** RAV Roadmap — 202 issues, all with Status/Category/Sub-Category/Type populated. Auto-add workflow enabled. PRs excluded.
 
-### Session Handoff (Sessions 25-45)
+### Session Handoff (Sessions 25-46)
+
+**Session 46 — WS2 Registration T&C Audit + WS3 Navigation + Messages Polish (Apr 10-11, 2026):**
+
+Three workstreams shipped plus Phase 21 DoD cleanup. All backed by GitHub issues (#315-#319, #322).
+
+- **Phase 21 DoD completion (PR #314):** Wired `useSendMessage` to invoke `notification-dispatcher` for the recipient after each new message (best-effort fire-and-forget). Updated `getNotificationLink` to route `message_received` → `/messages`.
+- **Messages page layout fix (PR #312, Issue #315):** QA reported Messages page rendered without Header/Footer, nav was too subtle. Fixed: added Header + Footer + bordered card layout, replaced icon-only button with visible "Messages" text link + badge (desktop + mobile), added Messages quick-access card to Owner Dashboard. Fix: missing Footer default export import.
+- **WS3 Navigation Redesign (PR #313, Issue #316):** Role-based nav in `Header.tsx` — Owner sees Owner's Edge | My Listings | Vacation Wishes | Messages; Traveler sees Explore | Name Your Price | Vacation Wishes | My Trips | Messages. Owner avatar dropdown gets List a Property + Free Tools. Terminology updates across 7 files ("Travel Requests" → "Vacation Wishes", "Make an Offer" tab → "Listings"). Bug fix: missing Badge import in Header.tsx. New `Header.test.tsx` with 10 tests.
+- **WS2 Story 1 (PR #320, Issue #318):** Migration 052 `terms_acceptance_log` audit table + 3 profile columns (onboarding_completed_at, current_terms_version, current_privacy_version) + backfill of 60 existing approved users. Signup form rewritten with 2 controlled checkboxes (age + terms), submit disabled until both checked, audit log write after signup. AuthContext metadata cleanup (removed hardcoded `terms_accepted_at: true`). `send-approval-email` gets explicit "Log In to Your Account" CTA. AdminUsers gets T&C Accepted + Onboarding columns.
+- **WS2 Story 2 (PR #321, Issue #319, closed Epic #317):** `/welcome` post-approval onboarding gate. `useOnboarding` hook with `needsOnboarding` guard + `useCompleteOnboarding` mutation. `WelcomePage` with 2-step flow: Step 1 T&C reconfirm (writes audit log with `post_approval_gate` method), Step 2 role-specific CTAs. `App.tsx` `ProtectedRoute` redirects approved-but-not-onboarded users to `/welcome` with `/terms` `/privacy` whitelist. RAV team bypasses gate. Flow manifests updated.
+- **WS4 (Issue #322, parked):** Post-beta feature brief for proposal location enforcement + fast-track property listing. DESIGN COMPLETE, implementation deferred until 30+ days of real proposal data. Issue created with full decisions + migration SQL + acceptance criteria embedded.
+
+**End state:** 940 tests (119 files), 0 type errors, build clean. Migrations at 052. 12 GitHub issues closed, 1 parked.
 
 **Session 45 — Unified Conversation Layer / Phase 21 (Apr 10, 2026):**
 - Epic #296 with 10 stories (#297-#306), Milestone: Phase 21: Unified Messaging

--- a/docs/testing/TEST-STRATEGY.md
+++ b/docs/testing/TEST-STRATEGY.md
@@ -1,6 +1,6 @@
 ---
-last_updated: "2026-04-10T19:18:28"
-change_ref: "cf233ec"
+last_updated: "2026-04-11T04:04:36"
+change_ref: "902990b"
 change_type: "session-39-docs-update"
 status: "active"
 ---
@@ -385,6 +385,44 @@ Located in `src/test/helpers/`:
 | Inbox rendering | `src/components/messaging/ConversationInbox.test.tsx` | Filter tabs, participant names, context badges, click selection |
 | Thread rendering | `src/components/messaging/ConversationThread.test.tsx` | Message bubbles, events, mark-read-on-mount, composer |
 | Messages page | `src/pages/Messages.test.tsx` | Two-panel layout, empty state, filter tabs |
+
+### Navigation & Terminology (P0) — WS3
+
+| Test | File | What it validates |
+|------|------|------------------|
+| Unauthenticated nav | `src/components/Header.test.tsx` | Public nav shows Explore, How It Works, Name Your Price, List Your Property, Free Tools |
+| Traveler nav | `src/components/Header.test.tsx` | Traveler sees Explore, Name Your Price, Vacation Wishes, My Trips, Messages |
+| Owner nav | `src/components/Header.test.tsx` | Owner sees Owner's Edge, My Listings, Vacation Wishes, Messages |
+| Traveler exclusions | `src/components/Header.test.tsx` | Traveler does NOT see How It Works or List Your Property in top nav |
+| Owner exclusions | `src/components/Header.test.tsx` | Owner does NOT see Explore or Name Your Price in top nav |
+| Owner's Edge route | `src/components/Header.test.tsx` | Link routes to `/owner-dashboard` |
+| My Listings route | `src/components/Header.test.tsx` | Link routes to `/owner-dashboard?tab=my-listings` |
+| Vacation Wishes route | `src/components/Header.test.tsx` | Link routes to `/bidding?tab=requests` |
+| Messages badge visible | `src/components/Header.test.tsx` | Badge shows when `useUnreadConversationCount > 0` |
+| Messages badge hidden | `src/components/Header.test.tsx` | Badge hidden when count is 0 |
+
+### Registration & Onboarding (P0) — WS2
+
+| Test | File | What it validates |
+|------|------|------------------|
+| Terms version constants | `src/lib/termsVersions.test.ts` | `CURRENT_TERMS_VERSION` / `CURRENT_PRIVACY_VERSION` exist and match semver format |
+| Signup two checkboxes | `src/pages/Signup.test.tsx` | Both age and terms checkboxes render and are separately toggleable |
+| Signup submit disabled | `src/pages/Signup.test.tsx` | Submit stays disabled until both checkboxes are checked |
+| Signup partial state | `src/pages/Signup.test.tsx` | Submit stays disabled if only age OR only terms is checked |
+| needsOnboarding for RAV team | `src/hooks/useOnboarding.test.ts` | Returns false for RAV team (bypass gate entirely) |
+| needsOnboarding for onboarded | `src/hooks/useOnboarding.test.ts` | Returns false for users with non-null `onboarding_completed_at` |
+| needsOnboarding for new users | `src/hooks/useOnboarding.test.ts` | Returns true for newly approved users with null `onboarding_completed_at` |
+| needsOnboarding for pending | `src/hooks/useOnboarding.test.ts` | Returns false for pending_approval and rejected users |
+| WelcomePage Step 1 | `src/pages/WelcomePage.test.tsx` | Renders welcome heading with user first name, T&C checkboxes |
+| Continue button gated | `src/pages/WelcomePage.test.tsx` | Continue disabled until both T&C checkboxes checked |
+| Continue calls mutation | `src/pages/WelcomePage.test.tsx` | Clicking Continue calls `useCompleteOnboarding` |
+| Advances to Step 2 | `src/pages/WelcomePage.test.tsx` | After successful mutation, Step 2 renders |
+| Owner-specific CTAs | `src/pages/WelcomePage.test.tsx` | Owner sees List Property, Owner's Edge, Browse Vacation Wishes |
+| Traveler-specific CTAs | `src/pages/WelcomePage.test.tsx` | Traveler sees Start Exploring, Name Your Price, Post Vacation Wish |
+| Pending user redirect | `src/pages/WelcomePage.test.tsx` | User with pending_approval redirected to `/pending-approval` |
+| RAV team redirect | `src/pages/WelcomePage.test.tsx` | RAV team redirected to `/rentals` (bypass gate) |
+| Onboarded owner redirect | `src/pages/WelcomePage.test.tsx` | Already-onboarded owner redirected to `/owner-dashboard` |
+| Onboarded traveler redirect | `src/pages/WelcomePage.test.tsx` | Already-onboarded traveler redirected to `/my-trips` |
 
 ---
 


### PR DESCRIPTION
## Summary
Documentation was lagging behind today's shipped work. This catches everything up — docs-only PR, no code changes.

### Changes
- **COMPLETED-PHASES.md**: Full WS2 Story 1 + Story 2 entry (was missing entirely between Phase 21 and WS3)
- **PROJECT-HUB.md**: Session 46 handoff covering WS2, WS3, Messages layout fix, Phase 21 DoD notification wiring, WS4 parking
- **ARCHITECTURE.md**: Migration count 51→52, rows 046-052 added to migration table, new "Terms Acceptance Audit + Post-Approval Onboarding Gate" section
- **TEST-STRATEGY.md**: New P0 sections for WS3 Navigation (10 tests) and WS2 Registration/Onboarding (16 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)