### PR TITLE
feat(marketplace): #328 attraction-based filtering

### DIFF
--- a/docs/PRIORITY-ROADMAP.md
+++ b/docs/PRIORITY-ROADMAP.md
@@ -1,7 +1,7 @@
 ---
-last_updated: "2026-04-12T23:23:26"
-change_ref: "bc486bf"
-change_type: "session-47"
+last_updated: "2026-04-13T04:36:33"
+change_ref: "699e4cf"
+change_type: "session-48"
 status: "active"
 ---
 # PRIORITY ROADMAP — Rent-A-Vacation
@@ -20,14 +20,12 @@ These are the highest-value items we can build RIGHT NOW. No blockers, no decisi
 
 | Order | Issue | Title | Why it's here |
 |-------|-------|-------|---------------|
-| **A1** | #273 | Homepage simplification (Airbnb-style) | VC advisor flagged. First impression = conversion. Integrate new brand terms + RAV Deals. |
-| **A2** | #326 | RAV Deals page (`/rav-deals`) | Existing idle listing infra. Drives bidding engine. Quick win. |
-| **A3** | #285 | Owner fee transparency | Owners won't list if they don't understand costs. Trust blocker. |
-| **A4** | #328 | Attraction-Based Filtering | Visual discovery. Changes how travelers browse. Icon-based pill bar. |
-| **A5** | #327 | Event-Based Search | High value but needs data curation. 10-15 curated events. |
-| **A6** | #283 | Price drop alert notifications | Completes saved search → alert loop (infra already built). |
-| **A7** | #286 | Owner Tax Information form (W-9) | Needed before real payouts. |
-| **A8** | #259 | Testimonials collection + display | Social proof for launch credibility. |
+| **A1** | #285 | Owner fee transparency | Owners won't list if they don't understand costs. Trust blocker. |
+| **A2** | #328 | Attraction-Based Filtering | Visual discovery. Changes how travelers browse. Icon-based pill bar. |
+| **A3** | #327 | Event-Based Search | High value but needs data curation. 10-15 curated events. |
+| **A4** | #283 | Price drop alert notifications | Completes saved search → alert loop (infra already built). |
+| **A5** | #286 | Owner Tax Information form (W-9) | Needed before real payouts. |
+| **A6** | #259 | Testimonials collection + display | Social proof for launch credibility. |
 
 ### Tier B: Pre-Launch Important (Needs Human Input)
 
@@ -104,6 +102,7 @@ These unblock when the LLC is formed. Not code-dependent.
 
 | Date | Session | Changes |
 |------|---------|---------|
+| Apr 13, 2026 | 48 | #326 RAV Deals completed + closed. #273 Homepage completed (Session 47). Header nav consistency fix. Renumbered Tier A. |
 | Apr 12, 2026 | 47 | Initial creation. Brand rebrand completed. Search & Discovery epic created (#325-#328). Full 5-tier prioritization. |
 
 ---

--- a/src/components/admin/AdminResortImport.tsx
+++ b/src/components/admin/AdminResortImport.tsx
@@ -105,6 +105,7 @@ const AdminResortImport = () => {
         location: row.location,
         description: row.description || null,
         resort_amenities: row.resort_amenities || null,
+        attraction_tags: row.attraction_tags || [],
         guest_rating: row.guest_rating || null,
         nearby_airports: row.nearby_airports || null,
       });

--- a/src/components/admin/AdminResortTagEditor.tsx
+++ b/src/components/admin/AdminResortTagEditor.tsx
@@ -1,0 +1,219 @@
+import { useState, useEffect } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { supabase } from "@/lib/supabase";
+import { useToast } from "@/hooks/use-toast";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Loader2, Save, Search } from "lucide-react";
+import { ATTRACTION_TAG_VALUES, type AttractionTag } from "@/lib/attractionTags";
+
+interface ResortRow {
+  id: string;
+  resort_name: string;
+  brand: string;
+  location: { city?: string; state?: string } | null;
+  attraction_tags: string[];
+}
+
+export default function AdminResortTagEditor() {
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+  const [searchFilter, setSearchFilter] = useState("");
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editTags, setEditTags] = useState<Set<string>>(new Set());
+
+  const { data: resorts = [], isLoading } = useQuery({
+    queryKey: ["admin-resorts-tags"],
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from("resorts")
+        .select("id, resort_name, brand, location, attraction_tags")
+        .order("resort_name");
+      if (error) throw error;
+      return (data || []) as ResortRow[];
+    },
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: async ({ id, tags }: { id: string; tags: string[] }) => {
+      const { error } = await supabase
+        .from("resorts")
+        .update({ attraction_tags: tags })
+        .eq("id", id);
+      if (error) throw error;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["admin-resorts-tags"] });
+      queryClient.invalidateQueries({ queryKey: ["listings"] });
+      toast({ title: "Tags updated", description: "Resort attraction tags saved." });
+      setEditingId(null);
+    },
+    onError: (error) => {
+      toast({
+        title: "Error",
+        description: `Failed to update tags: ${error.message}`,
+        variant: "destructive",
+      });
+    },
+  });
+
+  const filteredResorts = resorts.filter((r) => {
+    if (!searchFilter.trim()) return true;
+    const q = searchFilter.toLowerCase();
+    return (
+      r.resort_name.toLowerCase().includes(q) ||
+      r.brand.replace(/_/g, " ").toLowerCase().includes(q) ||
+      (r.location?.city || "").toLowerCase().includes(q) ||
+      (r.location?.state || "").toLowerCase().includes(q)
+    );
+  });
+
+  const startEdit = (resort: ResortRow) => {
+    setEditingId(resort.id);
+    setEditTags(new Set(resort.attraction_tags || []));
+  };
+
+  const toggleTag = (tag: string) => {
+    setEditTags((prev) => {
+      const next = new Set(prev);
+      if (next.has(tag)) {
+        next.delete(tag);
+      } else {
+        next.add(tag);
+      }
+      return next;
+    });
+  };
+
+  const saveEdit = () => {
+    if (!editingId) return;
+    updateMutation.mutate({ id: editingId, tags: Array.from(editTags) });
+  };
+
+  const taggedCount = resorts.filter((r) => r.attraction_tags?.length > 0).length;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Resort Attraction Tags</CardTitle>
+        <CardDescription>
+          Manage activity tags for resort-based filtering. {taggedCount} of {resorts.length} resorts tagged.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="flex items-center gap-2 mb-4">
+          <Search className="w-4 h-4 text-muted-foreground" />
+          <Input
+            placeholder="Search resorts..."
+            value={searchFilter}
+            onChange={(e) => setSearchFilter(e.target.value)}
+            className="max-w-sm"
+          />
+        </div>
+
+        {isLoading ? (
+          <div className="flex justify-center py-8">
+            <Loader2 className="w-6 h-6 animate-spin" />
+          </div>
+        ) : (
+          <div className="border rounded-lg overflow-auto max-h-[600px]">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead className="w-[250px]">Resort</TableHead>
+                  <TableHead className="w-[120px]">Location</TableHead>
+                  <TableHead>Attraction Tags</TableHead>
+                  <TableHead className="w-[80px]">Actions</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {filteredResorts.map((resort) => (
+                  <TableRow key={resort.id}>
+                    <TableCell className="font-medium text-sm">{resort.resort_name}</TableCell>
+                    <TableCell className="text-sm text-muted-foreground">
+                      {resort.location?.city}, {resort.location?.state}
+                    </TableCell>
+                    <TableCell>
+                      {editingId === resort.id ? (
+                        <div className="flex flex-wrap gap-1">
+                          {ATTRACTION_TAG_VALUES.map((tag) => (
+                            <button
+                              key={tag}
+                              onClick={() => toggleTag(tag)}
+                              className={`px-2 py-0.5 rounded-full text-xs font-medium border transition-colors ${
+                                editTags.has(tag)
+                                  ? "bg-primary text-primary-foreground border-primary"
+                                  : "bg-muted text-muted-foreground border-border hover:bg-accent"
+                              }`}
+                            >
+                              {tag}
+                            </button>
+                          ))}
+                        </div>
+                      ) : (
+                        <div className="flex flex-wrap gap-1">
+                          {(resort.attraction_tags || []).length > 0 ? (
+                            resort.attraction_tags.map((tag) => (
+                              <Badge key={tag} variant="secondary" className="text-xs">
+                                {tag}
+                              </Badge>
+                            ))
+                          ) : (
+                            <span className="text-xs text-muted-foreground">No tags</span>
+                          )}
+                        </div>
+                      )}
+                    </TableCell>
+                    <TableCell>
+                      {editingId === resort.id ? (
+                        <div className="flex gap-1">
+                          <Button
+                            size="sm"
+                            variant="default"
+                            onClick={saveEdit}
+                            disabled={updateMutation.isPending}
+                          >
+                            {updateMutation.isPending ? (
+                              <Loader2 className="w-3 h-3 animate-spin" />
+                            ) : (
+                              <Save className="w-3 h-3" />
+                            )}
+                          </Button>
+                          <Button
+                            size="sm"
+                            variant="ghost"
+                            onClick={() => setEditingId(null)}
+                          >
+                            Cancel
+                          </Button>
+                        </div>
+                      ) : (
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          onClick={() => startEdit(resort)}
+                        >
+                          Edit
+                        </Button>
+                      )}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/hooks/useSavedSearches.ts
+++ b/src/hooks/useSavedSearches.ts
@@ -9,6 +9,7 @@ export interface SearchCriteria {
   minGuests?: string;
   minBedrooms?: string;
   brandFilter?: string;
+  attractionTags?: string[];
   dateFrom?: string;
   dateTo?: string;
 }
@@ -100,6 +101,7 @@ export function summarizeCriteria(criteria: SearchCriteria): string {
   }
   if (criteria.minGuests) parts.push(`${criteria.minGuests}+ guests`);
   if (criteria.minBedrooms) parts.push(`${criteria.minBedrooms}+ beds`);
+  if (criteria.attractionTags?.length) parts.push(criteria.attractionTags.join(', '));
   if (criteria.dateFrom) parts.push(`from ${criteria.dateFrom}`);
 
   return parts.length > 0 ? parts.join(', ') : 'All listings';
@@ -114,6 +116,7 @@ export function criteriaToSearchParams(criteria: SearchCriteria): string {
   if (criteria.maxPrice) params.set('maxPrice', criteria.maxPrice);
   if (criteria.minGuests) params.set('minGuests', criteria.minGuests);
   if (criteria.minBedrooms) params.set('minBedrooms', criteria.minBedrooms);
+  if (criteria.attractionTags?.length) params.set('attractions', criteria.attractionTags.join(','));
   return params.toString();
 }
 
@@ -126,6 +129,7 @@ export function hasActiveFilters(criteria: SearchCriteria): boolean {
     criteria.minGuests ||
     criteria.minBedrooms ||
     criteria.brandFilter ||
+    (criteria.attractionTags && criteria.attractionTags.length > 0) ||
     criteria.dateFrom
   );
 }

--- a/src/lib/attractionTags.test.ts
+++ b/src/lib/attractionTags.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect } from "vitest";
+import {
+  ATTRACTION_TAGS,
+  ATTRACTION_TAG_VALUES,
+  filterByAttractions,
+  getAvailableAttractions,
+} from "./attractionTags";
+import type { ActiveListing } from "@/hooks/useListings";
+
+// Helper to create a minimal listing with resort attraction_tags
+function makeListing(id: string, tags: string[]): ActiveListing {
+  return {
+    id,
+    property_id: `prop-${id}`,
+    owner_id: "owner-1",
+    status: "active",
+    check_in_date: "2026-06-01",
+    check_out_date: "2026-06-08",
+    final_price: 1000,
+    owner_price: 870,
+    rav_markup: 130,
+    nightly_rate: 143,
+    notes: null,
+    cancellation_policy: "moderate",
+    open_for_bidding: true,
+    bidding_ends_at: null,
+    min_bid_amount: null,
+    created_at: "2026-04-01",
+    property: {
+      id: `prop-${id}`,
+      owner_id: "owner-1",
+      brand: "hilton_grand_vacations",
+      resort_name: "Test Resort",
+      location: "Orlando, FL",
+      description: null,
+      bedrooms: 2,
+      bathrooms: 2,
+      sleeps: 6,
+      amenities: [],
+      images: [],
+      resort_id: `resort-${id}`,
+      unit_type_id: null,
+      resort: {
+        id: `resort-${id}`,
+        brand: "hilton_grand_vacations" as const,
+        resort_name: "Test Resort",
+        location: { city: "Orlando", state: "FL", country: "US", full_address: "" },
+        description: null,
+        contact: null,
+        resort_amenities: [],
+        attraction_tags: tags,
+        policies: null,
+        nearby_airports: [],
+        guest_rating: null,
+        main_image_url: null,
+        additional_images: [],
+        created_at: "",
+        updated_at: "",
+      },
+      unit_type: null,
+    },
+  };
+}
+
+describe("ATTRACTION_TAGS", () => {
+  it("contains 8 tag definitions", () => {
+    expect(ATTRACTION_TAGS).toHaveLength(8);
+  });
+
+  it("has unique tag values", () => {
+    const tags = ATTRACTION_TAGS.map((t) => t.tag);
+    expect(new Set(tags).size).toBe(tags.length);
+  });
+
+  it("ATTRACTION_TAG_VALUES matches ATTRACTION_TAGS order", () => {
+    expect(ATTRACTION_TAG_VALUES).toEqual(ATTRACTION_TAGS.map((t) => t.tag));
+  });
+
+  it("each tag has an icon defined", () => {
+    for (const def of ATTRACTION_TAGS) {
+      expect(def.icon).toBeTruthy();
+    }
+  });
+});
+
+describe("filterByAttractions", () => {
+  const beachListing = makeListing("1", ["Beach"]);
+  const golfListing = makeListing("2", ["Golf", "Spa"]);
+  const skiListing = makeListing("3", ["Ski", "Mountain"]);
+  const noTagsListing = makeListing("4", []);
+  const allListings = [beachListing, golfListing, skiListing, noTagsListing];
+
+  it("returns all listings when no tags selected", () => {
+    const result = filterByAttractions(allListings, new Set());
+    expect(result).toHaveLength(4);
+  });
+
+  it("filters by single tag (Beach)", () => {
+    const result = filterByAttractions(allListings, new Set(["Beach"]));
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("1");
+  });
+
+  it("uses OR logic for multiple tags", () => {
+    const result = filterByAttractions(allListings, new Set(["Beach", "Ski"]));
+    expect(result).toHaveLength(2);
+    expect(result.map((l) => l.id).sort()).toEqual(["1", "3"]);
+  });
+
+  it("matches listings with multi-tag resorts", () => {
+    const result = filterByAttractions(allListings, new Set(["Spa"]));
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("2");
+  });
+
+  it("excludes listings with no tags", () => {
+    const result = filterByAttractions(allListings, new Set(["Beach"]));
+    expect(result.every((l) => l.id !== "4")).toBe(true);
+  });
+
+  it("excludes listings with null resort", () => {
+    const noResort: ActiveListing = {
+      ...beachListing,
+      id: "5",
+      property: { ...beachListing.property, resort: null },
+    };
+    const result = filterByAttractions([noResort], new Set(["Beach"]));
+    expect(result).toHaveLength(0);
+  });
+});
+
+describe("getAvailableAttractions", () => {
+  it("returns unique tags from all listings", () => {
+    const listings = [
+      makeListing("1", ["Beach", "Spa"]),
+      makeListing("2", ["Golf", "Spa"]),
+      makeListing("3", ["Ski"]),
+    ];
+    const available = getAvailableAttractions(listings);
+    expect(available).toEqual(new Set(["Beach", "Spa", "Golf", "Ski"]));
+  });
+
+  it("returns empty set for listings with no tags", () => {
+    const listings = [makeListing("1", [])];
+    const available = getAvailableAttractions(listings);
+    expect(available.size).toBe(0);
+  });
+
+  it("ignores invalid tag values", () => {
+    const listings = [makeListing("1", ["Beach", "InvalidTag"])];
+    const available = getAvailableAttractions(listings);
+    expect(available).toEqual(new Set(["Beach"]));
+  });
+});

--- a/src/lib/attractionTags.ts
+++ b/src/lib/attractionTags.ts
@@ -1,0 +1,78 @@
+import type { ActiveListing } from "@/hooks/useListings";
+
+/**
+ * Attraction tag definitions for resort-level activity filtering.
+ * Tags live on the resorts table; listings inherit via property → resort FK.
+ */
+
+export type AttractionTag =
+  | "Beach"
+  | "Theme Park"
+  | "Golf"
+  | "Casino"
+  | "Ski"
+  | "Spa"
+  | "Mountain"
+  | "Lake";
+
+export interface AttractionTagDef {
+  tag: AttractionTag;
+  label: string;
+  /** Lucide icon name — imported dynamically in the UI component */
+  icon: string;
+}
+
+/**
+ * Ordered list of attraction tags with display metadata.
+ * Order determines pill bar rendering order.
+ */
+export const ATTRACTION_TAGS: AttractionTagDef[] = [
+  { tag: "Beach", label: "Beach", icon: "Palmtree" },
+  { tag: "Theme Park", label: "Theme Park", icon: "Ferris Wheel" },
+  { tag: "Golf", label: "Golf", icon: "Flag" },
+  { tag: "Casino", label: "Casino", icon: "Dice5" },
+  { tag: "Ski", label: "Ski", icon: "Snowflake" },
+  { tag: "Spa", label: "Spa", icon: "Sparkles" },
+  { tag: "Mountain", label: "Mountain", icon: "Mountain" },
+  { tag: "Lake", label: "Lake", icon: "Waves" },
+];
+
+/** All valid tag values as a flat array */
+export const ATTRACTION_TAG_VALUES: AttractionTag[] = ATTRACTION_TAGS.map((t) => t.tag);
+
+/**
+ * Filter listings by selected attraction tags (OR logic).
+ * Returns all listings if no tags selected.
+ * A listing matches if its resort has ANY of the selected tags.
+ */
+export function filterByAttractions(
+  listings: ActiveListing[],
+  selectedTags: Set<string>
+): ActiveListing[] {
+  if (selectedTags.size === 0) return listings;
+
+  return listings.filter((listing) => {
+    const resortTags = listing.property?.resort?.attraction_tags;
+    if (!resortTags || resortTags.length === 0) return false;
+    return resortTags.some((tag) => selectedTags.has(tag));
+  });
+}
+
+/**
+ * Get all unique attraction tags present across a set of listings.
+ * Useful for showing only relevant tags in the UI.
+ */
+export function getAvailableAttractions(listings: ActiveListing[]): Set<AttractionTag> {
+  const available = new Set<AttractionTag>();
+  for (const listing of listings) {
+    const tags = listing.property?.resort?.attraction_tags;
+    if (tags) {
+      for (const tag of tags) {
+        if (ATTRACTION_TAG_VALUES.includes(tag as AttractionTag)) {
+          available.add(tag as AttractionTag);
+        }
+      }
+    }
+  }
+  return available;
+}

--- a/src/lib/resortImportUtils.ts
+++ b/src/lib/resortImportUtils.ts
@@ -11,6 +11,7 @@ export interface ResortImportRow {
   };
   description?: string;
   resort_amenities?: string[];
+  attraction_tags?: string[];
   guest_rating?: number;
   nearby_airports?: string[];
 }
@@ -118,6 +119,7 @@ export function generateTemplateJson(): string {
       },
       description: "A beautiful resort with world-class amenities.",
       resort_amenities: ["Pool", "Spa", "Fitness Center", "Restaurant"],
+      attraction_tags: ["Beach", "Spa"],
       guest_rating: 4.5,
       nearby_airports: ["MCO", "SFB"],
     },

--- a/src/pages/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard.tsx
@@ -57,6 +57,7 @@ import { VoiceControls } from "@/components/admin/VoiceControls";
 import AdminDisputes from "@/components/admin/AdminDisputes";
 import AdminTaxReporting from "@/components/admin/AdminTaxReporting";
 import AdminResortImport from "@/components/admin/AdminResortImport";
+import AdminResortTagEditor from "@/components/admin/AdminResortTagEditor";
 import { LaunchReadinessChecklist } from "@/components/admin/LaunchReadinessChecklist";
 import AdminApiKeys from "@/components/admin/AdminApiKeys";
 import AdminNotificationCenter from "@/components/admin/AdminNotificationCenter";
@@ -409,7 +410,10 @@ const AdminDashboard = () => {
 
           {isRavAdmin() && (
             <TabsContent value="resorts">
-              <AdminResortImport />
+              <div className="space-y-6">
+                <AdminResortTagEditor />
+                <AdminResortImport />
+              </div>
             </TabsContent>
           )}
 

--- a/src/pages/Rentals.tsx
+++ b/src/pages/Rentals.tsx
@@ -29,6 +29,14 @@ import {
   Loader2,
   Mic,
   ArrowUpDown,
+  Palmtree,
+  FerrisWheel,
+  Flag,
+  Dice5,
+  Snowflake,
+  Sparkles,
+  Mountain as MountainIcon,
+  Waves,
 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { useVoiceSearch } from "@/hooks/useVoiceSearch";
@@ -43,7 +51,7 @@ import { useFavoriteIds, useToggleFavorite } from "@/hooks/useFavorites";
 import { useToast } from "@/hooks/use-toast";
 import { useActiveListings, type ActiveListing } from "@/hooks/useListings";
 import { useListingSocialProof } from "@/hooks/useListingSocialProof";
-import { ListingCard } from "@/components/ListingCard";
+import { ListingCard, BRAND_LABELS, getDisplayName, getLocation, getBrandLabel } from "@/components/ListingCard";
 import { useVoiceFeatureFlags } from "@/hooks/useVoiceFeatureFlags";
 import { ListingFairValueBadge } from "@/components/fair-value/ListingFairValueBadge";
 import { PostRequestCTA } from "@/components/bidding/PostRequestCTA";
@@ -53,9 +61,20 @@ import { CompareListingsDialog } from "@/components/CompareListingsDialog";
 import { trackEvent } from "@/lib/posthog";
 import { SaveSearchButton } from "@/components/SaveSearchButton";
 import { Checkbox } from "@/components/ui/checkbox";
+import { ATTRACTION_TAGS, filterByAttractions, type AttractionTag } from "@/lib/attractionTags";
 const ITEMS_PER_PAGE = 6;
 
-// Shared helpers now in ListingCard.tsx (BRAND_LABELS, getDisplayName, etc.)
+// Icon map for attraction tags (keyed by AttractionTagDef.icon)
+const ATTRACTION_ICON_MAP: Record<string, React.ComponentType<{ className?: string }>> = {
+  "Palmtree": Palmtree,
+  "Ferris Wheel": FerrisWheel,
+  "Flag": Flag,
+  "Dice5": Dice5,
+  "Snowflake": Snowflake,
+  "Sparkles": Sparkles,
+  "Mountain": MountainIcon,
+  "Waves": Waves,
+};
 
 const Rentals = () => {
   usePageMeta({
@@ -77,6 +96,7 @@ const Rentals = () => {
   const [minGuests, setMinGuests] = useState("");
   const [minBedrooms, setMinBedrooms] = useState("");
   const [brandFilter, setBrandFilter] = useState("");
+  const [selectedAttractions, setSelectedAttractions] = useState<Set<string>>(new Set());
   const [sortOption, setSortOption] = useState<SortOption>("newest");
 
   // Compare mode
@@ -149,44 +169,48 @@ const Rentals = () => {
     minGuests,
     minBedrooms,
     brandFilter && brandFilter !== "all" ? brandFilter : "",
+    selectedAttractions.size > 0 ? "attractions" : "",
   ].filter(Boolean).length;
 
   // Filter listings by all criteria
-  const filteredListings = listings.filter((listing) => {
-    // Text search (existing)
-    if (searchQuery.trim()) {
-      const q = searchQuery.toLowerCase();
-      const name = getListingDisplayName(listing).toLowerCase();
-      const location = getListingLocation(listing).toLowerCase();
-      const brand = getListingBrandLabel(listing).toLowerCase();
-      if (!location.includes(q) && !name.includes(q) && !brand.includes(q)) return false;
-    }
+  const filteredListings = filterByAttractions(
+    listings.filter((listing) => {
+      // Text search (existing)
+      if (searchQuery.trim()) {
+        const q = searchQuery.toLowerCase();
+        const name = getDisplayName(listing).toLowerCase();
+        const location = getLocation(listing).toLowerCase();
+        const brand = getBrandLabel(listing).toLowerCase();
+        if (!location.includes(q) && !name.includes(q) && !brand.includes(q)) return false;
+      }
 
-    // Date range overlap
-    if (dateRange?.from) {
-      const listingStart = new Date(listing.check_in_date);
-      const listingEnd = new Date(listing.check_out_date);
-      const filterEnd = dateRange.to || dateRange.from;
-      if (listingStart > filterEnd || listingEnd < dateRange.from) return false;
-    }
+      // Date range overlap
+      if (dateRange?.from) {
+        const listingStart = new Date(listing.check_in_date);
+        const listingEnd = new Date(listing.check_out_date);
+        const filterEnd = dateRange.to || dateRange.from;
+        if (listingStart > filterEnd || listingEnd < dateRange.from) return false;
+      }
 
-    // Price range
-    if (minPrice && listing.final_price < Number(minPrice)) return false;
-    if (maxPrice && listing.final_price > Number(maxPrice)) return false;
+      // Price range
+      if (minPrice && listing.final_price < Number(minPrice)) return false;
+      if (maxPrice && listing.final_price > Number(maxPrice)) return false;
 
-    // Guests
-    if (minGuests && listing.property.sleeps < Number(minGuests)) return false;
+      // Guests
+      if (minGuests && listing.property.sleeps < Number(minGuests)) return false;
 
-    // Bedrooms
-    if (minBedrooms && listing.property.bedrooms < Number(minBedrooms)) return false;
+      // Bedrooms
+      if (minBedrooms && listing.property.bedrooms < Number(minBedrooms)) return false;
 
-    // Brand (from filter panel dropdown)
-    if (brandFilter && brandFilter !== "all") {
-      if (listing.property.brand !== brandFilter) return false;
-    }
+      // Brand (from filter panel dropdown)
+      if (brandFilter && brandFilter !== "all") {
+        if (listing.property.brand !== brandFilter) return false;
+      }
 
-    return true;
-  });
+      return true;
+    }),
+    selectedAttractions
+  );
 
   // Sort
   const sortedListings = sortListings(filteredListings, sortOption);
@@ -202,7 +226,20 @@ const Rentals = () => {
   // Reset page when any filter changes
   useEffect(() => {
     setCurrentPage(1);
-  }, [searchQuery, dateRange, minPrice, maxPrice, minGuests, minBedrooms, brandFilter, sortOption]);
+  }, [searchQuery, dateRange, minPrice, maxPrice, minGuests, minBedrooms, brandFilter, selectedAttractions, sortOption]);
+
+  // Toggle attraction tag selection
+  const toggleAttraction = (tag: string) => {
+    setSelectedAttractions((prev) => {
+      const next = new Set(prev);
+      if (next.has(tag)) {
+        next.delete(tag);
+      } else {
+        next.add(tag);
+      }
+      return next;
+    });
+  };
 
   // Clear all filters helper
   const clearAllFilters = () => {
@@ -212,6 +249,7 @@ const Rentals = () => {
     setMinGuests("");
     setMinBedrooms("");
     setBrandFilter("");
+    setSelectedAttractions(new Set());
     setSearchQuery("");
     setShowFilters(false);
     setCurrentPage(1);
@@ -329,6 +367,45 @@ const Rentals = () => {
         </div>
       </section>
 
+      {/* Browse by Activity Pill Bar */}
+      <section className="pt-6 pb-0">
+        <div className="container mx-auto px-4">
+          <h3 className="text-sm font-medium text-muted-foreground mb-3">Browse by Activity</h3>
+          <div className="flex flex-wrap gap-2">
+            {ATTRACTION_TAGS.map((tagDef) => {
+              const Icon = ATTRACTION_ICON_MAP[tagDef.icon];
+              const isSelected = selectedAttractions.has(tagDef.tag);
+              return (
+                <button
+                  key={tagDef.tag}
+                  onClick={() => toggleAttraction(tagDef.tag)}
+                  className={`inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm font-medium transition-colors border ${
+                    isSelected
+                      ? "bg-primary text-primary-foreground border-primary"
+                      : "bg-card text-foreground border-border hover:bg-accent hover:text-accent-foreground"
+                  }`}
+                  aria-pressed={isSelected}
+                  aria-label={`Filter by ${tagDef.label}`}
+                >
+                  {Icon && <Icon className="w-4 h-4" />}
+                  {tagDef.label}
+                </button>
+              );
+            })}
+            {selectedAttractions.size > 0 && (
+              <button
+                onClick={() => setSelectedAttractions(new Set())}
+                className="inline-flex items-center gap-1 px-3 py-1.5 rounded-full text-sm text-muted-foreground hover:text-foreground transition-colors"
+                aria-label="Clear activity filters"
+              >
+                <X className="w-3.5 h-3.5" />
+                Clear
+              </button>
+            )}
+          </div>
+        </div>
+      </section>
+
       {/* Filters & Results */}
       <section className="py-8">
         <div className="container mx-auto px-4">
@@ -379,6 +456,7 @@ const Rentals = () => {
                   minGuests: minGuests || undefined,
                   minBedrooms: minBedrooms || undefined,
                   brandFilter: brandFilter || undefined,
+                  attractionTags: selectedAttractions.size > 0 ? Array.from(selectedAttractions) : undefined,
                   dateFrom: dateRange?.from ? format(dateRange.from, 'yyyy-MM-dd') : undefined,
                   dateTo: dateRange?.to ? format(dateRange.to, 'yyyy-MM-dd') : undefined,
                 }}

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -2425,6 +2425,7 @@ export interface Resort {
     website: string;
   } | null;
   resort_amenities: string[];
+  attraction_tags: string[];
   policies: {
     check_in: string;
     check_out: string;

--- a/supabase/functions/seed-manager/index.ts
+++ b/supabase/functions/seed-manager/index.ts
@@ -644,6 +644,28 @@ async function createInventory(
 
   log.push(`Created ${propertyIds.length} properties`);
 
+  // Update resort attraction_tags for seed resorts
+  const resortTagMap: Record<string, string[]> = {
+    "Elara": ["Casino", "Spa"],
+    "Parc Soleil": ["Theme Park"],
+    "Grande Vista": ["Theme Park", "Golf"],
+    "Ko Olina": ["Beach", "Spa"],
+    "Animal Kingdom": ["Theme Park"],
+    "Beach Club": ["Theme Park", "Beach"],
+    "Bonnet Creek": ["Theme Park"],
+    "Ocean Walk": ["Beach"],
+    "Solterra": ["Theme Park"],
+    "Myrtle Beach": ["Beach", "Golf"],
+  };
+
+  for (const [nameFragment, tags] of Object.entries(resortTagMap)) {
+    await admin
+      .from("resorts")
+      .update({ attraction_tags: tags })
+      .ilike("resort_name", `%${nameFragment}%`);
+  }
+  log.push("Updated resort attraction_tags for seed data");
+
   // Create 30 listings across all properties
   const cancellationPolicies = ["flexible", "moderate", "strict", "super_strict"];
   const ownerEmails = [

--- a/supabase/migrations/053_attraction_tags.sql
+++ b/supabase/migrations/053_attraction_tags.sql
@@ -1,0 +1,155 @@
+-- Migration 053: Attraction-Based Filtering (#328)
+-- Adds attraction_tags TEXT[] to resorts table for activity-based discovery
+-- Tags: Beach, Theme Park, Golf, Casino, Ski, Spa, Mountain, Lake
+
+-- ============================================================
+-- 1. Add attraction_tags column to resorts
+-- ============================================================
+DO $$ BEGIN
+  ALTER TABLE resorts ADD COLUMN attraction_tags TEXT[] DEFAULT '{}';
+EXCEPTION
+  WHEN duplicate_column THEN NULL;
+END $$;
+
+-- GIN index for array containment queries (e.g., attraction_tags && ARRAY['Beach'])
+CREATE INDEX IF NOT EXISTS idx_resorts_attraction_tags ON resorts USING gin(attraction_tags);
+
+-- ============================================================
+-- 2. Backfill resorts with attraction tags based on name/location patterns
+-- ============================================================
+
+-- Beach resorts (coastal, oceanfront, island)
+UPDATE resorts SET attraction_tags = array_cat(attraction_tags, ARRAY['Beach'])
+WHERE (
+  resort_name ILIKE '%beach%'
+  OR resort_name ILIKE '%ocean%'
+  OR resort_name ILIKE '%island%'
+  OR resort_name ILIKE '%surf%'
+  OR resort_name ILIKE '%bay%'
+  OR resort_name ILIKE '%shore%'
+  OR resort_name ILIKE '%coast%'
+  OR resort_name ILIKE '%lagoon%'
+  OR resort_name ILIKE '%palm%'
+  OR resort_name ILIKE '%coral%'
+  OR resort_name ILIKE '%ko olina%'
+  OR resort_name ILIKE '%wailea%'
+  OR resort_name ILIKE '%waikoloa%'
+  OR resort_name ILIKE '%hawaiian village%'
+  OR resort_name ILIKE '%flamingo%'
+  OR resort_name ILIKE '%aruba%'
+  OR resort_name ILIKE '%cancun%'
+  OR resort_name ILIKE '%key west%'
+  OR resort_name ILIKE '%myrtle%'
+  OR resort_name ILIKE '%daytona%'
+  OR resort_name ILIKE '%maui%'
+  OR resort_name ILIKE '%kauai%'
+  OR resort_name ILIKE '%hilton head%'
+  OR resort_name ILIKE '%cabo%'
+  OR resort_name ILIKE '%puerto%'
+  OR resort_name ILIKE '%virgin%'
+  OR resort_name ILIKE '%seaside%'
+  OR resort_name ILIKE '%sandcastle%'
+  OR (location->>'state' IN ('HI') AND NOT resort_name ILIKE '%mountain%')
+)
+AND NOT ('Beach' = ANY(attraction_tags));
+
+-- Theme Park resorts (Disney, Orlando area near parks)
+UPDATE resorts SET attraction_tags = array_cat(attraction_tags, ARRAY['Theme Park'])
+WHERE (
+  resort_name ILIKE '%disney%'
+  OR resort_name ILIKE '%animal kingdom%'
+  OR resort_name ILIKE '%epcot%'
+  OR resort_name ILIKE '%bonnet creek%'
+  OR resort_name ILIKE '%solterra%'
+  OR (resort_name ILIKE '%orlando%' AND brand = 'disney_vacation_club')
+  OR (brand = 'disney_vacation_club')
+)
+AND NOT ('Theme Park' = ANY(attraction_tags));
+
+-- Golf resorts
+UPDATE resorts SET attraction_tags = array_cat(attraction_tags, ARRAY['Golf'])
+WHERE (
+  resort_name ILIKE '%golf%'
+  OR resort_name ILIKE '%grande vista%'
+  OR resort_name ILIKE '%waikoloa%'
+  OR resort_name ILIKE '%scottsdale%'
+  OR resort_name ILIKE '%desert%'
+  OR resort_name ILIKE '%plantation%'
+  OR resort_name ILIKE '%hilton head%'
+  OR resort_name ILIKE '%pinehurst%'
+  OR resort_name ILIKE '%kiawah%'
+)
+AND NOT ('Golf' = ANY(attraction_tags));
+
+-- Casino resorts (Las Vegas, Atlantic City, Reno)
+UPDATE resorts SET attraction_tags = array_cat(attraction_tags, ARRAY['Casino'])
+WHERE (
+  resort_name ILIKE '%las vegas%'
+  OR resort_name ILIKE '%elara%'
+  OR resort_name ILIKE '%flamingo%'
+  OR resort_name ILIKE '%atlantic city%'
+  OR resort_name ILIKE '%reno%'
+  OR resort_name ILIKE '%tahoe%'
+  OR (location->>'city' ILIKE '%las vegas%')
+  OR (location->>'city' ILIKE '%atlantic city%')
+)
+AND NOT ('Casino' = ANY(attraction_tags));
+
+-- Ski resorts
+UPDATE resorts SET attraction_tags = array_cat(attraction_tags, ARRAY['Ski'])
+WHERE (
+  resort_name ILIKE '%ski%'
+  OR resort_name ILIKE '%park city%'
+  OR resort_name ILIKE '%whistler%'
+  OR resort_name ILIKE '%breckenridge%'
+  OR resort_name ILIKE '%vail%'
+  OR resort_name ILIKE '%aspen%'
+  OR resort_name ILIKE '%mammoth%'
+  OR resort_name ILIKE '%steamboat%'
+  OR resort_name ILIKE '%telluride%'
+  OR resort_name ILIKE '%tahoe%'
+  OR resort_name ILIKE '%big sky%'
+  OR resort_name ILIKE '%snowmass%'
+)
+AND NOT ('Ski' = ANY(attraction_tags));
+
+-- Spa resorts
+UPDATE resorts SET attraction_tags = array_cat(attraction_tags, ARRAY['Spa'])
+WHERE (
+  resort_name ILIKE '%spa%'
+  OR resort_name ILIKE '%sedona%'
+  OR resort_name ILIKE '%wailea%'
+  OR resort_name ILIKE '%grand wailea%'
+  OR resort_name ILIKE '%canyon%'
+  OR resort_name ILIKE '%sanctuary%'
+  OR resort_name ILIKE '%wellness%'
+)
+AND NOT ('Spa' = ANY(attraction_tags));
+
+-- Mountain resorts
+UPDATE resorts SET attraction_tags = array_cat(attraction_tags, ARRAY['Mountain'])
+WHERE (
+  resort_name ILIKE '%mountain%'
+  OR resort_name ILIKE '%lodge%'
+  OR resort_name ILIKE '%ridge%'
+  OR resort_name ILIKE '%summit%'
+  OR resort_name ILIKE '%highland%'
+  OR resort_name ILIKE '%smoky%'
+  OR resort_name ILIKE '%gatlinburg%'
+  OR resort_name ILIKE '%pigeon forge%'
+  OR resort_name ILIKE '%blue ridge%'
+  OR resort_name ILIKE '%sedona%'
+  OR (location->>'state' IN ('CO', 'UT', 'MT', 'WY') AND NOT resort_name ILIKE '%beach%')
+)
+AND NOT ('Mountain' = ANY(attraction_tags));
+
+-- Lake resorts
+UPDATE resorts SET attraction_tags = array_cat(attraction_tags, ARRAY['Lake'])
+WHERE (
+  resort_name ILIKE '%lake%'
+  OR resort_name ILIKE '%lakeside%'
+  OR resort_name ILIKE '%tahoe%'
+  OR resort_name ILIKE '%ozark%'
+  OR resort_name ILIKE '%waterfront%'
+)
+AND NOT ('Lake' = ANY(attraction_tags));


### PR DESCRIPTION
## Summary
- Adds icon-based "Browse by Activity" pill bar on Rentals page for activity-based discovery (Beach, Golf, Casino, Theme Park, Ski, Spa, Mountain, Lake)
- Multi-select OR-logic filtering via resort-level `attraction_tags` column
- Admin tag editing UI in RAV Ops Resorts tab
- Fixes pre-existing bug where text search filter called undefined helper functions

## Changes
- **Migration 053:** `attraction_tags TEXT[]` on resorts with GIN index + pattern-based backfill
- **`attractionTags.ts`:** Tag definitions with Lucide icons, `filterByAttractions()` utility
- **Rentals.tsx:** Pill bar above toolbar, filter integration, saved search support
- **AdminResortTagEditor:** Inline per-resort tag editing with search
- **Resort import:** `attraction_tags` in template + insert
- **Seed manager:** Tags for 10 test resorts
- **SavedSearches:** `attractionTags` in criteria, summary, URL params

## Test plan
- [x] 13 new unit tests for attraction tag utilities (969 total, 122 files)
- [x] TypeScript: 0 errors
- [x] Build: clean
- [x] P0 critical path: passing
- [ ] Visual: verify pill bar renders with icons on /rentals
- [ ] Verify multi-select OR filtering works correctly
- [ ] Verify admin tag editing saves and reflects in listings

🤖 Generated with [Claude Code](https://claude.com/claude-code)