### PR TITLE
feat(marketplace): #327 + #328 search discovery — events + attractions + hotfix

### DIFF
--- a/src/hooks/useSavedSearches.ts
+++ b/src/hooks/useSavedSearches.ts
@@ -10,6 +10,7 @@ export interface SearchCriteria {
   minBedrooms?: string;
   brandFilter?: string;
   attractionTags?: string[];
+  eventSlug?: string;
   dateFrom?: string;
   dateTo?: string;
 }
@@ -102,6 +103,7 @@ export function summarizeCriteria(criteria: SearchCriteria): string {
   if (criteria.minGuests) parts.push(`${criteria.minGuests}+ guests`);
   if (criteria.minBedrooms) parts.push(`${criteria.minBedrooms}+ beds`);
   if (criteria.attractionTags?.length) parts.push(criteria.attractionTags.join(', '));
+  if (criteria.eventSlug) parts.push(`event: ${criteria.eventSlug.replace(/-/g, ' ')}`);
   if (criteria.dateFrom) parts.push(`from ${criteria.dateFrom}`);
 
   return parts.length > 0 ? parts.join(', ') : 'All listings';
@@ -117,6 +119,7 @@ export function criteriaToSearchParams(criteria: SearchCriteria): string {
   if (criteria.minGuests) params.set('minGuests', criteria.minGuests);
   if (criteria.minBedrooms) params.set('minBedrooms', criteria.minBedrooms);
   if (criteria.attractionTags?.length) params.set('attractions', criteria.attractionTags.join(','));
+  if (criteria.eventSlug) params.set('event', criteria.eventSlug);
   return params.toString();
 }
 
@@ -130,6 +133,7 @@ export function hasActiveFilters(criteria: SearchCriteria): boolean {
     criteria.minBedrooms ||
     criteria.brandFilter ||
     (criteria.attractionTags && criteria.attractionTags.length > 0) ||
+    criteria.eventSlug ||
     criteria.dateFrom
   );
 }

--- a/src/lib/events.test.ts
+++ b/src/lib/events.test.ts
@@ -1,0 +1,264 @@
+import { describe, it, expect } from "vitest";
+import {
+  CURATED_EVENTS,
+  dateRangesOverlap,
+  doesListingMatchEvent,
+  filterByEvent,
+  getUpcomingEvents,
+  findEventsByQuery,
+  formatEventDateRange,
+  type CuratedEvent,
+} from "./events";
+import type { ActiveListing } from "@/hooks/useListings";
+
+// Helper to create a minimal listing
+function makeListing(
+  id: string,
+  checkIn: string,
+  checkOut: string,
+  city: string,
+  state: string
+): ActiveListing {
+  return {
+    id,
+    property_id: `prop-${id}`,
+    owner_id: "owner-1",
+    status: "active",
+    check_in_date: checkIn,
+    check_out_date: checkOut,
+    final_price: 1000,
+    owner_price: 870,
+    rav_markup: 130,
+    nightly_rate: 143,
+    notes: null,
+    cancellation_policy: "moderate",
+    open_for_bidding: true,
+    bidding_ends_at: null,
+    min_bid_amount: null,
+    created_at: "2026-04-01",
+    property: {
+      id: `prop-${id}`,
+      owner_id: "owner-1",
+      brand: "hilton_grand_vacations",
+      resort_name: "Test Resort",
+      location: `${city}, ${state}`,
+      description: null,
+      bedrooms: 2,
+      bathrooms: 2,
+      sleeps: 6,
+      amenities: [],
+      images: [],
+      resort_id: null,
+      unit_type_id: null,
+      resort: {
+        id: "resort-1",
+        brand: "hilton_grand_vacations" as const,
+        resort_name: "Test Resort",
+        location: { city, state, country: "US", full_address: "" },
+        description: null,
+        contact: null,
+        resort_amenities: [],
+        attraction_tags: [],
+        policies: null,
+        nearby_airports: [],
+        guest_rating: null,
+        main_image_url: null,
+        additional_images: [],
+        created_at: "",
+        updated_at: "",
+      },
+      unit_type: null,
+    },
+  };
+}
+
+describe("CURATED_EVENTS data integrity", () => {
+  it("has 14 curated events", () => {
+    expect(CURATED_EVENTS.length).toBe(14);
+  });
+
+  it("all events have unique slugs", () => {
+    const slugs = CURATED_EVENTS.map((e) => e.slug);
+    expect(new Set(slugs).size).toBe(slugs.length);
+  });
+
+  it("all events have valid date ranges (start <= end)", () => {
+    for (const event of CURATED_EVENTS) {
+      expect(event.dateRange.start <= event.dateRange.end).toBe(true);
+    }
+  });
+
+  it("nationwide events have empty destinations array", () => {
+    const nationwide = CURATED_EVENTS.filter((e) => e.nationwide);
+    for (const event of nationwide) {
+      expect(event.destinations).toEqual([]);
+    }
+  });
+
+  it("non-nationwide events have at least one destination", () => {
+    const local = CURATED_EVENTS.filter((e) => !e.nationwide);
+    for (const event of local) {
+      expect(event.destinations.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("all events have an icon defined", () => {
+    for (const event of CURATED_EVENTS) {
+      expect(event.icon).toBeTruthy();
+    }
+  });
+});
+
+describe("dateRangesOverlap", () => {
+  it("returns true for overlapping ranges", () => {
+    expect(dateRangesOverlap("2026-03-01", "2026-03-10", "2026-03-05", "2026-03-15")).toBe(true);
+  });
+
+  it("returns true when ranges share a single day", () => {
+    expect(dateRangesOverlap("2026-03-01", "2026-03-10", "2026-03-10", "2026-03-20")).toBe(true);
+  });
+
+  it("returns false for non-overlapping ranges", () => {
+    expect(dateRangesOverlap("2026-03-01", "2026-03-10", "2026-03-11", "2026-03-20")).toBe(false);
+  });
+
+  it("returns true when one range contains the other", () => {
+    expect(dateRangesOverlap("2026-03-01", "2026-03-31", "2026-03-10", "2026-03-15")).toBe(true);
+  });
+
+  it("returns true for identical ranges", () => {
+    expect(dateRangesOverlap("2026-03-01", "2026-03-10", "2026-03-01", "2026-03-10")).toBe(true);
+  });
+});
+
+describe("doesListingMatchEvent", () => {
+  const springBreakEast: CuratedEvent = CURATED_EVENTS.find((e) => e.slug === "spring-break-east")!;
+  const fourthOfJuly: CuratedEvent = CURATED_EVENTS.find((e) => e.slug === "fourth-of-july-2026")!;
+
+  it("matches listing with date overlap + destination match", () => {
+    const listing = makeListing("1", "2026-03-10", "2026-03-17", "Orlando", "FL");
+    expect(doesListingMatchEvent(listing, springBreakEast)).toBe(true);
+  });
+
+  it("rejects listing with date overlap but wrong destination", () => {
+    const listing = makeListing("2", "2026-03-10", "2026-03-17", "Las Vegas", "NV");
+    expect(doesListingMatchEvent(listing, springBreakEast)).toBe(false);
+  });
+
+  it("rejects listing with right destination but no date overlap", () => {
+    const listing = makeListing("3", "2026-06-01", "2026-06-08", "Orlando", "FL");
+    expect(doesListingMatchEvent(listing, springBreakEast)).toBe(false);
+  });
+
+  it("matches any destination for nationwide events", () => {
+    const listing = makeListing("4", "2026-07-01", "2026-07-05", "Las Vegas", "NV");
+    expect(doesListingMatchEvent(listing, fourthOfJuly)).toBe(true);
+  });
+
+  it("still requires date overlap for nationwide events", () => {
+    const listing = makeListing("5", "2026-08-01", "2026-08-08", "Orlando", "FL");
+    expect(doesListingMatchEvent(listing, fourthOfJuly)).toBe(false);
+  });
+});
+
+describe("filterByEvent", () => {
+  const listings = [
+    makeListing("1", "2026-03-10", "2026-03-17", "Orlando", "FL"),
+    makeListing("2", "2026-03-12", "2026-03-19", "Miami", "FL"),
+    makeListing("3", "2026-03-10", "2026-03-17", "Las Vegas", "NV"),
+    makeListing("4", "2026-06-01", "2026-06-08", "Orlando", "FL"),
+  ];
+
+  it("returns all listings when no event selected", () => {
+    expect(filterByEvent(listings, null)).toHaveLength(4);
+  });
+
+  it("filters by spring break east (date + destination)", () => {
+    const result = filterByEvent(listings, "spring-break-east");
+    expect(result).toHaveLength(2);
+    expect(result.map((l) => l.id).sort()).toEqual(["1", "2"]);
+  });
+
+  it("returns all listings for unknown event slug", () => {
+    expect(filterByEvent(listings, "nonexistent")).toHaveLength(4);
+  });
+});
+
+describe("getUpcomingEvents", () => {
+  it("returns events with end date >= reference date", () => {
+    const upcoming = getUpcomingEvents("2026-06-01");
+    expect(upcoming.every((e) => e.dateRange.end >= "2026-06-01")).toBe(true);
+  });
+
+  it("returns events sorted by start date", () => {
+    const upcoming = getUpcomingEvents("2026-01-01");
+    for (let i = 1; i < upcoming.length; i++) {
+      expect(upcoming[i].dateRange.start >= upcoming[i - 1].dateRange.start).toBe(true);
+    }
+  });
+
+  it("respects limit parameter", () => {
+    const upcoming = getUpcomingEvents("2026-01-01", 3);
+    expect(upcoming).toHaveLength(3);
+  });
+
+  it("filters out past events", () => {
+    const upcoming = getUpcomingEvents("2027-12-01");
+    expect(upcoming).toHaveLength(0);
+  });
+});
+
+describe("findEventsByQuery", () => {
+  it("finds events by partial name match", () => {
+    const results = findEventsByQuery("super bowl");
+    expect(results).toHaveLength(1);
+    expect(results[0].slug).toBe("super-bowl-lx");
+  });
+
+  it("finds multiple matches", () => {
+    const results = findEventsByQuery("spring");
+    expect(results).toHaveLength(2);
+  });
+
+  it("returns empty for no match", () => {
+    expect(findEventsByQuery("olympics")).toHaveLength(0);
+  });
+
+  it("returns empty for empty query", () => {
+    expect(findEventsByQuery("")).toHaveLength(0);
+  });
+
+  it("is case insensitive", () => {
+    expect(findEventsByQuery("MARDI GRAS")).toHaveLength(1);
+  });
+});
+
+describe("formatEventDateRange", () => {
+  it("formats same-month range correctly", () => {
+    const event: CuratedEvent = {
+      slug: "test",
+      name: "Test",
+      category: "major_holiday",
+      dateRange: { start: "2026-03-07", end: "2026-03-21" },
+      year: 2026,
+      destinations: [],
+      nationwide: true,
+      icon: "Sun",
+    };
+    expect(formatEventDateRange(event)).toBe("Mar 7–21");
+  });
+
+  it("formats cross-month range correctly", () => {
+    const event: CuratedEvent = {
+      slug: "test",
+      name: "Test",
+      category: "major_holiday",
+      dateRange: { start: "2026-12-19", end: "2027-01-03" },
+      year: 2026,
+      destinations: [],
+      nationwide: true,
+      icon: "Gift",
+    };
+    expect(formatEventDateRange(event)).toBe("Dec 19 – Jan 3");
+  });
+});

--- a/src/lib/events.ts
+++ b/src/lib/events.ts
@@ -1,0 +1,257 @@
+import type { ActiveListing } from "@/hooks/useListings";
+import { getLocation } from "@/components/ListingCard";
+
+/**
+ * Curated event data for event-based search filtering.
+ * Static for now — structured for easy migration to a DB table later.
+ * Update quarterly to keep dates current.
+ */
+
+export type EventCategory = "major_holiday" | "sports" | "cultural" | "school_break" | "peak_season";
+
+export interface CuratedEvent {
+  slug: string;
+  name: string;
+  category: EventCategory;
+  dateRange: { start: string; end: string }; // ISO dates (YYYY-MM-DD)
+  year: number;
+  /** City/state names that match getLocation() output format (e.g., "Orlando", "Las Vegas", "HI") */
+  destinations: string[];
+  /** If true, matches all destinations (nationwide events) */
+  nationwide: boolean;
+  icon: string; // Lucide icon name
+}
+
+/**
+ * Curated events for 2026. Ordered roughly by date.
+ * Destinations use city/state names that match resort location strings.
+ */
+export const CURATED_EVENTS: CuratedEvent[] = [
+  {
+    slug: "sundance-2026",
+    name: "Sundance Film Festival",
+    category: "cultural",
+    dateRange: { start: "2026-01-22", end: "2026-02-01" },
+    year: 2026,
+    destinations: ["Park City"],
+    nationwide: false,
+    icon: "Film",
+  },
+  {
+    slug: "super-bowl-lx",
+    name: "Super Bowl LX",
+    category: "sports",
+    dateRange: { start: "2026-02-04", end: "2026-02-10" },
+    year: 2026,
+    destinations: ["Santa Clara", "San Francisco", "San Jose"],
+    nationwide: false,
+    icon: "Trophy",
+  },
+  {
+    slug: "mardi-gras-2026",
+    name: "Mardi Gras",
+    category: "cultural",
+    dateRange: { start: "2026-02-12", end: "2026-02-18" },
+    year: 2026,
+    destinations: ["New Orleans", "Orlando", "Miami"],
+    nationwide: false,
+    icon: "PartyPopper",
+  },
+  {
+    slug: "spring-break-east",
+    name: "Spring Break (East Coast)",
+    category: "school_break",
+    dateRange: { start: "2026-03-07", end: "2026-03-21" },
+    year: 2026,
+    destinations: ["Orlando", "Miami", "Tampa", "Myrtle Beach", "Daytona Beach"],
+    nationwide: false,
+    icon: "Sun",
+  },
+  {
+    slug: "spring-break-west",
+    name: "Spring Break (West Coast)",
+    category: "school_break",
+    dateRange: { start: "2026-03-14", end: "2026-03-28" },
+    year: 2026,
+    destinations: ["Cancun", "Cabo San Lucas", "Maui", "Oahu", "San Diego"],
+    nationwide: false,
+    icon: "Sun",
+  },
+  {
+    slug: "masters-golf-2026",
+    name: "The Masters",
+    category: "sports",
+    dateRange: { start: "2026-04-06", end: "2026-04-12" },
+    year: 2026,
+    destinations: ["Hilton Head", "Myrtle Beach", "Charleston"],
+    nationwide: false,
+    icon: "Flag",
+  },
+  {
+    slug: "memorial-day-2026",
+    name: "Memorial Day Weekend",
+    category: "major_holiday",
+    dateRange: { start: "2026-05-22", end: "2026-05-26" },
+    year: 2026,
+    destinations: [],
+    nationwide: true,
+    icon: "Flag",
+  },
+  {
+    slug: "summer-peak-2026",
+    name: "Summer Peak Season",
+    category: "peak_season",
+    dateRange: { start: "2026-06-15", end: "2026-08-15" },
+    year: 2026,
+    destinations: [],
+    nationwide: true,
+    icon: "Sun",
+  },
+  {
+    slug: "fourth-of-july-2026",
+    name: "Fourth of July",
+    category: "major_holiday",
+    dateRange: { start: "2026-06-27", end: "2026-07-06" },
+    year: 2026,
+    destinations: [],
+    nationwide: true,
+    icon: "Sparkles",
+  },
+  {
+    slug: "labor-day-2026",
+    name: "Labor Day Weekend",
+    category: "major_holiday",
+    dateRange: { start: "2026-09-04", end: "2026-09-08" },
+    year: 2026,
+    destinations: [],
+    nationwide: true,
+    icon: "Palmtree",
+  },
+  {
+    slug: "halloween-orlando-2026",
+    name: "Halloween at the Parks",
+    category: "cultural",
+    dateRange: { start: "2026-10-24", end: "2026-11-01" },
+    year: 2026,
+    destinations: ["Orlando"],
+    nationwide: false,
+    icon: "Ghost",
+  },
+  {
+    slug: "thanksgiving-2026",
+    name: "Thanksgiving Week",
+    category: "major_holiday",
+    dateRange: { start: "2026-11-21", end: "2026-11-29" },
+    year: 2026,
+    destinations: [],
+    nationwide: true,
+    icon: "UtensilsCrossed",
+  },
+  {
+    slug: "ski-season-2026",
+    name: "Ski Season",
+    category: "peak_season",
+    dateRange: { start: "2026-12-01", end: "2027-03-31" },
+    year: 2026,
+    destinations: ["Vail", "Breckenridge", "Aspen", "Steamboat Springs", "Park City", "Lake Tahoe"],
+    nationwide: false,
+    icon: "Snowflake",
+  },
+  {
+    slug: "holiday-season-2026",
+    name: "Holiday Season",
+    category: "major_holiday",
+    dateRange: { start: "2026-12-19", end: "2027-01-03" },
+    year: 2026,
+    destinations: [],
+    nationwide: true,
+    icon: "Gift",
+  },
+];
+
+/**
+ * Check if two date ranges overlap.
+ * Range A: [aStart, aEnd], Range B: [bStart, bEnd]
+ * Overlap if aStart <= bEnd AND aEnd >= bStart.
+ */
+export function dateRangesOverlap(
+  aStart: string,
+  aEnd: string,
+  bStart: string,
+  bEnd: string
+): boolean {
+  return aStart <= bEnd && aEnd >= bStart;
+}
+
+/**
+ * Check if a listing matches an event (date overlap + destination match).
+ */
+export function doesListingMatchEvent(listing: ActiveListing, event: CuratedEvent): boolean {
+  // Date overlap check
+  const hasDateOverlap = dateRangesOverlap(
+    listing.check_in_date,
+    listing.check_out_date,
+    event.dateRange.start,
+    event.dateRange.end
+  );
+  if (!hasDateOverlap) return false;
+
+  // Nationwide events match all destinations
+  if (event.nationwide) return true;
+
+  // Destination match — check if listing location contains any event destination
+  const locationStr = getLocation(listing).toLowerCase();
+  return event.destinations.some((dest) => locationStr.includes(dest.toLowerCase()));
+}
+
+/**
+ * Filter listings by a selected event.
+ * Returns all listings if no event slug provided.
+ */
+export function filterByEvent(
+  listings: ActiveListing[],
+  eventSlug: string | null
+): ActiveListing[] {
+  if (!eventSlug) return listings;
+
+  const event = CURATED_EVENTS.find((e) => e.slug === eventSlug);
+  if (!event) return listings;
+
+  return listings.filter((listing) => doesListingMatchEvent(listing, event));
+}
+
+/**
+ * Get upcoming events (not yet ended), sorted by start date proximity.
+ */
+export function getUpcomingEvents(referenceDate?: string, limit?: number): CuratedEvent[] {
+  const ref = referenceDate || new Date().toISOString().split("T")[0];
+
+  const upcoming = CURATED_EVENTS.filter((e) => e.dateRange.end >= ref);
+  upcoming.sort((a, b) => a.dateRange.start.localeCompare(b.dateRange.start));
+
+  return limit ? upcoming.slice(0, limit) : upcoming;
+}
+
+/**
+ * Find events matching a search query (for text search integration).
+ * Returns matching event slugs.
+ */
+export function findEventsByQuery(query: string): CuratedEvent[] {
+  if (!query.trim()) return [];
+  const q = query.toLowerCase();
+  return CURATED_EVENTS.filter((e) => e.name.toLowerCase().includes(q));
+}
+
+/**
+ * Format event date range for display.
+ */
+export function formatEventDateRange(event: CuratedEvent): string {
+  const start = new Date(event.dateRange.start + "T00:00:00");
+  const end = new Date(event.dateRange.end + "T00:00:00");
+  const monthNames = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+
+  if (start.getMonth() === end.getMonth() && start.getFullYear() === end.getFullYear()) {
+    return `${monthNames[start.getMonth()]} ${start.getDate()}–${end.getDate()}`;
+  }
+  return `${monthNames[start.getMonth()]} ${start.getDate()} – ${monthNames[end.getMonth()]} ${end.getDate()}`;
+}

--- a/src/pages/Rentals.tsx
+++ b/src/pages/Rentals.tsx
@@ -41,6 +41,13 @@ import {
   Sparkles,
   Mountain as MountainIcon,
   Waves,
+  Film,
+  Trophy,
+  PartyPopper,
+  Sun,
+  Ghost,
+  UtensilsCrossed,
+  Gift,
 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { useVoiceSearch } from "@/hooks/useVoiceSearch";
@@ -66,6 +73,7 @@ import { trackEvent } from "@/lib/posthog";
 import { SaveSearchButton } from "@/components/SaveSearchButton";
 import { Checkbox } from "@/components/ui/checkbox";
 import { ATTRACTION_TAGS, filterByAttractions, type AttractionTag } from "@/lib/attractionTags";
+import { getUpcomingEvents, filterByEvent, formatEventDateRange, type CuratedEvent } from "@/lib/events";
 const ITEMS_PER_PAGE = 6;
 
 // Icon map for attraction tags (keyed by AttractionTagDef.icon)
@@ -78,6 +86,21 @@ const ATTRACTION_ICON_MAP: Record<string, React.ComponentType<{ className?: stri
   "Sparkles": Sparkles,
   "Mountain": MountainIcon,
   "Waves": Waves,
+};
+
+// Icon map for event categories (keyed by CuratedEvent.icon)
+const EVENT_ICON_MAP: Record<string, React.ComponentType<{ className?: string }>> = {
+  "Film": Film,
+  "Trophy": Trophy,
+  "PartyPopper": PartyPopper,
+  "Sun": Sun,
+  "Flag": Flag,
+  "Snowflake": Snowflake,
+  "Sparkles": Sparkles,
+  "Ghost": Ghost,
+  "UtensilsCrossed": UtensilsCrossed,
+  "Gift": Gift,
+  "Palmtree": Palmtree,
 };
 
 const Rentals = () => {
@@ -101,7 +124,11 @@ const Rentals = () => {
   const [minBedrooms, setMinBedrooms] = useState("");
   const [brandFilter, setBrandFilter] = useState("");
   const [selectedAttractions, setSelectedAttractions] = useState<Set<string>>(new Set());
+  const [selectedEvent, setSelectedEvent] = useState<string | null>(null);
   const [sortOption, setSortOption] = useState<SortOption>("newest");
+
+  // Upcoming events for pill bar
+  const upcomingEvents = getUpcomingEvents(undefined, 8);
 
   // Compare mode
   const [compareMode, setCompareMode] = useState(false);
@@ -174,46 +201,50 @@ const Rentals = () => {
     minBedrooms,
     brandFilter && brandFilter !== "all" ? brandFilter : "",
     selectedAttractions.size > 0 ? "attractions" : "",
+    selectedEvent || "",
   ].filter(Boolean).length;
 
   // Filter listings by all criteria
-  const filteredListings = filterByAttractions(
-    listings.filter((listing) => {
-      // Text search (existing)
-      if (searchQuery.trim()) {
-        const q = searchQuery.toLowerCase();
-        const name = getDisplayName(listing).toLowerCase();
-        const location = getLocation(listing).toLowerCase();
-        const brand = getBrandLabel(listing).toLowerCase();
-        if (!location.includes(q) && !name.includes(q) && !brand.includes(q)) return false;
-      }
+  const baseFiltered = listings.filter((listing) => {
+    // Text search (existing)
+    if (searchQuery.trim()) {
+      const q = searchQuery.toLowerCase();
+      const name = getDisplayName(listing).toLowerCase();
+      const location = getLocation(listing).toLowerCase();
+      const brand = getBrandLabel(listing).toLowerCase();
+      if (!location.includes(q) && !name.includes(q) && !brand.includes(q)) return false;
+    }
 
-      // Date range overlap
-      if (dateRange?.from) {
-        const listingStart = new Date(listing.check_in_date);
-        const listingEnd = new Date(listing.check_out_date);
-        const filterEnd = dateRange.to || dateRange.from;
-        if (listingStart > filterEnd || listingEnd < dateRange.from) return false;
-      }
+    // Date range overlap
+    if (dateRange?.from) {
+      const listingStart = new Date(listing.check_in_date);
+      const listingEnd = new Date(listing.check_out_date);
+      const filterEnd = dateRange.to || dateRange.from;
+      if (listingStart > filterEnd || listingEnd < dateRange.from) return false;
+    }
 
-      // Price range
-      if (minPrice && listing.final_price < Number(minPrice)) return false;
-      if (maxPrice && listing.final_price > Number(maxPrice)) return false;
+    // Price range
+    if (minPrice && listing.final_price < Number(minPrice)) return false;
+    if (maxPrice && listing.final_price > Number(maxPrice)) return false;
 
-      // Guests
-      if (minGuests && listing.property.sleeps < Number(minGuests)) return false;
+    // Guests
+    if (minGuests && listing.property.sleeps < Number(minGuests)) return false;
 
-      // Bedrooms
-      if (minBedrooms && listing.property.bedrooms < Number(minBedrooms)) return false;
+    // Bedrooms
+    if (minBedrooms && listing.property.bedrooms < Number(minBedrooms)) return false;
 
-      // Brand (from filter panel dropdown)
-      if (brandFilter && brandFilter !== "all") {
-        if (listing.property.brand !== brandFilter) return false;
-      }
+    // Brand (from filter panel dropdown)
+    if (brandFilter && brandFilter !== "all") {
+      if (listing.property.brand !== brandFilter) return false;
+    }
 
-      return true;
-    }),
-    selectedAttractions
+    return true;
+  });
+
+  // Apply attraction + event filters
+  const filteredListings = filterByEvent(
+    filterByAttractions(baseFiltered, selectedAttractions),
+    selectedEvent
   );
 
   // Sort
@@ -230,7 +261,7 @@ const Rentals = () => {
   // Reset page when any filter changes
   useEffect(() => {
     setCurrentPage(1);
-  }, [searchQuery, dateRange, minPrice, maxPrice, minGuests, minBedrooms, brandFilter, selectedAttractions, sortOption]);
+  }, [searchQuery, dateRange, minPrice, maxPrice, minGuests, minBedrooms, brandFilter, selectedAttractions, selectedEvent, sortOption]);
 
   // Toggle attraction tag selection
   const toggleAttraction = (tag: string) => {
@@ -254,6 +285,7 @@ const Rentals = () => {
     setMinBedrooms("");
     setBrandFilter("");
     setSelectedAttractions(new Set());
+    setSelectedEvent(null);
     setSearchQuery("");
     setShowFilters(false);
     setCurrentPage(1);
@@ -276,7 +308,7 @@ const Rentals = () => {
               <div className="md:col-span-2 relative">
                 <MapPin className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-muted-foreground" />
                 <Input
-                  placeholder="Where do you want to go?"
+                  placeholder="Search by destination, resort brand, or event..."
                   className="pl-10"
                   value={searchQuery}
                   onChange={(e) => setSearchQuery(e.target.value)}
@@ -410,6 +442,66 @@ const Rentals = () => {
         </div>
       </section>
 
+      {/* Search by Event Pill Bar */}
+      {upcomingEvents.length > 0 && (
+        <section className="pt-4 pb-0">
+          <div className="container mx-auto px-4">
+            <h3 className="text-sm font-medium text-muted-foreground mb-3">Search by Event</h3>
+            <div className="flex flex-wrap gap-2">
+              {upcomingEvents.map((event) => {
+                const Icon = EVENT_ICON_MAP[event.icon];
+                const isSelected = selectedEvent === event.slug;
+                return (
+                  <button
+                    key={event.slug}
+                    onClick={() => setSelectedEvent(isSelected ? null : event.slug)}
+                    className={`inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm font-medium transition-colors border ${
+                      isSelected
+                        ? "bg-primary text-primary-foreground border-primary"
+                        : "bg-card text-foreground border-border hover:bg-accent hover:text-accent-foreground"
+                    }`}
+                    aria-pressed={isSelected}
+                    aria-label={`Filter by ${event.name}`}
+                  >
+                    {Icon && <Icon className="w-4 h-4" />}
+                    <span>{event.name}</span>
+                    <span className={`text-xs ${isSelected ? "text-primary-foreground/70" : "text-muted-foreground"}`}>
+                      {formatEventDateRange(event)}
+                    </span>
+                  </button>
+                );
+              })}
+              {selectedEvent && (
+                <button
+                  onClick={() => setSelectedEvent(null)}
+                  className="inline-flex items-center gap-1 px-3 py-1.5 rounded-full text-sm text-muted-foreground hover:text-foreground transition-colors"
+                  aria-label="Clear event filter"
+                >
+                  <X className="w-3.5 h-3.5" />
+                  Clear
+                </button>
+              )}
+            </div>
+          </div>
+        </section>
+      )}
+
+      {/* Event context banner */}
+      {selectedEvent && (() => {
+        const event = upcomingEvents.find((e) => e.slug === selectedEvent);
+        if (!event) return null;
+        return (
+          <div className="container mx-auto px-4 mt-4">
+            <div className="bg-primary/5 border border-primary/20 rounded-lg px-4 py-2 text-sm">
+              Showing listings near <span className="font-semibold">{event.name}</span> — {formatEventDateRange(event)}
+              {!event.nationwide && event.destinations.length > 0 && (
+                <span className="text-muted-foreground"> in {event.destinations.slice(0, 3).join(", ")}{event.destinations.length > 3 ? ` +${event.destinations.length - 3} more` : ""}</span>
+              )}
+            </div>
+          </div>
+        );
+      })()}
+
       {/* Filters & Results */}
       <section className="py-8">
         <div className="container mx-auto px-4">
@@ -461,6 +553,7 @@ const Rentals = () => {
                   minBedrooms: minBedrooms || undefined,
                   brandFilter: brandFilter || undefined,
                   attractionTags: selectedAttractions.size > 0 ? Array.from(selectedAttractions) : undefined,
+                  eventSlug: selectedEvent || undefined,
                   dateFrom: dateRange?.from ? format(dateRange.from, 'yyyy-MM-dd') : undefined,
                   dateTo: dateRange?.to ? format(dateRange.to, 'yyyy-MM-dd') : undefined,
                 }}


### PR DESCRIPTION
## Summary
- **#328 Attraction-Based Filtering:** Icon pill bar for Browse by Activity (Beach, Golf, Casino, etc.)
- **#327 Event-Based Search:** Pill bar for Search by Event (14 curated 2026 events with date+location filtering)
- **Hotfix:** Missing lucide icon imports (MapPin, Home, Star, Users) that caused /rentals crash
- **Search prompt:** Updated to "Search by destination, resort brand, or event..."

## Changes
- `src/lib/attractionTags.ts` + `src/lib/events.ts` — filter utilities with full test coverage
- `src/pages/Rentals.tsx` — two pill bars (activity + events), single/multi-select, context banner
- `AdminResortTagEditor` — admin UI for resort tag management
- Migration 053 (attraction_tags on resorts) — deployed to DEV + PROD
- 43 new tests (999 total, 123 files)

## Test plan
- [x] 999 tests passing (123 files)
- [x] TypeScript: 0 errors
- [x] Build: clean
- [x] P0 critical path: passing
- [ ] Visual: verify both pill bars render on /rentals
- [ ] Verify event selection shows context banner + filters by date+location
- [ ] Verify attraction multi-select OR filtering works

🤖 Generated with [Claude Code](https://claude.com/claude-code)