### PR TITLE
fix(ux): #337 site-wide contrast & crispness pass

### DIFF
--- a/docs/PRIORITY-ROADMAP.md
+++ b/docs/PRIORITY-ROADMAP.md
@@ -1,6 +1,6 @@
 ---
-last_updated: "2026-04-13T14:31:34"
-change_ref: "e69f323"
+last_updated: "2026-04-13T16:00:50"
+change_ref: "0222a29"
 change_type: "session-48"
 status: "active"
 ---
@@ -21,10 +21,9 @@ These are the highest-value items we can build RIGHT NOW. No blockers, no decisi
 | Order | Issue | Title | Why it's here |
 |-------|-------|-------|---------------|
 | **A1** | #285 | Owner fee transparency | Owners won't list if they don't understand costs. Trust blocker. |
-| **A2** | #327 | Event-Based Search | High value but needs data curation. 10-15 curated events. |
-| **A3** | #283 | Price drop alert notifications | Completes saved search → alert loop (infra already built). |
-| **A4** | #286 | Owner Tax Information form (W-9) | Needed before real payouts. |
-| **A5** | #259 | Testimonials collection + display | Social proof for launch credibility. |
+| **A2** | #283 | Price drop alert notifications | Completes saved search → alert loop (infra already built). |
+| **A3** | #286 | Owner Tax Information form (W-9) | Needed before real payouts. |
+| **A4** | #259 | Testimonials collection + display | Social proof for launch credibility. |
 
 ### Tier B: Pre-Launch Important (Needs Human Input)
 
@@ -101,7 +100,7 @@ These unblock when the LLC is formed. Not code-dependent.
 
 | Date | Session | Changes |
 |------|---------|---------|
-| Apr 13, 2026 | 49 | #328 Attraction-Based Filtering completed + closed. Migration 053 deployed to DEV. PR #334 merged. Renumbered Tier A. |
+| Apr 13, 2026 | 49 | #327 Event-Based Search + #328 Attraction-Based Filtering completed + closed. Migration 053 deployed to DEV+PROD. PRs #334-#336 merged. Search prompt updated. Renumbered Tier A. |
 | Apr 13, 2026 | 48 | #326 RAV Deals completed + closed. #273 Homepage completed (Session 47). Header nav consistency fix. Renumbered Tier A. |
 | Apr 12, 2026 | 47 | Initial creation. Brand rebrand completed. Search & Discovery epic created (#325-#328). Full 5-tier prioritization. |
 

--- a/docs/PRIORITY-ROADMAP.md
+++ b/docs/PRIORITY-ROADMAP.md
@@ -1,6 +1,6 @@
 ---
-last_updated: "2026-04-13T16:00:50"
-change_ref: "0222a29"
+last_updated: "2026-04-13T16:21:30"
+change_ref: "74c3c98"
 change_type: "session-48"
 status: "active"
 ---
@@ -20,10 +20,11 @@ These are the highest-value items we can build RIGHT NOW. No blockers, no decisi
 
 | Order | Issue | Title | Why it's here |
 |-------|-------|-------|---------------|
-| **A1** | #285 | Owner fee transparency | Owners won't list if they don't understand costs. Trust blocker. |
-| **A2** | #283 | Price drop alert notifications | Completes saved search → alert loop (infra already built). |
-| **A3** | #286 | Owner Tax Information form (W-9) | Needed before real payouts. |
-| **A4** | #259 | Testimonials collection + display | Social proof for launch credibility. |
+| **A1** | #337 | Site-wide contrast & crispness pass | Every user's first impression. Text/pills/header/hero all too dull. |
+| **A2** | #285 | Owner fee transparency | Owners won't list if they don't understand costs. Trust blocker. |
+| **A3** | #283 | Price drop alert notifications | Completes saved search → alert loop (infra already built). |
+| **A4** | #286 | Owner Tax Information form (W-9) | Needed before real payouts. |
+| **A5** | #259 | Testimonials collection + display | Social proof for launch credibility. |
 
 ### Tier B: Pre-Launch Important (Needs Human Input)
 
@@ -34,6 +35,8 @@ These require decisions, walkthroughs, or external dependencies before coding.
 | #187 | Pre-launch manual verification | Needs systematic walkthrough. Partially done. |
 | #257 | Resort data compliance audit | Legal review of seed data sources. |
 | #322 | RAV Wishes proposal enforcement | Deferred until 30+ days of real proposal data. Post-beta. |
+| #338 | Admin Event Management UI | Move events from static code to DB-driven admin. Depends on staff workflow. |
+| #339 | Multi-year event support | Recurring templates + 2027+ dates. Depends on #338. |
 
 ### Tier C: Tier Feature Differentiation (Bundle as Sprint)
 

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -33,7 +33,7 @@ const Header = () => {
   };
 
   return (
-    <header className="fixed top-0 left-0 right-0 z-50 bg-card/80 backdrop-blur-lg border-b border-border/50">
+    <header className="fixed top-0 left-0 right-0 z-50 bg-card/95 backdrop-blur-lg border-b border-border shadow-sm">
       {/* Skip-to-content link — WCAG 2.4.1 */}
       <a
         href="#main-content"
@@ -51,7 +51,7 @@ const Header = () => {
               className="h-14 md:h-16 w-auto select-none"
               draggable={false}
             />
-            <span className="font-display font-bold text-xl text-foreground">Rent-A-Vacation</span>
+            <span className="font-display font-bold text-xl text-foreground tracking-tight">Rent-A-Vacation</span>
           </Link>
 
           {/* Desktop Navigation — shared core + role layers */}
@@ -75,7 +75,7 @@ const Header = () => {
                   if (e.key === 'Escape') setIsDropdownOpen(false);
                 }}
               >
-                <span className="text-sm font-medium">Browse Rentals</span>
+                <span className="text-sm font-semibold">Browse Rentals</span>
                 <ChevronDown className={`w-3.5 h-3.5 transition-transform ${isDropdownOpen ? "rotate-180" : ""}`} />
               </button>
               {isDropdownOpen && (

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -43,12 +43,12 @@ const HeroSection = () => {
           <h1 className="font-display text-3xl sm:text-4xl md:text-5xl font-bold text-white mb-3 animate-slide-up">
             Name Your Price. Book Your Paradise.
           </h1>
-          <p className="text-base md:text-lg text-white/80 mb-8 max-w-xl mx-auto animate-fade-in">
+          <p className="text-base md:text-lg text-white/90 font-medium mb-8 max-w-xl mx-auto animate-fade-in">
             Luxury vacation rentals from verified timeshare owners — save 20-40% vs resort-direct.
           </p>
 
           {/* Search Box */}
-          <div className="bg-card/95 backdrop-blur-lg rounded-2xl shadow-card-hover p-4 md:p-6 max-w-3xl mx-auto animate-scale-in">
+          <div className="bg-card backdrop-blur-lg rounded-2xl shadow-card-hover p-4 md:p-6 max-w-3xl mx-auto animate-scale-in border border-border/50">
             {/* Tabs */}
             <div className="flex gap-2 mb-4">
               <button
@@ -56,7 +56,7 @@ const HeroSection = () => {
                 className={`px-4 py-2 rounded-lg text-sm font-medium transition-all ${
                   searchTab === "flexible"
                     ? "bg-primary text-primary-foreground"
-                    : "text-muted-foreground hover:bg-muted"
+                    : "text-foreground/70 hover:bg-muted hover:text-foreground"
                 }`}
               >
                 I'm Flexible
@@ -66,7 +66,7 @@ const HeroSection = () => {
                 className={`px-4 py-2 rounded-lg text-sm font-medium transition-all ${
                   searchTab === "calendar"
                     ? "bg-primary text-primary-foreground"
-                    : "text-muted-foreground hover:bg-muted"
+                    : "text-foreground/70 hover:bg-muted hover:text-foreground"
                 }`}
               >
                 <CalendarIcon className="w-4 h-4 inline-block mr-1" />

--- a/src/index.css
+++ b/src/index.css
@@ -9,26 +9,26 @@
 @layer base {
   :root {
     /* Core Brand Colors - Deep Teal & Warm Coral */
-    --background: 45 25% 97%;
-    --foreground: 200 25% 15%;
+    --background: 45 20% 97%;
+    --foreground: 210 30% 10%;
 
     --card: 0 0% 100%;
-    --card-foreground: 200 25% 15%;
+    --card-foreground: 210 30% 10%;
 
     --popover: 0 0% 100%;
-    --popover-foreground: 200 25% 15%;
+    --popover-foreground: 210 30% 10%;
 
     /* Deep Teal - Trust & Travel */
     --primary: 175 60% 28%;
     --primary-foreground: 0 0% 100%;
 
     /* Secondary - Soft Sand */
-    --secondary: 40 30% 94%;
-    --secondary-foreground: 200 25% 20%;
+    --secondary: 40 25% 94%;
+    --secondary-foreground: 210 30% 15%;
 
     /* Muted - Warm Gray */
-    --muted: 45 15% 92%;
-    --muted-foreground: 200 10% 45%;
+    --muted: 45 12% 92%;
+    --muted-foreground: 210 15% 35%;
 
     /* Accent - Warm Coral/Sunset */
     --accent: 18 85% 58%;
@@ -37,8 +37,8 @@
     --destructive: 0 84.2% 60.2%;
     --destructive-foreground: 210 40% 98%;
 
-    --border: 40 20% 88%;
-    --input: 40 20% 88%;
+    --border: 40 15% 82%;
+    --input: 40 15% 85%;
     --ring: 175 60% 28%;
 
     --radius: 0.75rem;
@@ -46,8 +46,8 @@
     /* Custom Design Tokens */
     --hero-gradient: linear-gradient(135deg, hsl(175 60% 28% / 0.9) 0%, hsl(200 50% 20% / 0.85) 100%);
     --hero-overlay: linear-gradient(180deg, hsl(0 0% 0% / 0.3) 0%, hsl(0 0% 0% / 0.5) 100%);
-    --card-shadow: 0 4px 20px -4px hsl(200 25% 15% / 0.1);
-    --card-shadow-hover: 0 12px 40px -8px hsl(200 25% 15% / 0.15);
+    --card-shadow: 0 4px 20px -4px hsl(210 30% 10% / 0.12);
+    --card-shadow-hover: 0 12px 40px -8px hsl(210 30% 10% / 0.18);
     --glow-primary: 0 0 40px hsl(175 60% 28% / 0.3);
     --glow-accent: 0 0 40px hsl(18 85% 58% / 0.3);
 

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -15,14 +15,14 @@ const WelcomeBanner = () => {
   const firstName = profile?.full_name?.split(" ")[0] || "there";
 
   return (
-    <div className="bg-primary/5 border-b border-primary/10">
-      <div className="container mx-auto px-4 py-4">
+    <div className="bg-card border-b border-border shadow-sm">
+      <div className="container mx-auto px-4 py-5">
         <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-3">
           <div>
-            <h2 className="text-lg font-semibold text-foreground">
+            <h2 className="text-lg font-bold text-foreground">
               Welcome back, {firstName}!
             </h2>
-            <p className="text-sm text-muted-foreground">
+            <p className="text-sm text-muted-foreground font-medium">
               Where to next? Pick up where you left off.
             </p>
           </div>

--- a/src/pages/Rentals.tsx
+++ b/src/pages/Rentals.tsx
@@ -406,7 +406,7 @@ const Rentals = () => {
       {/* Browse by Activity Pill Bar */}
       <section className="pt-6 pb-0">
         <div className="container mx-auto px-4">
-          <h3 className="text-sm font-medium text-muted-foreground mb-3">Browse by Activity</h3>
+          <h3 className="text-sm font-semibold text-foreground mb-3">Browse by Activity</h3>
           <div className="flex flex-wrap gap-2">
             {ATTRACTION_TAGS.map((tagDef) => {
               const Icon = ATTRACTION_ICON_MAP[tagDef.icon];
@@ -415,15 +415,15 @@ const Rentals = () => {
                 <button
                   key={tagDef.tag}
                   onClick={() => toggleAttraction(tagDef.tag)}
-                  className={`inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm font-medium transition-colors border ${
+                  className={`inline-flex items-center gap-1.5 px-4 py-2 rounded-full text-sm font-semibold transition-all border shadow-sm ${
                     isSelected
-                      ? "bg-primary text-primary-foreground border-primary"
-                      : "bg-card text-foreground border-border hover:bg-accent hover:text-accent-foreground"
+                      ? "bg-primary text-primary-foreground border-primary shadow-md"
+                      : "bg-card text-foreground border-border hover:border-primary/40 hover:shadow-md"
                   }`}
                   aria-pressed={isSelected}
                   aria-label={`Filter by ${tagDef.label}`}
                 >
-                  {Icon && <Icon className="w-4 h-4" />}
+                  {Icon && <Icon className={`w-4 h-4 ${isSelected ? "" : "text-primary"}`} />}
                   {tagDef.label}
                 </button>
               );
@@ -431,7 +431,7 @@ const Rentals = () => {
             {selectedAttractions.size > 0 && (
               <button
                 onClick={() => setSelectedAttractions(new Set())}
-                className="inline-flex items-center gap-1 px-3 py-1.5 rounded-full text-sm text-muted-foreground hover:text-foreground transition-colors"
+                className="inline-flex items-center gap-1 px-3 py-2 rounded-full text-sm font-medium text-muted-foreground hover:text-foreground transition-colors"
                 aria-label="Clear activity filters"
               >
                 <X className="w-3.5 h-3.5" />
@@ -446,7 +446,7 @@ const Rentals = () => {
       {upcomingEvents.length > 0 && (
         <section className="pt-4 pb-0">
           <div className="container mx-auto px-4">
-            <h3 className="text-sm font-medium text-muted-foreground mb-3">Search by Event</h3>
+            <h3 className="text-sm font-semibold text-foreground mb-3">Search by Event</h3>
             <div className="flex flex-wrap gap-2">
               {upcomingEvents.map((event) => {
                 const Icon = EVENT_ICON_MAP[event.icon];
@@ -455,15 +455,15 @@ const Rentals = () => {
                   <button
                     key={event.slug}
                     onClick={() => setSelectedEvent(isSelected ? null : event.slug)}
-                    className={`inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm font-medium transition-colors border ${
+                    className={`inline-flex items-center gap-1.5 px-4 py-2 rounded-full text-sm font-semibold transition-all border shadow-sm ${
                       isSelected
-                        ? "bg-primary text-primary-foreground border-primary"
-                        : "bg-card text-foreground border-border hover:bg-accent hover:text-accent-foreground"
+                        ? "bg-primary text-primary-foreground border-primary shadow-md"
+                        : "bg-card text-foreground border-border hover:border-primary/40 hover:shadow-md"
                     }`}
                     aria-pressed={isSelected}
                     aria-label={`Filter by ${event.name}`}
                   >
-                    {Icon && <Icon className="w-4 h-4" />}
+                    {Icon && <Icon className={`w-4 h-4 ${isSelected ? "" : "text-accent"}`} />}
                     <span>{event.name}</span>
                     <span className={`text-xs ${isSelected ? "text-primary-foreground/70" : "text-muted-foreground"}`}>
                       {formatEventDateRange(event)}
@@ -474,7 +474,7 @@ const Rentals = () => {
               {selectedEvent && (
                 <button
                   onClick={() => setSelectedEvent(null)}
-                  className="inline-flex items-center gap-1 px-3 py-1.5 rounded-full text-sm text-muted-foreground hover:text-foreground transition-colors"
+                  className="inline-flex items-center gap-1 px-3 py-2 rounded-full text-sm font-medium text-muted-foreground hover:text-foreground transition-colors"
                   aria-label="Clear event filter"
                 >
                   <X className="w-3.5 h-3.5" />


### PR DESCRIPTION
## Summary
- Global visual contrast improvements — darker text, stronger borders, crisper fonts
- Pill bars with tinted icons, shadows, and hover effects
- Header with solid background and stronger nav weight
- Hero search box and welcome banner with clear visual separation
- No brand color changes — all improvements within existing palette

## What Changed
- **CSS variables:** foreground darkened (15%→10%), muted-foreground strengthened (45%→35%), borders more visible (88%→82%)
- **Header:** `bg-card/95` + `shadow-sm`, `font-semibold` nav links
- **Pill bars:** `shadow-sm`, tinted icons (teal for activities, coral for events), `font-semibold`, hover border effects
- **Hero:** `text-white/90` description, solid search box, stronger inactive tab contrast
- **Welcome banner:** `bg-card` with `shadow-sm` for clear hero separation
- **PRIORITY-ROADMAP:** #337 as A1, #338/#339 in Tier B

## Test plan
- [x] 999 tests passing (123 files)
- [x] TypeScript: 0 errors
- [x] Build: clean
- [ ] Visual: check /rentals pill bars for pop and icon color
- [ ] Visual: check header contrast on homepage and inner pages
- [ ] Visual: check hero → welcome banner separation

🤖 Generated with [Claude Code](https://claude.com/claude-code)