### PR TITLE
feat(owner): #285 fee transparency — commission + Stripe explainer

### DIFF
--- a/src/components/owner/OwnerEarnings.tsx
+++ b/src/components/owner/OwnerEarnings.tsx
@@ -19,6 +19,7 @@ import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContaine
 import type { Booking, Listing, Property, PayoutStatus, EscrowStatus } from "@/types/database";
 import { useOwnerCommission } from "@/hooks/useOwnerCommission";
 import StripeConnectBanner from "./StripeConnectBanner";
+import { OwnerFeeExplainer } from "./OwnerFeeExplainer";
 
 interface EscrowInfo {
   escrow_status: EscrowStatus;
@@ -344,23 +345,10 @@ const OwnerEarnings = () => {
         <StripeConnectBanner />
       </div>
 
-      {/* Commission Rate Card */}
-      <Card className="mb-6">
-        <CardContent className="flex items-center gap-4 py-4">
-          <div className="flex-shrink-0 w-10 h-10 rounded-full bg-primary/10 flex items-center justify-center">
-            <Percent className="h-5 w-5 text-primary" />
-          </div>
-          <div>
-            <p className="text-sm font-medium">
-              Your Commission Rate: {commissionLoading ? "..." : `${effectiveRate}%`}
-            </p>
-            <p className="text-xs text-muted-foreground">
-              {tierName} tier
-              {tierDiscount > 0 && ` (${tierDiscount}% discount applied)`}
-            </p>
-          </div>
-        </CardContent>
-      </Card>
+      {/* Fee Transparency */}
+      <div className="mb-6">
+        <OwnerFeeExplainer />
+      </div>
 
       {/* Summary Cards */}
       <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4 mb-8">

--- a/src/components/owner/OwnerFeeExplainer.test.tsx
+++ b/src/components/owner/OwnerFeeExplainer.test.tsx
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { OwnerFeeExplainer } from "./OwnerFeeExplainer";
+import { MemoryRouter } from "react-router-dom";
+
+// Mock useOwnerCommission
+const mockCommission = vi.hoisted(() => ({
+  effectiveRate: 15,
+  tierDiscount: 0,
+  tierName: "Free",
+  loading: false,
+}));
+
+vi.mock("@/hooks/useOwnerCommission", () => ({
+  useOwnerCommission: () => mockCommission,
+}));
+
+function renderExplainer() {
+  return render(
+    <MemoryRouter>
+      <OwnerFeeExplainer />
+    </MemoryRouter>
+  );
+}
+
+describe("OwnerFeeExplainer", () => {
+  beforeEach(() => {
+    mockCommission.effectiveRate = 15;
+    mockCommission.tierDiscount = 0;
+    mockCommission.tierName = "Free";
+    mockCommission.loading = false;
+  });
+
+  it("renders the fee explainer card", () => {
+    renderExplainer();
+    expect(screen.getByText("How Your Fees Work")).toBeTruthy();
+  });
+
+  it("shows effective commission rate", () => {
+    renderExplainer();
+    expect(screen.getByText("15%")).toBeTruthy();
+    expect(screen.getByText("15% base rate")).toBeTruthy();
+  });
+
+  it("shows Stripe protection message", () => {
+    renderExplainer();
+    expect(screen.getByText("Stripe processing fees never touch your payout")).toBeTruthy();
+  });
+
+  it("shows sample calculation", () => {
+    renderExplainer();
+    expect(screen.getByText("$200 × 5 nights")).toBeTruthy();
+    expect(screen.getByText("$1,000")).toBeTruthy();
+    expect(screen.getByText("$1,100")).toBeTruthy(); // owner payout
+    expect(screen.getByText("$1,250")).toBeTruthy(); // guest total
+  });
+
+  it("shows tier upgrade nudge for Free tier", () => {
+    renderExplainer();
+    expect(screen.getByText(/Upgrade to/)).toBeTruthy();
+    expect(screen.getByText("View plans")).toBeTruthy();
+  });
+
+  it("shows tier discount for Pro users", () => {
+    mockCommission.effectiveRate = 13;
+    mockCommission.tierDiscount = 2;
+    mockCommission.tierName = "Pro";
+    renderExplainer();
+    expect(screen.getByText("13%")).toBeTruthy();
+    expect(screen.getByText(/15% base − 2% Pro discount/)).toBeTruthy();
+    expect(screen.getByText(/Pro savings/)).toBeTruthy();
+    // No upgrade nudge for Pro
+    expect(screen.queryByText(/Upgrade to/)).toBeNull();
+  });
+
+  it("shows Business tier discount", () => {
+    mockCommission.effectiveRate = 10;
+    mockCommission.tierDiscount = 5;
+    mockCommission.tierName = "Business";
+    renderExplainer();
+    expect(screen.getByText("10%")).toBeTruthy();
+    expect(screen.getByText(/15% base − 5% Business discount/)).toBeTruthy();
+  });
+
+  it("returns null while loading", () => {
+    mockCommission.loading = true;
+    const { container } = renderExplainer();
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("links to fee guide", () => {
+    renderExplainer();
+    expect(screen.getByText("Full fee details in our guide")).toBeTruthy();
+  });
+});

--- a/src/components/owner/OwnerFeeExplainer.tsx
+++ b/src/components/owner/OwnerFeeExplainer.tsx
@@ -1,0 +1,123 @@
+import { useOwnerCommission } from "@/hooks/useOwnerCommission";
+import { computeOwnerPayoutBreakdown } from "@/lib/pricing";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { DollarSign, ShieldCheck, TrendingUp, Info } from "lucide-react";
+import { Link } from "react-router-dom";
+
+/**
+ * OwnerFeeExplainer — Transparent fee breakdown for property owners.
+ * Shows their effective commission rate, a sample calculation, and
+ * the key message that Stripe fees never touch their payout.
+ */
+export function OwnerFeeExplainer() {
+  const { effectiveRate, tierDiscount, tierName, loading } = useOwnerCommission();
+
+  if (loading) return null;
+
+  // Sample calculation for illustration ($200/night × 5 nights + $100 cleaning)
+  const sample = computeOwnerPayoutBreakdown(200, 5, effectiveRate, 100);
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="flex items-center gap-2 text-base">
+          <DollarSign className="w-5 h-5 text-primary" />
+          How Your Fees Work
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {/* Rate summary */}
+        <div className="flex items-center justify-between p-3 bg-primary/5 rounded-lg">
+          <div>
+            <p className="text-sm font-semibold text-foreground">Your Commission Rate</p>
+            <p className="text-xs text-muted-foreground">
+              {tierDiscount > 0
+                ? `15% base − ${tierDiscount}% ${tierName} discount`
+                : "15% base rate"}
+            </p>
+          </div>
+          <div className="text-right">
+            <p className="text-2xl font-bold text-primary">{effectiveRate}%</p>
+            {tierDiscount > 0 && (
+              <Badge variant="secondary" className="text-xs">
+                <TrendingUp className="w-3 h-3 mr-1" />
+                {tierName} savings
+              </Badge>
+            )}
+          </div>
+        </div>
+
+        {/* Key message */}
+        <div className="flex gap-2 p-3 bg-green-50 dark:bg-green-950/30 rounded-lg border border-green-200 dark:border-green-800">
+          <ShieldCheck className="w-5 h-5 text-green-600 shrink-0 mt-0.5" />
+          <div className="text-sm">
+            <p className="font-semibold text-green-800 dark:text-green-200">
+              Stripe processing fees never touch your payout
+            </p>
+            <p className="text-green-700 dark:text-green-300 text-xs mt-0.5">
+              Stripe charges 2.9% + $0.30 per transaction. This comes out of our commission — you always receive your full nightly rate + cleaning fee.
+            </p>
+          </div>
+        </div>
+
+        {/* Sample calculation */}
+        <div>
+          <p className="text-xs font-semibold text-muted-foreground mb-2 uppercase tracking-wide">Example Booking</p>
+          <div className="text-sm space-y-1.5 bg-muted/50 rounded-lg p-3">
+            <div className="flex justify-between">
+              <span className="text-muted-foreground">$200 × 5 nights</span>
+              <span>${sample.baseAmount.toLocaleString()}</span>
+            </div>
+            <div className="flex justify-between">
+              <span className="text-muted-foreground">Cleaning fee</span>
+              <span>${sample.cleaningFee.toLocaleString()}</span>
+            </div>
+            <div className="flex justify-between">
+              <span className="text-muted-foreground">RAV commission ({effectiveRate}%)</span>
+              <span className="text-muted-foreground">${sample.ravCommission.toLocaleString()}</span>
+            </div>
+            <div className="border-t border-border my-1" />
+            <div className="flex justify-between">
+              <span className="text-muted-foreground">Guest pays</span>
+              <span className="font-medium">${sample.guestTotal.toLocaleString()}</span>
+            </div>
+            <div className="flex justify-between text-primary font-bold">
+              <span>You receive</span>
+              <span>${sample.ownerPayout.toLocaleString()}</span>
+            </div>
+            <div className="flex justify-between text-xs text-muted-foreground">
+              <span>Stripe fee (from our commission)</span>
+              <span>−${sample.stripeFee}</span>
+            </div>
+            <div className="flex justify-between text-xs text-muted-foreground">
+              <span>RAV net revenue</span>
+              <span>${sample.ravNetRevenue}</span>
+            </div>
+          </div>
+        </div>
+
+        {/* Tier upgrade nudge (only for Free tier) */}
+        {tierDiscount === 0 && (
+          <div className="flex items-start gap-2 p-3 bg-accent/5 rounded-lg border border-accent/20">
+            <Info className="w-4 h-4 text-accent shrink-0 mt-0.5" />
+            <p className="text-xs text-muted-foreground">
+              <span className="font-semibold text-foreground">Reduce your rate:</span>{" "}
+              Upgrade to <span className="font-semibold">Pro</span> (13%) or{" "}
+              <span className="font-semibold">Business</span> (10%) to keep more of each booking.{" "}
+              <Link to="/owner-dashboard?tab=account" className="text-primary hover:underline">
+                View plans
+              </Link>
+            </p>
+          </div>
+        )}
+
+        <p className="text-xs text-muted-foreground">
+          <Link to="/user-guide#owner-fees-commission" className="text-primary hover:underline">
+            Full fee details in our guide
+          </Link>
+        </p>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/lib/pricing.test.ts
+++ b/src/lib/pricing.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { calculateNights, computeListingPricing, computeFeeBreakdown } from './pricing';
+import { calculateNights, computeListingPricing, computeFeeBreakdown, computeOwnerPayoutBreakdown } from './pricing';
 
 describe('calculateNights @p0', () => {
   it('returns correct nights for a standard week', () => {
@@ -126,5 +126,66 @@ describe('computeFeeBreakdown @p0', () => {
   it('defaults cleaning fee to 0 when not provided', () => {
     const result = computeFeeBreakdown(100, 1);
     expect(result.cleaningFee).toBe(0);
+  });
+});
+
+describe('computeOwnerPayoutBreakdown', () => {
+  it('calculates standard 15% commission breakdown', () => {
+    // $200/night × 5 nights = $1000 base, 15% commission
+    const result = computeOwnerPayoutBreakdown(200, 5, 15, 100);
+    expect(result.baseAmount).toBe(1000);
+    expect(result.cleaningFee).toBe(100);
+    expect(result.ownerPayout).toBe(1100); // base + cleaning
+    expect(result.ravCommission).toBe(150); // 15% of 1000
+    expect(result.guestTotal).toBe(1250); // 1000 + 150 + 100
+    expect(result.effectiveCommissionPct).toBe(15);
+  });
+
+  it('owner payout is always base + cleaning (Stripe comes from RAV)', () => {
+    const result = computeOwnerPayoutBreakdown(200, 5, 15, 100);
+    expect(result.ownerPayout).toBe(result.baseAmount + result.cleaningFee);
+    expect(result.ravNetRevenue).toBeLessThan(result.ravCommission);
+  });
+
+  it('calculates Stripe fee correctly (2.9% + $0.30)', () => {
+    const result = computeOwnerPayoutBreakdown(200, 5, 15, 100);
+    // Stripe fee on $1250 total: 1250 × 0.029 + 0.30 = 36.25 + 0.30 = 36.55
+    expect(result.stripeFee).toBe(36.55);
+    expect(result.ravNetRevenue).toBe(113.45); // 150 - 36.55
+  });
+
+  it('applies Pro tier discount (13%)', () => {
+    const result = computeOwnerPayoutBreakdown(200, 5, 13, 0);
+    expect(result.ravCommission).toBe(130); // 13% of 1000
+    expect(result.ownerPayout).toBe(1000); // unchanged — owner always gets base
+    expect(result.guestTotal).toBe(1130);
+    expect(result.effectiveCommissionPct).toBe(13);
+  });
+
+  it('applies Business tier discount (10%)', () => {
+    const result = computeOwnerPayoutBreakdown(200, 5, 10, 0);
+    expect(result.ravCommission).toBe(100);
+    expect(result.guestTotal).toBe(1100);
+  });
+
+  it('handles zero commission', () => {
+    const result = computeOwnerPayoutBreakdown(200, 5, 0, 0);
+    expect(result.ravCommission).toBe(0);
+    expect(result.ownerPayout).toBe(1000);
+    expect(result.guestTotal).toBe(1000);
+    expect(result.ravNetRevenue).toBeLessThan(0); // RAV absorbs Stripe fee
+  });
+
+  it('handles zero-night edge case', () => {
+    const result = computeOwnerPayoutBreakdown(200, 0, 15, 0);
+    expect(result.baseAmount).toBe(0);
+    expect(result.ravCommission).toBe(0);
+    expect(result.ownerPayout).toBe(0);
+  });
+
+  it('cleaning fee passes through to owner payout untouched', () => {
+    const withCleaning = computeOwnerPayoutBreakdown(100, 1, 15, 500);
+    expect(withCleaning.ownerPayout).toBe(600); // 100 + 500
+    expect(withCleaning.ravCommission).toBe(15); // 15% of 100 only
   });
 });

--- a/src/lib/pricing.ts
+++ b/src/lib/pricing.ts
@@ -8,7 +8,9 @@
  * from a nightly rate and number of nights.
  */
 
-const RAV_MARKUP_RATE = 0.15; // 15%
+export const RAV_MARKUP_RATE = 0.15; // 15% base commission
+const STRIPE_RATE = 0.029; // 2.9%
+const STRIPE_FIXED = 0.30; // $0.30 per transaction
 
 /**
  * Calculate the number of nights between check-in and check-out dates.
@@ -66,4 +68,46 @@ export function computeFeeBreakdown(
   const subtotal = baseAmount + serviceFee + cleaningFee;
   const ownerPayout = baseAmount + cleaningFee;
   return { baseAmount, serviceFee, cleaningFee, subtotal, ownerPayout };
+}
+
+export interface OwnerPayoutBreakdown {
+  baseAmount: number;
+  cleaningFee: number;
+  ownerPayout: number;
+  ravCommission: number;
+  stripeFee: number;
+  ravNetRevenue: number;
+  guestTotal: number;
+  effectiveCommissionPct: number;
+}
+
+/**
+ * Compute detailed owner payout breakdown with tier-aware commission and Stripe fees.
+ *
+ * Key insight for owners: Stripe fees come out of RAV's commission, NOT the owner's payout.
+ * Owner always receives baseAmount + cleaningFee.
+ */
+export function computeOwnerPayoutBreakdown(
+  nightlyRate: number,
+  nights: number,
+  commissionPct: number,
+  cleaningFee = 0
+): OwnerPayoutBreakdown {
+  const baseAmount = Math.round(nightlyRate * nights);
+  const ravCommission = Math.round(baseAmount * (commissionPct / 100));
+  const ownerPayout = baseAmount + cleaningFee;
+  const guestTotal = baseAmount + ravCommission + cleaningFee;
+  const stripeFee = Math.round((guestTotal * STRIPE_RATE + STRIPE_FIXED) * 100) / 100;
+  const ravNetRevenue = Math.round((ravCommission - stripeFee) * 100) / 100;
+
+  return {
+    baseAmount,
+    cleaningFee,
+    ownerPayout,
+    ravCommission,
+    stripeFee,
+    ravNetRevenue,
+    guestTotal,
+    effectiveCommissionPct: commissionPct,
+  };
 }

--- a/src/pages/ListProperty.tsx
+++ b/src/pages/ListProperty.tsx
@@ -33,7 +33,8 @@ import { useAuth } from "@/hooks/useAuth";
 import { useCheckListingLimit } from "@/hooks/useCheckListingLimit";
 import { RoleUpgradeDialog } from "@/components/RoleUpgradeDialog";
 import { EmailVerificationBanner } from "@/components/EmailVerificationBanner";
-import { calculateNights, computeFeeBreakdown } from "@/lib/pricing";
+import { calculateNights, computeOwnerPayoutBreakdown } from "@/lib/pricing";
+import { useOwnerCommission } from "@/hooks/useOwnerCommission";
 import { trackEvent } from "@/lib/posthog";
 
 const benefits = [
@@ -139,6 +140,7 @@ const ListProperty = () => {
   const navigate = useNavigate();
   const { user, isPropertyOwner, isEmailVerified } = useAuth();
   const { canCreate: canCreateListing } = useCheckListingLimit();
+  const { effectiveRate, tierDiscount, tierName } = useOwnerCommission();
 
   // Load draft from localStorage (survives page refresh after role upgrade)
   const draft = loadDraft();
@@ -172,15 +174,15 @@ const ListProperty = () => {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
 
-  // Pricing preview
+  // Pricing preview with tier-aware commission
   const pricingPreview = useMemo(() => {
     const rate = parseFloat(nightlyRate);
     const cleaning = parseFloat(cleaningFee) || 0;
     if (!rate || !checkInDate || !checkOutDate) return null;
     const nights = calculateNights(checkInDate, checkOutDate);
     if (nights <= 0) return null;
-    return { ...computeFeeBreakdown(rate, nights, cleaning), nights };
-  }, [nightlyRate, cleaningFee, checkInDate, checkOutDate]);
+    return { ...computeOwnerPayoutBreakdown(rate, nights, effectiveRate, cleaning), nights };
+  }, [nightlyRate, cleaningFee, checkInDate, checkOutDate, effectiveRate]);
 
   const todayStr = new Date().toISOString().split("T")[0];
 
@@ -302,12 +304,12 @@ const ListProperty = () => {
 
       if (propError || !newProperty) throw new Error(propError?.message || "Failed to create property");
 
-      // 2. Create listing
+      // 2. Create listing (use tier-aware commission rate)
       const rate = parseFloat(nightlyRate);
       const cleaning = parseFloat(cleaningFee) || 0;
       const nights = calculateNights(checkInDate, checkOutDate);
       const ownerPrice = Math.round(rate * nights);
-      const ravMarkup = Math.round(ownerPrice * 0.15);
+      const ravMarkup = Math.round(ownerPrice * (effectiveRate / 100));
       const finalPrice = ownerPrice + ravMarkup;
 
       const listingData = {
@@ -784,27 +786,32 @@ const ListProperty = () => {
                       <p className="text-sm font-medium text-primary">Pricing Preview</p>
                       <div className="text-sm text-muted-foreground space-y-1">
                         <div className="flex justify-between">
-                          <span>${nightlyRate} x {pricingPreview.nights} night{pricingPreview.nights !== 1 ? "s" : ""}</span>
-                          <span>${pricingPreview.baseAmount}</span>
+                          <span>${nightlyRate} × {pricingPreview.nights} night{pricingPreview.nights !== 1 ? "s" : ""}</span>
+                          <span>${pricingPreview.baseAmount.toLocaleString()}</span>
                         </div>
                         <div className="flex justify-between">
-                          <span>Service fee (15%)</span>
-                          <span>${pricingPreview.serviceFee}</span>
+                          <span>RAV commission ({effectiveRate}%{tierDiscount > 0 ? "*" : ""})</span>
+                          <span>${pricingPreview.ravCommission.toLocaleString()}</span>
                         </div>
                         {pricingPreview.cleaningFee > 0 && (
                           <div className="flex justify-between">
                             <span>Cleaning fee</span>
-                            <span>${pricingPreview.cleaningFee}</span>
+                            <span>${pricingPreview.cleaningFee.toLocaleString()}</span>
                           </div>
                         )}
                         <div className="flex justify-between font-medium text-foreground border-t pt-1">
                           <span>Guest pays</span>
-                          <span>${pricingPreview.subtotal}</span>
+                          <span>${pricingPreview.guestTotal.toLocaleString()}</span>
                         </div>
-                        <div className="flex justify-between text-primary">
-                          <span>You earn</span>
-                          <span>${pricingPreview.ownerPayout}</span>
+                        <div className="flex justify-between font-bold text-primary">
+                          <span>You receive</span>
+                          <span>${pricingPreview.ownerPayout.toLocaleString()}</span>
                         </div>
+                        {tierDiscount > 0 && (
+                          <p className="text-xs text-primary/80 pt-1">
+                            * {tierName} tier discount applied (−{tierDiscount}%)
+                          </p>
+                        )}
                       </div>
                     </div>
                   )}
@@ -857,7 +864,7 @@ const ListProperty = () => {
                     {pricingPreview && (
                       <div className="flex justify-between text-sm pt-1 border-t">
                         <span className="text-muted-foreground">Guest total</span>
-                        <span className="font-medium">${pricingPreview.subtotal}</span>
+                        <span className="font-medium">${pricingPreview.guestTotal.toLocaleString()}</span>
                       </div>
                     )}
                   </div>

--- a/src/pages/UserGuide.tsx
+++ b/src/pages/UserGuide.tsx
@@ -45,7 +45,8 @@ import {
   Star,
   Share2,
   Compass,
-  Crown
+  Crown,
+  Percent
 } from "lucide-react";
 
 const UserGuide = () => {
@@ -75,6 +76,7 @@ const UserGuide = () => {
     { id: "manage-bids", label: "Manage Offers & Proposals", icon: Gavel },
     { id: "confirm-bookings", label: "Confirm Bookings", icon: Calendar },
     { id: "receive-payouts", label: "Receive Payouts", icon: DollarSign },
+    { id: "owner-fees-commission", label: "Understanding Fees", icon: Percent },
     { id: "cancellations", label: "Cancellations", icon: Ban },
     { id: "portfolio", label: "Portfolio Overview", icon: BarChart3 },
     { id: "pricing-suggestions", label: "Pricing Suggestions", icon: TrendingUp },
@@ -674,6 +676,109 @@ const UserGuide = () => {
                     View all earnings, pending payouts, and transaction history in Owner Dashboard → "Earnings" tab.
                     You can see your Stripe connection status and payout history at any time.
                   </p>
+                </div>
+              </section>
+            )}
+
+            {/* Owner Fees & Commission */}
+            {activeRole === "owner" && (isPrinting || activeSection === "owner-fees-commission") && (
+              <section className="space-y-8 print:break-after-page">
+                <div>
+                  <h1 className="text-4xl font-bold text-foreground mb-4">Understanding Fees & Commission</h1>
+                  <p className="text-xl text-muted-foreground">
+                    A clear breakdown of how fees work on Rent-A-Vacation — what you pay, what guests pay, and what we keep.
+                  </p>
+                </div>
+
+                <div className="bg-card rounded-xl p-6 border">
+                  <h3 className="font-semibold mb-3">How Commission Works</h3>
+                  <div className="text-sm text-muted-foreground space-y-3">
+                    <p>
+                      Rent-A-Vacation charges a <strong className="text-foreground">15% base commission</strong> on the nightly rate portion of each booking. This commission is added to the guest's total — it does not reduce your payout.
+                    </p>
+                    <p>
+                      <strong className="text-foreground">You always receive:</strong> your nightly rate × nights + cleaning fee. The commission is charged to the guest on top of your price.
+                    </p>
+                  </div>
+                </div>
+
+                <div className="bg-card rounded-xl p-6 border">
+                  <h3 className="font-semibold mb-3">Tier Discounts</h3>
+                  <div className="text-sm text-muted-foreground space-y-2">
+                    <p>Higher membership tiers reduce the commission rate, making your listings more competitive for guests:</p>
+                    <div className="grid grid-cols-3 gap-3 mt-3">
+                      <div className="text-center p-3 bg-muted/50 rounded-lg">
+                        <p className="font-bold text-foreground text-lg">15%</p>
+                        <p className="text-xs">Free tier</p>
+                      </div>
+                      <div className="text-center p-3 bg-primary/5 rounded-lg border border-primary/20">
+                        <p className="font-bold text-primary text-lg">13%</p>
+                        <p className="text-xs">Pro tier (−2%)</p>
+                      </div>
+                      <div className="text-center p-3 bg-primary/10 rounded-lg border border-primary/30">
+                        <p className="font-bold text-primary text-lg">10%</p>
+                        <p className="text-xs">Business tier (−5%)</p>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+
+                <div className="bg-card rounded-xl p-6 border">
+                  <h3 className="font-semibold mb-3">Example Booking Breakdown</h3>
+                  <div className="text-sm space-y-2 bg-muted/50 rounded-lg p-4">
+                    <div className="flex justify-between">
+                      <span className="text-muted-foreground">Nightly rate: $200 × 5 nights</span>
+                      <span>$1,000</span>
+                    </div>
+                    <div className="flex justify-between">
+                      <span className="text-muted-foreground">Cleaning fee</span>
+                      <span>$100</span>
+                    </div>
+                    <div className="flex justify-between">
+                      <span className="text-muted-foreground">RAV commission (15%)</span>
+                      <span>$150</span>
+                    </div>
+                    <div className="border-t my-1" />
+                    <div className="flex justify-between font-medium">
+                      <span>Guest pays</span>
+                      <span>$1,250</span>
+                    </div>
+                    <div className="flex justify-between font-bold text-primary">
+                      <span>You receive</span>
+                      <span>$1,100</span>
+                    </div>
+                    <div className="flex justify-between text-xs text-muted-foreground">
+                      <span>Stripe processing (2.9% + $0.30)</span>
+                      <span>−$36.55</span>
+                    </div>
+                    <div className="flex justify-between text-xs text-muted-foreground">
+                      <span>RAV keeps</span>
+                      <span>$113.45</span>
+                    </div>
+                  </div>
+                </div>
+
+                <div className="bg-green-50 dark:bg-green-950/30 rounded-xl p-6 border border-green-200 dark:border-green-800">
+                  <h3 className="font-semibold mb-3 text-green-800 dark:text-green-200">Stripe Fees Never Touch Your Payout</h3>
+                  <p className="text-sm text-green-700 dark:text-green-300">
+                    Stripe charges 2.9% + $0.30 per transaction for payment processing. This fee is deducted from our commission — <strong>your payout is always the full nightly rate plus cleaning fee</strong>. We absorb the cost of payment processing.
+                  </p>
+                </div>
+
+                <div className="bg-card rounded-xl p-6 border">
+                  <h3 className="font-semibold mb-3">Custom Agreements</h3>
+                  <p className="text-sm text-muted-foreground">
+                    In some cases, Rent-A-Vacation may offer custom commission rates for high-volume owners or strategic partnerships. If you have a custom agreement, your personalized rate will be displayed in your Owner Dashboard under "Earnings." Contact <strong>support@rent-a-vacation.com</strong> for inquiries.
+                  </p>
+                </div>
+
+                <div className="bg-card rounded-xl p-6 border">
+                  <h3 className="font-semibold mb-3">Where to See Your Fees</h3>
+                  <ul className="text-sm text-muted-foreground space-y-2">
+                    <li>• <strong className="text-foreground">Owner Dashboard → Earnings</strong> — Your effective rate, sample calculation, and booking-level fee breakdown</li>
+                    <li>• <strong className="text-foreground">List Property flow</strong> — Real-time pricing preview shows your rate and estimated payout as you set prices</li>
+                    <li>• <strong className="text-foreground">Booking details</strong> — Each booking shows commission charged and your net payout</li>
+                  </ul>
                 </div>
               </section>
             )}


### PR DESCRIPTION
## Summary
Owners now see clear, transparent fee breakdowns across 3 surfaces — building trust before they list.

## Changes
1. **Owner Dashboard (Earnings):** OwnerFeeExplainer card — effective rate with tier discount, sample booking breakdown, Stripe protection callout, tier upgrade nudge
2. **List Property:** Tier-aware pricing preview (uses actual commission rate, not hardcoded 15%), submission applies effective rate
3. **User Guide:** New "Understanding Fees" section — base rate, tier discounts (15%/13%/10%), Stripe explanation, example calculation, custom agreements

## Key message
Stripe processing fees (2.9% + $0.30) come out of RAV's commission — the owner always receives their full nightly rate + cleaning fee.

## Test plan
- [x] 1,016 tests passing (124 files, +17 new)
- [x] TypeScript: 0 errors
- [x] Build: clean
- [ ] Visual: Owner Dashboard Earnings shows fee explainer card
- [ ] Visual: List Property shows tier-adjusted rate in preview
- [ ] Visual: User Guide has "Understanding Fees" section

🤖 Generated with [Claude Code](https://claude.com/claude-code)