### PR TITLE
feat(marketplace): #283 price drop alert notifications

### DIFF
--- a/docs/PRIORITY-ROADMAP.md
+++ b/docs/PRIORITY-ROADMAP.md
@@ -1,6 +1,6 @@
 ---
-last_updated: "2026-04-13T16:21:30"
-change_ref: "74c3c98"
+last_updated: "2026-04-13T19:59:15"
+change_ref: "3750de6"
 change_type: "session-48"
 status: "active"
 ---
@@ -20,11 +20,9 @@ These are the highest-value items we can build RIGHT NOW. No blockers, no decisi
 
 | Order | Issue | Title | Why it's here |
 |-------|-------|-------|---------------|
-| **A1** | #337 | Site-wide contrast & crispness pass | Every user's first impression. Text/pills/header/hero all too dull. |
-| **A2** | #285 | Owner fee transparency | Owners won't list if they don't understand costs. Trust blocker. |
-| **A3** | #283 | Price drop alert notifications | Completes saved search → alert loop (infra already built). |
-| **A4** | #286 | Owner Tax Information form (W-9) | Needed before real payouts. |
-| **A5** | #259 | Testimonials collection + display | Social proof for launch credibility. |
+| **A1** | #283 | Price drop alert notifications | Completes saved search → alert loop (infra already built). |
+| **A2** | #286 | Owner Tax Information form (W-9) | Needed before real payouts. |
+| **A3** | #259 | Testimonials collection + display | Social proof for launch credibility. |
 
 ### Tier B: Pre-Launch Important (Needs Human Input)
 
@@ -103,7 +101,7 @@ These unblock when the LLC is formed. Not code-dependent.
 
 | Date | Session | Changes |
 |------|---------|---------|
-| Apr 13, 2026 | 49 | #327 Event-Based Search + #328 Attraction-Based Filtering completed + closed. Migration 053 deployed to DEV+PROD. PRs #334-#336 merged. Search prompt updated. Renumbered Tier A. |
+| Apr 13, 2026 | 49 | #285 Fee transparency, #327 Event Search, #328 Attraction Filter, #337 Contrast pass completed. Logos updated. Discovery bar redesigned. 1016 tests. PRs #334-#345. |
 | Apr 13, 2026 | 48 | #326 RAV Deals completed + closed. #273 Homepage completed (Session 47). Header nav consistency fix. Renumbered Tier A. |
 | Apr 12, 2026 | 47 | Initial creation. Brand rebrand completed. Search & Discovery epic created (#325-#328). Full 5-tier prioritization. |
 

--- a/src/lib/priceDropUtils.test.ts
+++ b/src/lib/priceDropUtils.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from "vitest";
+import {
+  doesListingMatchCriteria,
+  isPriceDrop,
+  priceDropPercentage,
+  formatPriceDrop,
+  type ListingForMatch,
+  type SavedSearchCriteria,
+} from "./priceDropUtils";
+
+const baseListing: ListingForMatch = {
+  nightly_rate: 180,
+  previous_nightly_rate: 220,
+  brand: "hilton_grand_vacations",
+  location: "Orlando, FL",
+  bedrooms: 2,
+  sleeps: 6,
+};
+
+describe("doesListingMatchCriteria", () => {
+  it("matches when criteria is empty (match all)", () => {
+    expect(doesListingMatchCriteria(baseListing, {})).toBe(true);
+  });
+
+  it("matches on brand filter", () => {
+    expect(doesListingMatchCriteria(baseListing, { brandFilter: "hilton_grand_vacations" })).toBe(true);
+    expect(doesListingMatchCriteria(baseListing, { brandFilter: "marriott_vacation_club" })).toBe(false);
+  });
+
+  it("ignores brand filter 'all'", () => {
+    expect(doesListingMatchCriteria(baseListing, { brandFilter: "all" })).toBe(true);
+  });
+
+  it("matches on location search query", () => {
+    expect(doesListingMatchCriteria(baseListing, { searchQuery: "Orlando" })).toBe(true);
+    expect(doesListingMatchCriteria(baseListing, { searchQuery: "orlando" })).toBe(true);
+    expect(doesListingMatchCriteria(baseListing, { searchQuery: "Las Vegas" })).toBe(false);
+  });
+
+  it("matches brand name in search query", () => {
+    expect(doesListingMatchCriteria(baseListing, { searchQuery: "hilton" })).toBe(true);
+  });
+
+  it("filters by min price", () => {
+    expect(doesListingMatchCriteria(baseListing, { minPrice: "150" })).toBe(true);
+    expect(doesListingMatchCriteria(baseListing, { minPrice: "200" })).toBe(false);
+  });
+
+  it("filters by max price", () => {
+    expect(doesListingMatchCriteria(baseListing, { maxPrice: "200" })).toBe(true);
+    expect(doesListingMatchCriteria(baseListing, { maxPrice: "150" })).toBe(false);
+  });
+
+  it("filters by min bedrooms", () => {
+    expect(doesListingMatchCriteria(baseListing, { minBedrooms: "2" })).toBe(true);
+    expect(doesListingMatchCriteria(baseListing, { minBedrooms: "3" })).toBe(false);
+  });
+
+  it("filters by min guests", () => {
+    expect(doesListingMatchCriteria(baseListing, { minGuests: "4" })).toBe(true);
+    expect(doesListingMatchCriteria(baseListing, { minGuests: "8" })).toBe(false);
+  });
+
+  it("combines multiple criteria (AND logic)", () => {
+    expect(doesListingMatchCriteria(baseListing, {
+      searchQuery: "Orlando",
+      brandFilter: "hilton_grand_vacations",
+      minBedrooms: "2",
+      maxPrice: "200",
+    })).toBe(true);
+
+    expect(doesListingMatchCriteria(baseListing, {
+      searchQuery: "Orlando",
+      brandFilter: "marriott_vacation_club", // wrong brand
+      minBedrooms: "2",
+    })).toBe(false);
+  });
+});
+
+describe("isPriceDrop", () => {
+  it("returns true when previous rate > current rate", () => {
+    expect(isPriceDrop(baseListing)).toBe(true);
+  });
+
+  it("returns false when no previous rate", () => {
+    expect(isPriceDrop({ ...baseListing, previous_nightly_rate: null })).toBe(false);
+  });
+
+  it("returns false when price increased", () => {
+    expect(isPriceDrop({ ...baseListing, previous_nightly_rate: 150 })).toBe(false);
+  });
+
+  it("returns false when price unchanged", () => {
+    expect(isPriceDrop({ ...baseListing, previous_nightly_rate: 180 })).toBe(false);
+  });
+});
+
+describe("priceDropPercentage", () => {
+  it("calculates correct percentage", () => {
+    expect(priceDropPercentage(200, 180)).toBe(10);
+    expect(priceDropPercentage(100, 75)).toBe(25);
+    expect(priceDropPercentage(300, 150)).toBe(50);
+  });
+
+  it("rounds to nearest integer", () => {
+    expect(priceDropPercentage(200, 170)).toBe(15);
+    expect(priceDropPercentage(100, 67)).toBe(33);
+  });
+
+  it("returns 0 for zero old rate", () => {
+    expect(priceDropPercentage(0, 100)).toBe(0);
+  });
+});
+
+describe("formatPriceDrop", () => {
+  it("formats price drop string", () => {
+    expect(formatPriceDrop(220, 180)).toBe("$220/night → $180/night (18% off)");
+  });
+
+  it("handles round numbers", () => {
+    expect(formatPriceDrop(200, 150)).toBe("$200/night → $150/night (25% off)");
+  });
+});

--- a/src/lib/priceDropUtils.ts
+++ b/src/lib/priceDropUtils.ts
@@ -1,0 +1,90 @@
+/**
+ * Price drop alert utilities — matching saved searches against price-dropped listings.
+ * Pure functions usable in both frontend tests and edge function logic.
+ */
+
+export interface ListingForMatch {
+  nightly_rate: number;
+  previous_nightly_rate: number | null;
+  brand: string;
+  location: string;
+  bedrooms: number;
+  sleeps: number;
+}
+
+export interface SavedSearchCriteria {
+  searchQuery?: string;
+  brandFilter?: string;
+  minPrice?: string;
+  maxPrice?: string;
+  minBedrooms?: string;
+  minGuests?: string;
+}
+
+/**
+ * Check if a listing matches a saved search's criteria.
+ * Empty criteria fields are treated as "match any".
+ */
+export function doesListingMatchCriteria(
+  listing: ListingForMatch,
+  criteria: SavedSearchCriteria
+): boolean {
+  // Brand filter
+  if (criteria.brandFilter && criteria.brandFilter !== "all") {
+    if (listing.brand !== criteria.brandFilter) return false;
+  }
+
+  // Location/text search
+  if (criteria.searchQuery?.trim()) {
+    const q = criteria.searchQuery.toLowerCase();
+    if (!listing.location.toLowerCase().includes(q) && !listing.brand.replace(/_/g, " ").toLowerCase().includes(q)) {
+      return false;
+    }
+  }
+
+  // Price range (compare nightly rate, not total)
+  if (criteria.minPrice) {
+    if (listing.nightly_rate < Number(criteria.minPrice)) return false;
+  }
+  if (criteria.maxPrice) {
+    if (listing.nightly_rate > Number(criteria.maxPrice)) return false;
+  }
+
+  // Bedrooms
+  if (criteria.minBedrooms) {
+    if (listing.bedrooms < Number(criteria.minBedrooms)) return false;
+  }
+
+  // Guests
+  if (criteria.minGuests) {
+    if (listing.sleeps < Number(criteria.minGuests)) return false;
+  }
+
+  return true;
+}
+
+/**
+ * Check if a listing has had a price drop.
+ */
+export function isPriceDrop(listing: ListingForMatch): boolean {
+  return (
+    listing.previous_nightly_rate !== null &&
+    listing.previous_nightly_rate > listing.nightly_rate
+  );
+}
+
+/**
+ * Calculate the price drop percentage.
+ */
+export function priceDropPercentage(oldRate: number, newRate: number): number {
+  if (oldRate <= 0) return 0;
+  return Math.round(((oldRate - newRate) / oldRate) * 100);
+}
+
+/**
+ * Format a price drop for display.
+ */
+export function formatPriceDrop(oldRate: number, newRate: number): string {
+  const pct = priceDropPercentage(oldRate, newRate);
+  return `$${oldRate}/night → $${newRate}/night (${pct}% off)`;
+}

--- a/supabase/functions/price-drop-checker/index.ts
+++ b/supabase/functions/price-drop-checker/index.ts
@@ -1,0 +1,247 @@
+import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
+import { createClient } from "npm:@supabase/supabase-js@2";
+import { Resend } from "npm:resend@2.0.0";
+import { buildEmailHtml, detailRow, infoBox } from "../_shared/email-template.ts";
+
+/**
+ * Price Drop Checker — Cron-triggered edge function (#283)
+ *
+ * Finds listings where nightly_rate dropped in the last 24 hours,
+ * matches them against saved searches with notify_email=true,
+ * and dispatches price drop notifications (in-app + email).
+ *
+ * Schedule: Daily via Supabase cron or external scheduler
+ * Auth: Service role key (no user auth required)
+ */
+
+const MAX_NOTIFICATIONS_PER_RUN = 100;
+const COOLDOWN_HOURS = 24; // Don't re-notify same saved search within this window
+
+interface PriceDropListing {
+  id: string;
+  nightly_rate: number;
+  previous_nightly_rate: number;
+  price_changed_at: string;
+  owner_id: string;
+  check_in_date: string;
+  check_out_date: string;
+  property: {
+    brand: string;
+    resort_name: string;
+    location: string;
+    bedrooms: number;
+    sleeps: number;
+  };
+}
+
+interface SavedSearch {
+  id: string;
+  user_id: string;
+  name: string | null;
+  criteria: Record<string, string | undefined>;
+  notify_email: boolean;
+  last_notified_at: string | null;
+}
+
+function doesListingMatchCriteria(
+  listing: PriceDropListing,
+  criteria: Record<string, string | undefined>
+): boolean {
+  if (criteria.brandFilter && criteria.brandFilter !== "all") {
+    if (listing.property.brand !== criteria.brandFilter) return false;
+  }
+  if (criteria.searchQuery?.trim()) {
+    const q = criteria.searchQuery.toLowerCase();
+    if (
+      !listing.property.location.toLowerCase().includes(q) &&
+      !listing.property.brand.replace(/_/g, " ").toLowerCase().includes(q) &&
+      !listing.property.resort_name.toLowerCase().includes(q)
+    ) {
+      return false;
+    }
+  }
+  if (criteria.minPrice && listing.nightly_rate < Number(criteria.minPrice)) return false;
+  if (criteria.maxPrice && listing.nightly_rate > Number(criteria.maxPrice)) return false;
+  if (criteria.minBedrooms && listing.property.bedrooms < Number(criteria.minBedrooms)) return false;
+  if (criteria.minGuests && listing.property.sleeps < Number(criteria.minGuests)) return false;
+  return true;
+}
+
+const handler = async (req: Request): Promise<Response> => {
+  if (req.method === "OPTIONS") {
+    return new Response(null, { status: 204 });
+  }
+
+  try {
+    const supabaseUrl = Deno.env.get("SUPABASE_URL")!;
+    const serviceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+    const resendKey = Deno.env.get("RESEND_API_KEY");
+
+    const supabase = createClient(supabaseUrl, serviceRoleKey);
+    const resend = resendKey ? new Resend(resendKey) : null;
+
+    const now = new Date();
+    const oneDayAgo = new Date(now.getTime() - 24 * 60 * 60 * 1000).toISOString();
+
+    // 1. Find listings with price drops in the last 24 hours
+    const { data: droppedListings, error: listingsError } = await supabase
+      .from("listings")
+      .select(`
+        id, nightly_rate, previous_nightly_rate, price_changed_at,
+        owner_id, check_in_date, check_out_date,
+        property:properties!listings_property_id_fkey(
+          brand, resort_name, location, bedrooms, sleeps
+        )
+      `)
+      .eq("status", "active")
+      .gte("price_changed_at", oneDayAgo)
+      .not("previous_nightly_rate", "is", null);
+
+    if (listingsError) {
+      console.error("Failed to fetch price-dropped listings:", listingsError);
+      return new Response(JSON.stringify({ error: listingsError.message }), { status: 500 });
+    }
+
+    // Filter to actual drops (previous > current)
+    const priceDrops = (droppedListings || []).filter(
+      (l: PriceDropListing) => l.previous_nightly_rate > l.nightly_rate
+    ) as PriceDropListing[];
+
+    if (priceDrops.length === 0) {
+      return new Response(
+        JSON.stringify({ sent: 0, priceDrops: 0, message: "No price drops found" }),
+        { status: 200 }
+      );
+    }
+
+    // 2. Fetch saved searches with email notifications enabled
+    const { data: savedSearches, error: searchError } = await supabase
+      .from("saved_searches")
+      .select("id, user_id, name, criteria, notify_email, last_notified_at")
+      .eq("notify_email", true);
+
+    if (searchError) {
+      console.error("Failed to fetch saved searches:", searchError);
+      return new Response(JSON.stringify({ error: searchError.message }), { status: 500 });
+    }
+
+    if (!savedSearches || savedSearches.length === 0) {
+      return new Response(
+        JSON.stringify({ sent: 0, priceDrops: priceDrops.length, message: "No saved searches with notifications" }),
+        { status: 200 }
+      );
+    }
+
+    // 3. Match and notify
+    let notificationsSent = 0;
+    const results: Array<{ search_id: string; listing_id: string; success: boolean }> = [];
+
+    const baseUrl = Deno.env.get("IS_DEV_ENVIRONMENT") === "true"
+      ? "https://rentavacation.vercel.app"
+      : "https://rent-a-vacation.com";
+
+    for (const listing of priceDrops) {
+      if (notificationsSent >= MAX_NOTIFICATIONS_PER_RUN) break;
+
+      const dropPct = Math.round(
+        ((listing.previous_nightly_rate - listing.nightly_rate) / listing.previous_nightly_rate) * 100
+      );
+
+      for (const search of savedSearches as SavedSearch[]) {
+        if (notificationsSent >= MAX_NOTIFICATIONS_PER_RUN) break;
+
+        // Don't notify the listing owner about their own listing
+        if (search.user_id === listing.owner_id) continue;
+
+        // Cooldown check
+        if (search.last_notified_at) {
+          const lastNotified = new Date(search.last_notified_at);
+          const hoursSince = (now.getTime() - lastNotified.getTime()) / (1000 * 60 * 60);
+          if (hoursSince < COOLDOWN_HOURS) continue;
+        }
+
+        // Criteria match
+        if (!doesListingMatchCriteria(listing, search.criteria)) continue;
+
+        // Create in-app notification
+        await supabase.from("notifications").insert({
+          user_id: search.user_id,
+          type: "price_drop",
+          title: `Price dropped ${dropPct}% on a listing you're watching`,
+          message: `${listing.property.resort_name} in ${listing.property.location} — now $${listing.nightly_rate}/night (was $${listing.previous_nightly_rate}/night)`,
+          linked_entity_id: listing.id,
+          linked_entity_type: "listing",
+        });
+
+        // Send email
+        if (resend) {
+          const { data: profile } = await supabase
+            .from("profiles")
+            .select("email, full_name")
+            .eq("id", search.user_id)
+            .single();
+
+          if (profile?.email) {
+            const html = buildEmailHtml({
+              recipientName: profile.full_name?.split(" ")[0] || undefined,
+              heading: "Price Drop Alert",
+              body: `
+                <p>Great news! A listing matching your saved search just dropped in price.</p>
+                ${detailRow("Resort", listing.property.resort_name)}
+                ${detailRow("Location", listing.property.location)}
+                ${detailRow("Was", `$${listing.previous_nightly_rate}/night`)}
+                ${detailRow("Now", `<strong style="color: #0d6b5c;">$${listing.nightly_rate}/night</strong>`)}
+                ${detailRow("Savings", `${dropPct}% off`)}
+                ${detailRow("Dates", `${listing.check_in_date} → ${listing.check_out_date}`)}
+                ${infoBox("Price drops don't last long — make a RAV Offer before someone else does!", "info")}
+                <p style="font-size: 12px; color: #718096; margin-top: 20px;">
+                  You're receiving this because you have a saved search with price alerts enabled.
+                  <a href="${baseUrl}/my-trips?tab=saved-searches" style="color: #0d6b5c;">Manage your saved searches</a>
+                </p>`,
+              cta: { label: "View Listing", url: `${baseUrl}/property/${listing.id}` },
+            });
+
+            try {
+              await resend.emails.send({
+                from: "Rent-A-Vacation <notifications@updates.rent-a-vacation.com>",
+                to: profile.email,
+                subject: `📉 Price dropped ${dropPct}% — ${listing.property.resort_name}`,
+                html,
+              });
+              results.push({ search_id: search.id, listing_id: listing.id, success: true });
+            } catch (emailError) {
+              console.error(`Email failed for ${profile.email}:`, emailError);
+              results.push({ search_id: search.id, listing_id: listing.id, success: false });
+            }
+          }
+        }
+
+        // Update last_notified_at
+        await supabase
+          .from("saved_searches")
+          .update({ last_notified_at: now.toISOString() })
+          .eq("id", search.id);
+
+        notificationsSent++;
+      }
+    }
+
+    return new Response(
+      JSON.stringify({
+        priceDrops: priceDrops.length,
+        savedSearches: (savedSearches as SavedSearch[]).length,
+        sent: notificationsSent,
+        results,
+      }),
+      { status: 200, headers: { "Content-Type": "application/json" } }
+    );
+  } catch (err) {
+    console.error("Price drop checker error:", err);
+    return new Response(
+      JSON.stringify({ error: String(err) }),
+      { status: 500 }
+    );
+  }
+};
+
+serve(handler);

--- a/supabase/functions/seed-manager/index.ts
+++ b/supabase/functions/seed-manager/index.ts
@@ -751,6 +751,19 @@ async function createInventory(
   }
 
   log.push(`Created ${listingIds.length} listings (15 active, 10 bidding, 5 draft)`);
+
+  // Simulate price drops on first 3 active listings for UI badge testing
+  for (let i = 0; i < Math.min(3, listingIds.length); i++) {
+    await admin
+      .from("listings")
+      .update({
+        previous_nightly_rate: randomInt(250, 400),
+        price_changed_at: new Date().toISOString(),
+      })
+      .eq("id", listingIds[i]);
+  }
+  log.push("Set price drops on 3 listings for badge testing");
+
   return { propertyIds, listingIds };
 }
 

--- a/supabase/migrations/054_price_drop_alerts.sql
+++ b/supabase/migrations/054_price_drop_alerts.sql
@@ -1,0 +1,44 @@
+-- Migration 054: Price Drop Alert Infrastructure (#283)
+-- 1. Trigger to auto-track nightly_rate changes on listings
+-- 2. Notification catalog entry for price_drop_alert
+
+-- ============================================================
+-- 1. Trigger function to track nightly rate changes
+-- ============================================================
+CREATE OR REPLACE FUNCTION track_nightly_rate_change()
+RETURNS TRIGGER AS $$
+BEGIN
+  -- Only fire when nightly_rate actually changed and decreased (price drop)
+  IF OLD.nightly_rate IS DISTINCT FROM NEW.nightly_rate THEN
+    NEW.previous_nightly_rate := OLD.nightly_rate;
+    NEW.price_changed_at := NOW();
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Apply trigger to listings table
+DROP TRIGGER IF EXISTS track_listing_price_change ON listings;
+CREATE TRIGGER track_listing_price_change
+  BEFORE UPDATE ON listings
+  FOR EACH ROW
+  EXECUTE FUNCTION track_nightly_rate_change();
+
+-- ============================================================
+-- 2. Add price_drop_alert to notification catalog
+-- ============================================================
+INSERT INTO notification_catalog (
+  type_key, display_name, description, category, opt_out_level,
+  default_in_app, default_email, default_sms,
+  channel_in_app_allowed, channel_email_allowed, channel_sms_allowed,
+  sort_order
+) VALUES (
+  'price_drop_alert',
+  'Price Drop Alert',
+  'Notification when a listing matching your saved search drops in price',
+  'marketing',
+  'fully_optional',
+  true, true, false,
+  true, true, false,
+  53
+) ON CONFLICT (type_key) DO NOTHING;


### PR DESCRIPTION
## Summary
Completes the saved search → alert loop. When an owner drops their nightly rate, travelers with matching saved searches get notified via in-app + email.

## Changes
- **Migration 054:** Trigger on listings to auto-track nightly_rate changes + `price_drop_alert` catalog entry
- **price-drop-checker edge function:** Daily cron — finds drops, matches saved searches, dispatches notifications
- **priceDropUtils.ts:** Matching (brand, location, price, bedrooms, guests) + formatting utilities
- **Seed manager:** 3 listings get simulated price drops for UI testing

## How it works
1. Owner updates nightly rate → trigger stores `previous_nightly_rate` + `price_changed_at`
2. Daily cron finds listings with drops in last 24h
3. Matches against saved searches with `notify_email=true`
4. Dispatches in-app notification + branded email with old→new price, savings %, CTA
5. 24h cooldown per saved search, max 100 per run

## Test plan
- [x] 1,035 tests (125 files, +19 new)
- [x] TypeScript: 0 errors
- [x] Build: clean
- [ ] Deploy migration 054 to DEV
- [ ] Deploy edge function to DEV

🤖 Generated with [Claude Code](https://claude.com/claude-code)