### PR TITLE
feat(owner): #286 tax information form (W-9)

### DIFF
--- a/docs/PRIORITY-ROADMAP.md
+++ b/docs/PRIORITY-ROADMAP.md
@@ -1,6 +1,6 @@
 ---
-last_updated: "2026-04-13T19:59:15"
-change_ref: "3750de6"
+last_updated: "2026-04-13T21:22:54"
+change_ref: "cc4ccb8"
 change_type: "session-48"
 status: "active"
 ---
@@ -20,9 +20,8 @@ These are the highest-value items we can build RIGHT NOW. No blockers, no decisi
 
 | Order | Issue | Title | Why it's here |
 |-------|-------|-------|---------------|
-| **A1** | #283 | Price drop alert notifications | Completes saved search → alert loop (infra already built). |
-| **A2** | #286 | Owner Tax Information form (W-9) | Needed before real payouts. |
-| **A3** | #259 | Testimonials collection + display | Social proof for launch credibility. |
+| **A1** | #286 | Owner Tax Information form (W-9) | Needed before real payouts. |
+| **A2** | #259 | Testimonials collection + display | Social proof for launch credibility. |
 
 ### Tier B: Pre-Launch Important (Needs Human Input)
 
@@ -101,7 +100,7 @@ These unblock when the LLC is formed. Not code-dependent.
 
 | Date | Session | Changes |
 |------|---------|---------|
-| Apr 13, 2026 | 49 | #285 Fee transparency, #327 Event Search, #328 Attraction Filter, #337 Contrast pass completed. Logos updated. Discovery bar redesigned. 1016 tests. PRs #334-#345. |
+| Apr 13, 2026 | 49 | #283 Price drop alerts, #285 Fee transparency, #327 Event Search, #328 Attraction Filter, #337 Contrast pass. Logos updated. Discovery bar. 1035 tests. PRs #334-#346. |
 | Apr 13, 2026 | 48 | #326 RAV Deals completed + closed. #273 Homepage completed (Session 47). Header nav consistency fix. Renumbered Tier A. |
 | Apr 12, 2026 | 47 | Initial creation. Brand rebrand completed. Search & Discovery epic created (#325-#328). Full 5-tier prioritization. |
 

--- a/src/components/owner/OwnerTaxInfo.test.tsx
+++ b/src/components/owner/OwnerTaxInfo.test.tsx
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { OwnerTaxInfo } from "./OwnerTaxInfo";
+
+// Mock auth
+const mockUser = { id: "user-1", email: "test@test.com" };
+vi.mock("@/hooks/useAuth", () => ({
+  useAuth: () => ({ user: mockUser }),
+}));
+
+// Mock toast
+vi.mock("@/hooks/use-toast", () => ({
+  useToast: () => ({ toast: vi.fn() }),
+}));
+
+// Mock supabase
+const mockSelect = vi.fn().mockReturnValue({
+  eq: vi.fn().mockReturnValue({
+    single: vi.fn().mockResolvedValue({
+      data: {
+        tax_id_type: null,
+        tax_id_last4: null,
+        w9_submitted_at: null,
+        tax_business_name: null,
+        tax_address_line1: null,
+        tax_address_line2: null,
+        tax_city: null,
+        tax_state: null,
+        tax_zip: null,
+      },
+      error: null,
+    }),
+  }),
+});
+
+vi.mock("@/lib/supabase", () => ({
+  supabase: {
+    from: () => ({ select: mockSelect }),
+  },
+}));
+
+function renderTaxInfo() {
+  return render(<OwnerTaxInfo />);
+}
+
+describe("OwnerTaxInfo", () => {
+  it("renders the tax info card", async () => {
+    renderTaxInfo();
+    expect(await screen.findByText("Tax Information (W-9)")).toBeTruthy();
+  });
+
+  it("shows Incomplete badge when W-9 not submitted", async () => {
+    renderTaxInfo();
+    expect(await screen.findByText("Incomplete")).toBeTruthy();
+  });
+
+  it("shows SSN and EIN radio options", async () => {
+    renderTaxInfo();
+    expect(await screen.findByText("Social Security Number (SSN)")).toBeTruthy();
+    expect(screen.getByText("Employer Identification Number (EIN)")).toBeTruthy();
+  });
+
+  it("shows tax ID input with mask prefix", async () => {
+    renderTaxInfo();
+    expect(await screen.findByText("***-**-")).toBeTruthy();
+    expect(screen.getByPlaceholderText("0000")).toBeTruthy();
+  });
+
+  it("shows address fields", async () => {
+    renderTaxInfo();
+    expect(await screen.findByPlaceholderText("Address line 1")).toBeTruthy();
+    expect(screen.getByPlaceholderText("City")).toBeTruthy();
+    expect(screen.getByPlaceholderText("ZIP")).toBeTruthy();
+  });
+
+  it("shows W-9 certification checkbox", async () => {
+    renderTaxInfo();
+    expect(await screen.findByText(/W-9 Certification/)).toBeTruthy();
+  });
+
+  it("shows security note about last 4 digits", async () => {
+    renderTaxInfo();
+    expect(await screen.findByText(/only store the last 4 digits/)).toBeTruthy();
+  });
+
+  it("shows $600 threshold info", async () => {
+    renderTaxInfo();
+    const matches = await screen.findAllByText(/\$600 or more/);
+    expect(matches.length).toBeGreaterThan(0);
+  });
+
+  it("shows submit button", async () => {
+    renderTaxInfo();
+    expect(await screen.findByText("Submit W-9 Information")).toBeTruthy();
+  });
+});
+
+describe("OwnerTaxInfo with submitted data", () => {
+  beforeEach(() => {
+    mockSelect.mockReturnValue({
+      eq: vi.fn().mockReturnValue({
+        single: vi.fn().mockResolvedValue({
+          data: {
+            tax_id_type: "ssn",
+            tax_id_last4: "1234",
+            w9_submitted_at: "2026-03-15T00:00:00Z",
+            tax_business_name: null,
+            tax_address_line1: "123 Main St",
+            tax_address_line2: null,
+            tax_city: "Orlando",
+            tax_state: "FL",
+            tax_zip: "32801",
+          },
+          error: null,
+        }),
+      }),
+    });
+  });
+
+  it("shows W-9 Submitted badge", async () => {
+    renderTaxInfo();
+    expect(await screen.findByText("W-9 Submitted")).toBeTruthy();
+  });
+
+  it("shows Update button instead of Submit", async () => {
+    renderTaxInfo();
+    expect(await screen.findByText("Update Tax Information")).toBeTruthy();
+  });
+
+  it("shows last submitted date", async () => {
+    renderTaxInfo();
+    expect(await screen.findByText(/Last submitted:/)).toBeTruthy();
+  });
+});

--- a/src/components/owner/OwnerTaxInfo.tsx
+++ b/src/components/owner/OwnerTaxInfo.tsx
@@ -1,0 +1,328 @@
+import { useState, useEffect } from "react";
+import { supabase } from "@/lib/supabase";
+import { useAuth } from "@/hooks/useAuth";
+import { useToast } from "@/hooks/use-toast";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { FileText, CheckCircle, AlertCircle, Loader2, ShieldCheck } from "lucide-react";
+
+const US_STATES = [
+  "AL","AK","AZ","AR","CA","CO","CT","DE","FL","GA","HI","ID","IL","IN","IA",
+  "KS","KY","LA","ME","MD","MA","MI","MN","MS","MO","MT","NE","NV","NH","NJ",
+  "NM","NY","NC","ND","OH","OK","OR","PA","RI","SC","SD","TN","TX","UT","VT",
+  "VA","WA","WV","WI","WY","DC",
+];
+
+interface TaxData {
+  tax_id_type: "ssn" | "ein" | null;
+  tax_id_last4: string | null;
+  w9_submitted_at: string | null;
+  tax_business_name: string | null;
+  tax_address_line1: string | null;
+  tax_address_line2: string | null;
+  tax_city: string | null;
+  tax_state: string | null;
+  tax_zip: string | null;
+}
+
+export function OwnerTaxInfo() {
+  const { user } = useAuth();
+  const { toast } = useToast();
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSaving, setIsSaving] = useState(false);
+  const [taxData, setTaxData] = useState<TaxData>({
+    tax_id_type: null,
+    tax_id_last4: null,
+    w9_submitted_at: null,
+    tax_business_name: null,
+    tax_address_line1: null,
+    tax_address_line2: null,
+    tax_city: null,
+    tax_state: null,
+    tax_zip: null,
+  });
+  const [taxIdInput, setTaxIdInput] = useState("");
+  const [w9Acknowledged, setW9Acknowledged] = useState(false);
+
+  // Fetch existing tax data
+  useEffect(() => {
+    if (!user) return;
+    const fetchTaxData = async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const { data, error } = await (supabase.from("profiles") as any)
+        .select("tax_id_type, tax_id_last4, w9_submitted_at, tax_business_name, tax_address_line1, tax_address_line2, tax_city, tax_state, tax_zip")
+        .eq("id", user.id)
+        .single();
+
+      if (!error && data) {
+        setTaxData(data as TaxData);
+        if (data.w9_submitted_at) setW9Acknowledged(true);
+      }
+      setIsLoading(false);
+    };
+    fetchTaxData();
+  }, [user]);
+
+  const isSubmitted = !!taxData.w9_submitted_at;
+  const isEin = taxData.tax_id_type === "ein";
+
+  const canSave =
+    taxData.tax_id_type &&
+    taxIdInput.length === 4 &&
+    /^\d{4}$/.test(taxIdInput) &&
+    taxData.tax_address_line1?.trim() &&
+    taxData.tax_city?.trim() &&
+    taxData.tax_state &&
+    taxData.tax_zip?.trim() &&
+    /^\d{5}(-\d{4})?$/.test(taxData.tax_zip?.trim() || "") &&
+    w9Acknowledged &&
+    (!isEin || taxData.tax_business_name?.trim());
+
+  const handleSave = async () => {
+    if (!user || !canSave) return;
+    setIsSaving(true);
+
+    try {
+      const updateData = {
+        tax_id_type: taxData.tax_id_type,
+        tax_id_last4: taxIdInput,
+        tax_business_name: isEin ? taxData.tax_business_name : null,
+        tax_address_line1: taxData.tax_address_line1,
+        tax_address_line2: taxData.tax_address_line2 || null,
+        tax_city: taxData.tax_city,
+        tax_state: taxData.tax_state,
+        tax_zip: taxData.tax_zip,
+        w9_submitted_at: new Date().toISOString(),
+      };
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const { error } = await (supabase.from("profiles") as any)
+        .update(updateData)
+        .eq("id", user.id);
+
+      if (error) throw error;
+
+      setTaxData((prev) => ({ ...prev, ...updateData }));
+      toast({
+        title: "Tax information saved",
+        description: "Your W-9 information has been submitted successfully.",
+      });
+    } catch (error) {
+      console.error("Error saving tax info:", error);
+      toast({
+        title: "Error",
+        description: "Failed to save tax information. Please try again.",
+        variant: "destructive",
+      });
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const updateField = (field: keyof TaxData, value: string | null) => {
+    setTaxData((prev) => ({ ...prev, [field]: value }));
+  };
+
+  if (isLoading) {
+    return (
+      <Card>
+        <CardContent className="flex justify-center py-8">
+          <Loader2 className="w-6 h-6 animate-spin text-muted-foreground" />
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center justify-between">
+          <div>
+            <CardTitle className="flex items-center gap-2">
+              <FileText className="w-5 h-5 text-primary" />
+              Tax Information (W-9)
+            </CardTitle>
+            <CardDescription className="mt-1">
+              Required for 1099-K tax reporting if you earn $600 or more per year.
+            </CardDescription>
+          </div>
+          {isSubmitted ? (
+            <Badge variant="secondary" className="bg-green-100 text-green-700 border-green-200">
+              <CheckCircle className="w-3 h-3 mr-1" />
+              W-9 Submitted
+            </Badge>
+          ) : (
+            <Badge variant="secondary" className="bg-amber-100 text-amber-700 border-amber-200">
+              <AlertCircle className="w-3 h-3 mr-1" />
+              Incomplete
+            </Badge>
+          )}
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        {/* Tax ID Type */}
+        <div className="space-y-2">
+          <Label className="text-sm font-semibold">Tax ID Type</Label>
+          <div className="flex gap-4">
+            <label className="flex items-center gap-2 cursor-pointer">
+              <input
+                type="radio"
+                name="taxIdType"
+                checked={taxData.tax_id_type === "ssn"}
+                onChange={() => updateField("tax_id_type", "ssn")}
+                className="accent-primary"
+              />
+              <span className="text-sm">Social Security Number (SSN)</span>
+            </label>
+            <label className="flex items-center gap-2 cursor-pointer">
+              <input
+                type="radio"
+                name="taxIdType"
+                checked={taxData.tax_id_type === "ein"}
+                onChange={() => updateField("tax_id_type", "ein")}
+                className="accent-primary"
+              />
+              <span className="text-sm">Employer Identification Number (EIN)</span>
+            </label>
+          </div>
+        </div>
+
+        {/* Tax ID Last 4 */}
+        <div className="space-y-2">
+          <Label htmlFor="taxIdLast4" className="text-sm font-semibold">
+            Last 4 digits of your {taxData.tax_id_type === "ein" ? "EIN" : "SSN"}
+          </Label>
+          <div className="flex items-center gap-2 max-w-xs">
+            <span className="text-muted-foreground text-sm font-mono">***-**-</span>
+            <Input
+              id="taxIdLast4"
+              type="text"
+              inputMode="numeric"
+              maxLength={4}
+              pattern="\d{4}"
+              placeholder="0000"
+              value={taxIdInput || taxData.tax_id_last4 || ""}
+              onChange={(e) => {
+                const val = e.target.value.replace(/\D/g, "").slice(0, 4);
+                setTaxIdInput(val);
+              }}
+              className="w-24 font-mono"
+            />
+          </div>
+          <p className="text-xs text-muted-foreground">
+            <ShieldCheck className="w-3 h-3 inline mr-1" />
+            We only store the last 4 digits for your security. Full tax ID is never stored.
+          </p>
+        </div>
+
+        {/* Business Name (EIN only) */}
+        {isEin && (
+          <div className="space-y-2">
+            <Label htmlFor="businessName" className="text-sm font-semibold">Business Name</Label>
+            <Input
+              id="businessName"
+              placeholder="Legal business name"
+              value={taxData.tax_business_name || ""}
+              onChange={(e) => updateField("tax_business_name", e.target.value)}
+            />
+          </div>
+        )}
+
+        {/* Address */}
+        <div className="space-y-4">
+          <Label className="text-sm font-semibold">Tax Address</Label>
+          <div className="space-y-3">
+            <Input
+              placeholder="Address line 1"
+              value={taxData.tax_address_line1 || ""}
+              onChange={(e) => updateField("tax_address_line1", e.target.value)}
+            />
+            <Input
+              placeholder="Address line 2 (optional)"
+              value={taxData.tax_address_line2 || ""}
+              onChange={(e) => updateField("tax_address_line2", e.target.value)}
+            />
+            <div className="grid grid-cols-3 gap-3">
+              <Input
+                placeholder="City"
+                value={taxData.tax_city || ""}
+                onChange={(e) => updateField("tax_city", e.target.value)}
+              />
+              <Select
+                value={taxData.tax_state || ""}
+                onValueChange={(v) => updateField("tax_state", v)}
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="State" />
+                </SelectTrigger>
+                <SelectContent>
+                  {US_STATES.map((s) => (
+                    <SelectItem key={s} value={s}>{s}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <Input
+                placeholder="ZIP"
+                value={taxData.tax_zip || ""}
+                onChange={(e) => updateField("tax_zip", e.target.value)}
+                maxLength={10}
+              />
+            </div>
+          </div>
+        </div>
+
+        {/* W-9 Acknowledgment */}
+        <div className="flex items-start gap-3 p-4 bg-muted/50 rounded-lg border">
+          <Checkbox
+            id="w9Acknowledge"
+            checked={w9Acknowledged}
+            onCheckedChange={(checked) => setW9Acknowledged(checked === true)}
+          />
+          <label htmlFor="w9Acknowledge" className="text-sm cursor-pointer leading-relaxed">
+            <strong>W-9 Certification:</strong> Under penalties of perjury, I certify that the information provided above is correct, including my taxpayer identification number (last 4 digits). I understand this information will be used for IRS Form 1099-K reporting if my earnings exceed $600 in a calendar year.
+          </label>
+        </div>
+
+        {/* Info note */}
+        <div className="flex gap-2 text-xs text-muted-foreground bg-primary/5 rounded-lg p-3">
+          <AlertCircle className="w-4 h-4 shrink-0 mt-0.5 text-primary" />
+          <p>
+            The IRS requires platforms to issue Form 1099-K if you receive $600 or more in a calendar year. Your tax information is encrypted and only used for tax reporting purposes.
+          </p>
+        </div>
+
+        {/* Save button */}
+        <div className="flex gap-3">
+          <Button onClick={handleSave} disabled={!canSave || isSaving}>
+            {isSaving ? (
+              <>
+                <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                Saving...
+              </>
+            ) : isSubmitted ? (
+              "Update Tax Information"
+            ) : (
+              "Submit W-9 Information"
+            )}
+          </Button>
+          {isSubmitted && taxData.w9_submitted_at && (
+            <p className="text-xs text-muted-foreground self-center">
+              Last submitted: {new Date(taxData.w9_submitted_at).toLocaleDateString()}
+            </p>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/pages/OwnerDashboard.tsx
+++ b/src/pages/OwnerDashboard.tsx
@@ -50,6 +50,7 @@ import { OwnerPayouts } from "@/components/owner/OwnerPayouts";
 import { MembershipPlans } from "@/components/MembershipPlans";
 import { SubscriptionManagement } from "@/components/SubscriptionManagement";
 import { ReferralDashboard } from "@/components/owner/ReferralDashboard";
+import { OwnerTaxInfo } from "@/components/owner/OwnerTaxInfo";
 import { useOwnerCommission } from "@/hooks/useOwnerCommission";
 import { useOwnerDashboardStats } from "@/hooks/owner/useOwnerDashboardStats";
 import { useOwnerEarnings } from "@/hooks/owner/useOwnerEarnings";
@@ -650,6 +651,19 @@ const OwnerDashboard = () => {
               </CollapsibleTrigger>
               <CollapsibleContent>
                 <OwnerVerification />
+              </CollapsibleContent>
+            </Collapsible>
+
+            <Collapsible>
+              <CollapsibleTrigger className="flex items-center justify-between w-full py-3 text-left border-t pt-6">
+                <h3 className="text-lg font-semibold flex items-center gap-2">
+                  <FileText className="h-5 w-5 text-primary" />
+                  Tax Information
+                </h3>
+                <ChevronDown className="h-4 w-4 text-muted-foreground transition-transform [[data-state=open]>&]:rotate-180" />
+              </CollapsibleTrigger>
+              <CollapsibleContent>
+                <OwnerTaxInfo />
               </CollapsibleContent>
             </Collapsible>
 


### PR DESCRIPTION
## Summary
Owners can now submit their tax information (SSN/EIN + address) for 1099-K compliance, directly from their Dashboard.

## Changes
- `OwnerTaxInfo` component: SSN/EIN selector, masked ID input (last 4 only), conditional business name, full address form, W-9 certification checkbox
- Integrated into Owner Dashboard → Account tab as collapsible "Tax Information" section
- Status badges: W-9 Submitted (green) vs Incomplete (amber)
- Security: only last 4 digits stored, clear disclosure to owner

## Test plan
- [x] 1,047 tests (126 files, +12 new)
- [x] TypeScript: 0 errors
- [x] Build: clean
- [ ] Visual: Owner Dashboard Account tab shows Tax Information section
- [ ] Verify SSN/EIN toggle, masked input, conditional business name
- [ ] Verify W-9 submission saves to profiles table

🤖 Generated with [Claude Code](https://claude.com/claude-code)