### PR TITLE
feat(admin): #338 unify curated events into DB + admin CRUD UI

### DIFF
--- a/docs/PRIORITY-ROADMAP.md
+++ b/docs/PRIORITY-ROADMAP.md
@@ -1,7 +1,7 @@
 ---
-last_updated: "2026-04-13T23:02:02"
-change_ref: "c90ec51"
-change_type: "session-48"
+last_updated: "2026-04-14T10:45:32"
+change_ref: "e45e7fb"
+change_type: "session-50"
 status: "active"
 ---
 # PRIORITY ROADMAP — Rent-A-Vacation
@@ -27,8 +27,7 @@ These require decisions, walkthroughs, or external dependencies before coding.
 | #187 | Pre-launch manual verification | Needs systematic walkthrough. Partially done. |
 | #257 | Resort data compliance audit | Legal review of seed data sources. |
 | #322 | RAV Wishes proposal enforcement | Deferred until 30+ days of real proposal data. Post-beta. |
-| #338 | Admin Event Management UI | Move events from static code to DB-driven admin. Depends on staff workflow. |
-| #339 | Multi-year event support | Recurring templates + 2027+ dates. Depends on #338. |
+| #339 | Multi-year event support | Recurring templates + 2027+ dates. Depends on #338 (now unblocked). |
 | #349 | UI polish audit — spacing, sections, visual hierarchy | Aggressive site-wide pass. Can run in parallel with feature work. |
 
 ### Tier C: Tier Feature Differentiation (Bundle as Sprint)
@@ -96,6 +95,7 @@ These unblock when the LLC is formed. Not code-dependent.
 
 | Date | Session | Changes |
 |------|---------|---------|
+| Apr 14, 2026 | 50 | #338 completed. Events unified: static `lib/events.ts` migrated to DB (seasonal_events + event_instances). Migration 055 (slug/icon/is_nationwide/search_destinations columns, end_date, nullable destination, 14 events backfilled, get_curated_events RPC). Admin Templates tab + Add/Edit instance dialogs. `useCuratedEvents` hook. 1046 tests. #339 now unblocked. |
 | Apr 13, 2026 | 49 | Tier A cleared: #259, #283, #285, #286, #327, #328, #337. Logos. Discovery bar. Tax form. Social proof. 1047 tests. PRs #334-#348. |
 | Apr 13, 2026 | 48 | #326 RAV Deals completed + closed. #273 Homepage completed (Session 47). Header nav consistency fix. Renumbered Tier A. |
 | Apr 12, 2026 | 47 | Initial creation. Brand rebrand completed. Search & Discovery epic created (#325-#328). Full 5-tier prioritization. |

--- a/docs/PRIORITY-ROADMAP.md
+++ b/docs/PRIORITY-ROADMAP.md
@@ -1,6 +1,6 @@
 ---
-last_updated: "2026-04-13T21:55:14"
-change_ref: "94c5739"
+last_updated: "2026-04-13T22:19:39"
+change_ref: "bd9f850"
 change_type: "session-48"
 status: "active"
 ---
@@ -16,11 +16,7 @@ status: "active"
 
 ### Tier A: Build Next (High Impact, Code-Ready)
 
-These are the highest-value items we can build RIGHT NOW. No blockers, no decisions needed.
-
-| Order | Issue | Title | Why it's here |
-|-------|-------|-------|---------------|
-| **A1** | #259 | Testimonials collection + display | Social proof for launch credibility. |
+**Tier A is EMPTY** — all items completed in Session 49. Promote from Tier B/C as needed.
 
 ### Tier B: Pre-Launch Important (Needs Human Input)
 
@@ -99,7 +95,7 @@ These unblock when the LLC is formed. Not code-dependent.
 
 | Date | Session | Changes |
 |------|---------|---------|
-| Apr 13, 2026 | 49 | #283, #285, #286, #327, #328, #337 completed. Logos updated. Discovery bar. Tax form. 1047 tests. PRs #334-#347. |
+| Apr 13, 2026 | 49 | Tier A cleared: #259, #283, #285, #286, #327, #328, #337. Logos. Discovery bar. Tax form. Social proof. 1047 tests. PRs #334-#348. |
 | Apr 13, 2026 | 48 | #326 RAV Deals completed + closed. #273 Homepage completed (Session 47). Header nav consistency fix. Renumbered Tier A. |
 | Apr 12, 2026 | 47 | Initial creation. Brand rebrand completed. Search & Discovery epic created (#325-#328). Full 5-tier prioritization. |
 

--- a/docs/PRIORITY-ROADMAP.md
+++ b/docs/PRIORITY-ROADMAP.md
@@ -1,6 +1,6 @@
 ---
-last_updated: "2026-04-13T22:19:39"
-change_ref: "bd9f850"
+last_updated: "2026-04-13T23:02:02"
+change_ref: "c90ec51"
 change_type: "session-48"
 status: "active"
 ---
@@ -29,6 +29,7 @@ These require decisions, walkthroughs, or external dependencies before coding.
 | #322 | RAV Wishes proposal enforcement | Deferred until 30+ days of real proposal data. Post-beta. |
 | #338 | Admin Event Management UI | Move events from static code to DB-driven admin. Depends on staff workflow. |
 | #339 | Multi-year event support | Recurring templates + 2027+ dates. Depends on #338. |
+| #349 | UI polish audit — spacing, sections, visual hierarchy | Aggressive site-wide pass. Can run in parallel with feature work. |
 
 ### Tier C: Tier Feature Differentiation (Bundle as Sprint)
 

--- a/src/components/admin/AdminEventTemplates.tsx
+++ b/src/components/admin/AdminEventTemplates.tsx
@@ -1,0 +1,213 @@
+/**
+ * Admin Event Templates tab — CRUD for seasonal_events.
+ * Issue #338.
+ */
+
+import { useState, useEffect, useCallback } from "react";
+import { supabase } from "@/lib/supabase";
+import { useToast } from "@/hooks/use-toast";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Plus, Edit2, Archive, ArchiveRestore } from "lucide-react";
+import { EventTemplateDialog, type EventTemplate } from "./EventTemplateDialog";
+
+interface TemplateRow extends EventTemplate {
+  id: string;
+}
+
+export function AdminEventTemplates() {
+  const { toast } = useToast();
+  const [rows, setRows] = useState<TemplateRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [editing, setEditing] = useState<TemplateRow | null>(null);
+  const [confirmRetire, setConfirmRetire] = useState<TemplateRow | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    const { data, error } = await supabase
+      .from("seasonal_events")
+      .select("*")
+      .order("typical_month", { ascending: true, nullsFirst: false })
+      .order("name");
+    if (error) {
+      toast({ title: "Load failed", description: error.message, variant: "destructive" });
+    } else {
+      setRows((data ?? []) as TemplateRow[]);
+    }
+    setLoading(false);
+  }, [toast]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const handleToggleActive = async (row: TemplateRow) => {
+    const next = !row.active;
+    const { error } = await supabase
+      .from("seasonal_events")
+      .update({ active: next })
+      .eq("id", row.id);
+    if (error) {
+      toast({ title: "Update failed", description: error.message, variant: "destructive" });
+    } else {
+      setRows((prev) => prev.map((r) => (r.id === row.id ? { ...r, active: next } : r)));
+      toast({ title: next ? "Template reactivated" : "Template retired" });
+    }
+    setConfirmRetire(null);
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <div>
+          <p className="text-sm text-muted-foreground">
+            Event templates define recurring events. Add specific-year dates in the Event Calendar tab.
+          </p>
+        </div>
+        <Button
+          size="sm"
+          onClick={() => {
+            setEditing(null);
+            setDialogOpen(true);
+          }}
+        >
+          <Plus className="h-4 w-4 mr-1.5" />
+          New Template
+        </Button>
+      </div>
+
+      {loading ? (
+        <div className="py-8 text-center text-muted-foreground">Loading...</div>
+      ) : (
+        <div className="overflow-x-auto">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Name</TableHead>
+                <TableHead>Slug</TableHead>
+                <TableHead>Category</TableHead>
+                <TableHead>Recurrence</TableHead>
+                <TableHead>Scope</TableHead>
+                <TableHead>Destinations</TableHead>
+                <TableHead>Active</TableHead>
+                <TableHead>Actions</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {rows.length === 0 ? (
+                <TableRow>
+                  <TableCell colSpan={8} className="text-center py-8 text-muted-foreground">
+                    No event templates yet. Click "New Template" to create one.
+                  </TableCell>
+                </TableRow>
+              ) : (
+                rows.map((row) => (
+                  <TableRow key={row.id} className={row.active ? "" : "opacity-50"}>
+                    <TableCell className="text-sm font-medium">{row.name}</TableCell>
+                    <TableCell className="text-xs font-mono text-muted-foreground">
+                      {row.slug ?? "—"}
+                    </TableCell>
+                    <TableCell className="text-xs">
+                      <Badge variant="outline">{row.category}</Badge>
+                    </TableCell>
+                    <TableCell className="text-xs">{row.recurrence_type}</TableCell>
+                    <TableCell className="text-xs">
+                      {row.is_nationwide ? (
+                        <Badge variant="outline" className="bg-blue-50">Nationwide</Badge>
+                      ) : (
+                        <Badge variant="outline">Destination-scoped</Badge>
+                      )}
+                    </TableCell>
+                    <TableCell className="text-xs text-muted-foreground max-w-40 truncate">
+                      {(row.search_destinations ?? []).join(", ") || "—"}
+                    </TableCell>
+                    <TableCell>
+                      <Badge variant="outline" className={row.active ? "bg-green-50" : "bg-gray-50"}>
+                        {row.active ? "Active" : "Retired"}
+                      </Badge>
+                    </TableCell>
+                    <TableCell>
+                      <div className="flex items-center gap-1">
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          className="h-7 w-7"
+                          title="Edit"
+                          onClick={() => {
+                            setEditing(row);
+                            setDialogOpen(true);
+                          }}
+                        >
+                          <Edit2 className="h-3.5 w-3.5" />
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          className="h-7 w-7"
+                          title={row.active ? "Retire" : "Reactivate"}
+                          onClick={() =>
+                            row.active ? setConfirmRetire(row) : handleToggleActive(row)
+                          }
+                        >
+                          {row.active ? (
+                            <Archive className="h-3.5 w-3.5" />
+                          ) : (
+                            <ArchiveRestore className="h-3.5 w-3.5" />
+                          )}
+                        </Button>
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                ))
+              )}
+            </TableBody>
+          </Table>
+        </div>
+      )}
+
+      <EventTemplateDialog
+        open={dialogOpen}
+        onOpenChange={setDialogOpen}
+        initial={editing}
+        onSaved={load}
+      />
+
+      <AlertDialog open={!!confirmRetire} onOpenChange={() => setConfirmRetire(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Retire event template?</AlertDialogTitle>
+            <AlertDialogDescription>
+              "{confirmRetire?.name}" will be hidden from renter-facing search and SMS dispatch.
+              Existing instances are preserved and can be reactivated later.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={() => confirmRetire && handleToggleActive(confirmRetire)}>
+              Retire
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}

--- a/src/components/admin/AdminNotificationCenter.tsx
+++ b/src/components/admin/AdminNotificationCenter.tsx
@@ -56,8 +56,12 @@ import {
   CheckCircle2,
   Clock,
   MessageSquare,
+  Plus,
+  LayoutTemplate,
 } from "lucide-react";
 import { formatDistanceToNow, format } from "date-fns";
+import { AdminEventTemplates } from "./AdminEventTemplates";
+import { EventInstanceDialog, type EventInstance } from "./EventInstanceDialog";
 
 const DESTINATION_LABELS: Record<string, string> = {
   orlando: "Orlando",
@@ -335,6 +339,9 @@ function EventCalendarTab() {
   const [yearFilter, setYearFilter] = useState("2026");
   const [sendingId, setSendingId] = useState<string | null>(null);
   const [confirmSend, setConfirmSend] = useState<Record<string, unknown> | null>(null);
+  const [instanceDialogOpen, setInstanceDialogOpen] = useState(false);
+  const [editingInstance, setEditingInstance] = useState<EventInstance | null>(null);
+  const [reloadKey, setReloadKey] = useState(0);
 
   useEffect(() => {
     async function load() {
@@ -354,7 +361,7 @@ function EventCalendarTab() {
       setLoading(false);
     }
     load();
-  }, [destFilter, yearFilter]);
+  }, [destFilter, yearFilter, reloadKey]);
 
   const handleConfirmDate = async (instanceId: string) => {
     const { error } = await supabase
@@ -411,7 +418,7 @@ function EventCalendarTab() {
 
   return (
     <div className="space-y-4">
-      <div className="flex flex-wrap gap-3">
+      <div className="flex flex-wrap items-center gap-3">
         <Select value={yearFilter} onValueChange={setYearFilter}>
           <SelectTrigger className="w-24">
             <SelectValue />
@@ -435,6 +442,17 @@ function EventCalendarTab() {
             ))}
           </SelectContent>
         </Select>
+        <Button
+          size="sm"
+          className="ml-auto"
+          onClick={() => {
+            setEditingInstance(null);
+            setInstanceDialogOpen(true);
+          }}
+        >
+          <Plus className="h-4 w-4 mr-1.5" />
+          Add Instance
+        </Button>
       </div>
 
       {loading ? (
@@ -500,8 +518,31 @@ function EventCalendarTab() {
                             variant="ghost"
                             size="icon"
                             className="h-7 w-7"
-                            title="Manual send"
-                            disabled={ev.status !== "active" || sendingId === ev.id}
+                            title="Edit"
+                            onClick={() => {
+                              setEditingInstance({
+                                id: ev.id as string,
+                                event_id: ev.event_id as string,
+                                destination: (ev.destination as string | null) ?? null,
+                                year: ev.year as number,
+                                event_date: ev.event_date as string,
+                                end_date: (ev.end_date as string | null) ?? null,
+                                priority: ev.priority as string,
+                                status: ev.status as string,
+                                date_confirmed: ev.date_confirmed as boolean,
+                                notes: (ev.notes as string | null) ?? null,
+                              });
+                              setInstanceDialogOpen(true);
+                            }}
+                          >
+                            <Edit2 className="h-3.5 w-3.5" />
+                          </Button>
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            className="h-7 w-7"
+                            title={ev.destination ? "Manual send" : "No SMS destination"}
+                            disabled={ev.status !== "active" || sendingId === ev.id || !ev.destination}
                             onClick={() => setConfirmSend(ev)}
                           >
                             {sendingId === ev.id ? (
@@ -531,6 +572,15 @@ function EventCalendarTab() {
           </Table>
         </div>
       )}
+
+      {/* Add / Edit instance dialog */}
+      <EventInstanceDialog
+        open={instanceDialogOpen}
+        onOpenChange={setInstanceDialogOpen}
+        initial={editingInstance}
+        defaultYear={parseInt(yearFilter)}
+        onSaved={() => setReloadKey((k) => k + 1)}
+      />
 
       {/* Manual send confirm dialog */}
       <AlertDialog open={!!confirmSend} onOpenChange={() => setConfirmSend(null)}>
@@ -755,6 +805,10 @@ export default function AdminNotificationCenter() {
             <MessageSquare className="h-3.5 w-3.5" />
             Types
           </TabsTrigger>
+          <TabsTrigger value="templates" className="gap-1.5">
+            <LayoutTemplate className="h-3.5 w-3.5" />
+            Templates
+          </TabsTrigger>
           <TabsTrigger value="calendar" className="gap-1.5">
             <Calendar className="h-3.5 w-3.5" />
             Event Calendar
@@ -770,6 +824,9 @@ export default function AdminNotificationCenter() {
         </TabsContent>
         <TabsContent value="types">
           <NotificationTypesTab />
+        </TabsContent>
+        <TabsContent value="templates">
+          <AdminEventTemplates />
         </TabsContent>
         <TabsContent value="calendar">
           <EventCalendarTab />

--- a/src/components/admin/EventInstanceDialog.tsx
+++ b/src/components/admin/EventInstanceDialog.tsx
@@ -1,0 +1,279 @@
+/**
+ * Add/Edit dialog for event_instances (specific-year dates).
+ * Used from Event Calendar tab in Admin Notification Center.
+ * Issue #338.
+ */
+
+import { useState, useEffect } from "react";
+import { supabase } from "@/lib/supabase";
+import { useToast } from "@/hooks/use-toast";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Switch } from "@/components/ui/switch";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+export interface EventInstance {
+  id?: string;
+  event_id: string;
+  destination: string | null;
+  year: number;
+  event_date: string;
+  end_date: string | null;
+  priority: string;
+  status: string;
+  date_confirmed: boolean;
+  notes: string | null;
+}
+
+interface SeasonalEventOption {
+  id: string;
+  name: string;
+}
+
+const DESTINATION_OPTIONS = [
+  { value: "", label: "— None (search-only event) —" },
+  { value: "orlando", label: "Orlando" },
+  { value: "miami", label: "Miami" },
+  { value: "las_vegas", label: "Las Vegas" },
+  { value: "maui_hawaii", label: "Maui / Hawaii" },
+  { value: "myrtle_beach", label: "Myrtle Beach" },
+  { value: "colorado", label: "Colorado" },
+  { value: "new_york", label: "New York" },
+  { value: "nashville", label: "Nashville" },
+];
+
+const PRIORITY_OPTIONS = ["urgent", "high", "medium", "plan"];
+const STATUS_OPTIONS = ["active", "cancelled", "past"];
+
+function emptyInstance(year: number): EventInstance {
+  return {
+    event_id: "",
+    destination: null,
+    year,
+    event_date: `${year}-01-01`,
+    end_date: null,
+    priority: "medium",
+    status: "active",
+    date_confirmed: false,
+    notes: null,
+  };
+}
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  initial?: EventInstance | null;
+  defaultYear: number;
+  onSaved: () => void;
+}
+
+export function EventInstanceDialog({ open, onOpenChange, initial, defaultYear, onSaved }: Props) {
+  const { toast } = useToast();
+  const [form, setForm] = useState<EventInstance>(emptyInstance(defaultYear));
+  const [templates, setTemplates] = useState<SeasonalEventOption[]>([]);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    if (open) {
+      setForm(initial ?? emptyInstance(defaultYear));
+      supabase
+        .from("seasonal_events")
+        .select("id, name")
+        .eq("active", true)
+        .order("name")
+        .then(({ data }) => setTemplates((data ?? []) as SeasonalEventOption[]));
+    }
+  }, [open, initial, defaultYear]);
+
+  const handleSave = async () => {
+    if (!form.event_id) {
+      toast({ title: "Select a template", variant: "destructive" });
+      return;
+    }
+    if (!form.event_date) {
+      toast({ title: "Event date required", variant: "destructive" });
+      return;
+    }
+    if (form.end_date && form.end_date < form.event_date) {
+      toast({ title: "End date must be on or after start date", variant: "destructive" });
+      return;
+    }
+
+    setSaving(true);
+    const payload = {
+      event_id: form.event_id,
+      destination: form.destination || null,
+      year: form.year,
+      event_date: form.event_date,
+      end_date: form.end_date || null,
+      priority: form.priority,
+      status: form.status,
+      date_confirmed: form.date_confirmed,
+      notes: form.notes,
+    };
+
+    const { error } = form.id
+      ? await supabase.from("event_instances").update(payload).eq("id", form.id)
+      : await supabase.from("event_instances").insert(payload);
+
+    if (error) {
+      toast({ title: "Save failed", description: error.message, variant: "destructive" });
+    } else {
+      toast({ title: form.id ? "Instance updated" : "Instance created" });
+      onOpenChange(false);
+      onSaved();
+    }
+    setSaving(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-[95vw] sm:max-w-lg max-h-[90vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>{form.id ? "Edit Event Instance" : "New Event Instance"}</DialogTitle>
+          <DialogDescription>
+            Specific-year date for an event template. Leave destination blank for search-only events (no SMS).
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div>
+            <Label>Event Template</Label>
+            <Select
+              value={form.event_id}
+              onValueChange={(v) => setForm({ ...form, event_id: v })}
+              disabled={!!form.id}
+            >
+              <SelectTrigger>
+                <SelectValue placeholder="Select template..." />
+              </SelectTrigger>
+              <SelectContent>
+                {templates.map((t) => (
+                  <SelectItem key={t.id} value={t.id}>{t.name}</SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <Label>Destination (for SMS)</Label>
+              <Select
+                value={form.destination ?? ""}
+                onValueChange={(v) => setForm({ ...form, destination: v || null })}
+              >
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {DESTINATION_OPTIONS.map((d) => (
+                    <SelectItem key={d.value || "none"} value={d.value}>{d.label}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div>
+              <Label htmlFor="ev-year">Year</Label>
+              <Input
+                id="ev-year"
+                type="number"
+                value={form.year}
+                onChange={(e) => setForm({ ...form, year: Number(e.target.value) })}
+              />
+            </div>
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <Label htmlFor="ev-start">Start date</Label>
+              <Input
+                id="ev-start"
+                type="date"
+                value={form.event_date}
+                onChange={(e) => setForm({ ...form, event_date: e.target.value })}
+              />
+            </div>
+            <div>
+              <Label htmlFor="ev-end">End date (optional)</Label>
+              <Input
+                id="ev-end"
+                type="date"
+                value={form.end_date ?? ""}
+                onChange={(e) => setForm({ ...form, end_date: e.target.value || null })}
+              />
+            </div>
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <Label>Priority</Label>
+              <Select value={form.priority} onValueChange={(v) => setForm({ ...form, priority: v })}>
+                <SelectTrigger><SelectValue /></SelectTrigger>
+                <SelectContent>
+                  {PRIORITY_OPTIONS.map((p) => (
+                    <SelectItem key={p} value={p}>{p}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div>
+              <Label>Status</Label>
+              <Select value={form.status} onValueChange={(v) => setForm({ ...form, status: v })}>
+                <SelectTrigger><SelectValue /></SelectTrigger>
+                <SelectContent>
+                  {STATUS_OPTIONS.map((s) => (
+                    <SelectItem key={s} value={s}>{s}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+
+          <div className="flex items-center justify-between">
+            <Label htmlFor="ev-confirmed">Date confirmed</Label>
+            <Switch
+              id="ev-confirmed"
+              checked={form.date_confirmed}
+              onCheckedChange={(v) => setForm({ ...form, date_confirmed: v })}
+            />
+          </div>
+
+          <div>
+            <Label htmlFor="ev-notes">Notes</Label>
+            <Textarea
+              id="ev-notes"
+              value={form.notes ?? ""}
+              onChange={(e) => setForm({ ...form, notes: e.target.value })}
+              rows={2}
+            />
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={saving}>
+            Cancel
+          </Button>
+          <Button onClick={handleSave} disabled={saving}>
+            {saving ? "Saving..." : form.id ? "Save changes" : "Create instance"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/admin/EventTemplateDialog.tsx
+++ b/src/components/admin/EventTemplateDialog.tsx
@@ -1,0 +1,282 @@
+/**
+ * Add/Edit dialog for seasonal_events (event templates).
+ * Used from the Templates tab in Admin Notification Center.
+ * GitHub Issue: #338
+ */
+
+import { useState, useEffect } from "react";
+import { supabase } from "@/lib/supabase";
+import { useToast } from "@/hooks/use-toast";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Switch } from "@/components/ui/switch";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+export interface EventTemplate {
+  id?: string;
+  name: string;
+  slug: string | null;
+  icon: string | null;
+  category: string;
+  recurrence_type: string;
+  typical_month: number | null;
+  is_nationwide: boolean;
+  is_location_fixed: boolean;
+  search_destinations: string[];
+  active: boolean;
+  notes: string | null;
+}
+
+const CATEGORIES = [
+  { value: "major_holidays", label: "Major Holidays" },
+  { value: "school_breaks", label: "School Breaks" },
+  { value: "sports_events", label: "Sports Events" },
+  { value: "local_events", label: "Local / Cultural Events" },
+  { value: "weather_peak_season", label: "Weather / Peak Season" },
+];
+
+const RECURRENCE_TYPES = [
+  { value: "annual_fixed", label: "Annual fixed (same dates each year)" },
+  { value: "annual_floating", label: "Annual floating (dates shift yearly)" },
+  { value: "one_time", label: "One-time event" },
+];
+
+function emptyTemplate(): EventTemplate {
+  return {
+    name: "",
+    slug: null,
+    icon: "Sparkles",
+    category: "local_events",
+    recurrence_type: "annual_fixed",
+    typical_month: null,
+    is_nationwide: false,
+    is_location_fixed: true,
+    search_destinations: [],
+    active: true,
+    notes: null,
+  };
+}
+
+function slugify(name: string): string {
+  return name
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9\s-]/g, "")
+    .replace(/\s+/g, "-")
+    .replace(/-+/g, "-");
+}
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  initial?: EventTemplate | null;
+  onSaved: () => void;
+}
+
+export function EventTemplateDialog({ open, onOpenChange, initial, onSaved }: Props) {
+  const { toast } = useToast();
+  const [form, setForm] = useState<EventTemplate>(emptyTemplate());
+  const [destinationsInput, setDestinationsInput] = useState("");
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    if (open) {
+      const tmpl = initial ?? emptyTemplate();
+      setForm(tmpl);
+      setDestinationsInput((tmpl.search_destinations ?? []).join(", "));
+    }
+  }, [open, initial]);
+
+  const handleSave = async () => {
+    if (!form.name.trim()) {
+      toast({ title: "Name required", variant: "destructive" });
+      return;
+    }
+    setSaving(true);
+    const destinations = destinationsInput
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean);
+
+    const payload = {
+      name: form.name.trim(),
+      slug: form.slug?.trim() || slugify(form.name),
+      icon: form.icon || "Sparkles",
+      category: form.category,
+      recurrence_type: form.recurrence_type,
+      typical_month: form.typical_month,
+      is_nationwide: form.is_nationwide,
+      is_location_fixed: form.is_location_fixed,
+      search_destinations: destinations,
+      active: form.active,
+      notes: form.notes,
+    };
+
+    const { error } = form.id
+      ? await supabase.from("seasonal_events").update(payload).eq("id", form.id)
+      : await supabase.from("seasonal_events").insert(payload);
+
+    if (error) {
+      toast({ title: "Save failed", description: error.message, variant: "destructive" });
+    } else {
+      toast({ title: form.id ? "Template updated" : "Template created" });
+      onOpenChange(false);
+      onSaved();
+    }
+    setSaving(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-[95vw] sm:max-w-2xl max-h-[90vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>{form.id ? "Edit Event Template" : "New Event Template"}</DialogTitle>
+          <DialogDescription>
+            Templates define the event itself. Use the Event Calendar tab to add specific-year dates (instances).
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div>
+            <Label htmlFor="ev-name">Name</Label>
+            <Input
+              id="ev-name"
+              value={form.name}
+              onChange={(e) => setForm({ ...form, name: e.target.value })}
+              placeholder="e.g. Sundance Film Festival"
+            />
+          </div>
+
+          <div>
+            <Label htmlFor="ev-slug">Slug (URL-safe, unique)</Label>
+            <Input
+              id="ev-slug"
+              value={form.slug ?? ""}
+              onChange={(e) => setForm({ ...form, slug: e.target.value })}
+              placeholder={slugify(form.name) || "auto-generated-from-name"}
+            />
+            <p className="text-xs text-muted-foreground mt-1">Leave blank to auto-generate from name.</p>
+          </div>
+
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <div>
+              <Label>Category</Label>
+              <Select value={form.category} onValueChange={(v) => setForm({ ...form, category: v })}>
+                <SelectTrigger><SelectValue /></SelectTrigger>
+                <SelectContent>
+                  {CATEGORIES.map((c) => (
+                    <SelectItem key={c.value} value={c.value}>{c.label}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div>
+              <Label>Recurrence</Label>
+              <Select value={form.recurrence_type} onValueChange={(v) => setForm({ ...form, recurrence_type: v })}>
+                <SelectTrigger><SelectValue /></SelectTrigger>
+                <SelectContent>
+                  {RECURRENCE_TYPES.map((r) => (
+                    <SelectItem key={r.value} value={r.value}>{r.label}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <div>
+              <Label htmlFor="ev-icon">Icon (Lucide name)</Label>
+              <Input
+                id="ev-icon"
+                value={form.icon ?? ""}
+                onChange={(e) => setForm({ ...form, icon: e.target.value })}
+                placeholder="e.g. Film, Trophy, Sun"
+              />
+            </div>
+            <div>
+              <Label htmlFor="ev-month">Typical month (1-12)</Label>
+              <Input
+                id="ev-month"
+                type="number"
+                min={1}
+                max={12}
+                value={form.typical_month ?? ""}
+                onChange={(e) =>
+                  setForm({ ...form, typical_month: e.target.value ? Number(e.target.value) : null })
+                }
+              />
+            </div>
+          </div>
+
+          <div>
+            <Label htmlFor="ev-destinations">Search destinations (comma-separated)</Label>
+            <Input
+              id="ev-destinations"
+              value={destinationsInput}
+              onChange={(e) => setDestinationsInput(e.target.value)}
+              placeholder="e.g. Park City, Vail, Aspen"
+              disabled={form.is_nationwide}
+            />
+            <p className="text-xs text-muted-foreground mt-1">
+              City or region names used to match listings to this event. Disabled for nationwide events.
+            </p>
+          </div>
+
+          <div className="space-y-3">
+            <div className="flex items-center justify-between">
+              <Label htmlFor="ev-nationwide">Nationwide event</Label>
+              <Switch
+                id="ev-nationwide"
+                checked={form.is_nationwide}
+                onCheckedChange={(v) => setForm({ ...form, is_nationwide: v })}
+              />
+            </div>
+            <div className="flex items-center justify-between">
+              <Label htmlFor="ev-active">Active</Label>
+              <Switch
+                id="ev-active"
+                checked={form.active}
+                onCheckedChange={(v) => setForm({ ...form, active: v })}
+              />
+            </div>
+          </div>
+
+          <div>
+            <Label htmlFor="ev-notes">Notes (internal)</Label>
+            <Textarea
+              id="ev-notes"
+              value={form.notes ?? ""}
+              onChange={(e) => setForm({ ...form, notes: e.target.value })}
+              rows={2}
+            />
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={saving}>
+            Cancel
+          </Button>
+          <Button onClick={handleSave} disabled={saving}>
+            {saving ? "Saving..." : form.id ? "Save changes" : "Create template"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/hooks/useCuratedEvents.test.ts
+++ b/src/hooks/useCuratedEvents.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Unit tests for useCuratedEvents — verifies DB-to-frontend row mapping.
+ * Issue #338.
+ */
+
+import React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useCuratedEvents } from "./useCuratedEvents";
+
+const rpcMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/supabase", () => ({
+  supabase: { rpc: rpcMock },
+}));
+
+function createWrapper() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client }, children);
+}
+
+describe("useCuratedEvents", () => {
+  beforeEach(() => {
+    rpcMock.mockReset();
+  });
+
+  it("maps DB rows to CuratedEvent shape with category translation", async () => {
+    rpcMock.mockResolvedValue({
+      data: [
+        {
+          id: "1",
+          slug: "sundance-2026",
+          name: "Sundance Film Festival",
+          icon: "Film",
+          category: "local_events",
+          recurrence_type: "annual_fixed",
+          is_nationwide: false,
+          search_destinations: ["Park City"],
+          year: 2026,
+          start_date: "2026-01-22",
+          end_date: "2026-02-01",
+        },
+      ],
+      error: null,
+    });
+
+    const { result } = renderHook(() => useCuratedEvents(2026), { wrapper: createWrapper() });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toHaveLength(1);
+    const ev = result.current.data![0];
+    expect(ev.slug).toBe("sundance-2026");
+    expect(ev.category).toBe("cultural"); // local_events → cultural
+    expect(ev.dateRange).toEqual({ start: "2026-01-22", end: "2026-02-01" });
+    expect(ev.destinations).toEqual(["Park City"]);
+    expect(ev.nationwide).toBe(false);
+    expect(ev.icon).toBe("Film");
+  });
+
+  it("maps each DB category enum to the frontend union", async () => {
+    rpcMock.mockResolvedValue({
+      data: [
+        { id: "1", slug: "a", name: "A", icon: null, category: "major_holidays",      recurrence_type: "annual_fixed", is_nationwide: true,  search_destinations: [], year: 2026, start_date: "2026-01-01", end_date: "2026-01-02" },
+        { id: "2", slug: "b", name: "B", icon: null, category: "sports_events",       recurrence_type: "annual_fixed", is_nationwide: false, search_destinations: [], year: 2026, start_date: "2026-01-01", end_date: "2026-01-02" },
+        { id: "3", slug: "c", name: "C", icon: null, category: "school_breaks",       recurrence_type: "annual_fixed", is_nationwide: false, search_destinations: [], year: 2026, start_date: "2026-01-01", end_date: "2026-01-02" },
+        { id: "4", slug: "d", name: "D", icon: null, category: "weather_peak_season", recurrence_type: "annual_fixed", is_nationwide: false, search_destinations: [], year: 2026, start_date: "2026-01-01", end_date: "2026-01-02" },
+      ],
+      error: null,
+    });
+
+    const { result } = renderHook(() => useCuratedEvents(2026), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const cats = result.current.data!.map((e) => e.category);
+    expect(cats).toEqual(["major_holiday", "sports", "school_break", "peak_season"]);
+  });
+
+  it("returns empty array when RPC returns null data", async () => {
+    rpcMock.mockResolvedValue({ data: null, error: null });
+    const { result } = renderHook(() => useCuratedEvents(2026), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual([]);
+  });
+
+  it("surfaces RPC errors", async () => {
+    rpcMock.mockResolvedValue({ data: null, error: new Error("RPC failed") });
+    const { result } = renderHook(() => useCuratedEvents(2026), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+
+  it("falls back to Sparkles when icon is null", async () => {
+    rpcMock.mockResolvedValue({
+      data: [
+        {
+          id: "1",
+          slug: "x",
+          name: "X",
+          icon: null,
+          category: "major_holidays",
+          recurrence_type: "annual_fixed",
+          is_nationwide: true,
+          search_destinations: [],
+          year: 2026,
+          start_date: "2026-01-01",
+          end_date: "2026-01-02",
+        },
+      ],
+      error: null,
+    });
+    const { result } = renderHook(() => useCuratedEvents(2026), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data![0].icon).toBe("Sparkles");
+  });
+});

--- a/src/hooks/useCuratedEvents.ts
+++ b/src/hooks/useCuratedEvents.ts
@@ -1,0 +1,64 @@
+import { useQuery } from "@tanstack/react-query";
+import { supabase } from "@/lib/supabase";
+import type { CuratedEvent, EventCategory } from "@/lib/events";
+
+/**
+ * Raw row shape returned by the `get_curated_events` RPC.
+ * Maps DB `event_category` enum to the frontend `EventCategory` union.
+ */
+interface CuratedEventRow {
+  id: string;
+  slug: string;
+  name: string;
+  icon: string | null;
+  category: string;
+  recurrence_type: string;
+  is_nationwide: boolean;
+  search_destinations: string[] | null;
+  year: number;
+  start_date: string;
+  end_date: string;
+}
+
+/**
+ * Map DB enum values back to the frontend union used by Rentals.tsx / events.ts.
+ * DB uses plural forms (e.g., `major_holidays`); frontend uses singular (e.g., `major_holiday`).
+ */
+const DB_TO_FE_CATEGORY: Record<string, EventCategory> = {
+  major_holidays: "major_holiday",
+  sports_events: "sports",
+  local_events: "cultural",
+  school_breaks: "school_break",
+  weather_peak_season: "peak_season",
+};
+
+function rowToCuratedEvent(row: CuratedEventRow): CuratedEvent {
+  return {
+    slug: row.slug,
+    name: row.name,
+    category: DB_TO_FE_CATEGORY[row.category] ?? "cultural",
+    dateRange: { start: row.start_date, end: row.end_date },
+    year: row.year,
+    destinations: row.search_destinations ?? [],
+    nationwide: row.is_nationwide,
+    icon: row.icon ?? "Sparkles",
+  };
+}
+
+/**
+ * Fetch all curated events for a given year (defaults to current year).
+ * Powers the renter-facing Rentals events filter and the upcoming events pill bar.
+ */
+export function useCuratedEvents(year?: number) {
+  return useQuery({
+    queryKey: ["curated-events", year ?? "current"],
+    queryFn: async () => {
+      const { data, error } = await supabase.rpc("get_curated_events", {
+        p_year: year ?? null,
+      });
+      if (error) throw error;
+      return ((data ?? []) as CuratedEventRow[]).map(rowToCuratedEvent);
+    },
+    staleTime: 5 * 60 * 1000, // Events rarely change mid-session.
+  });
+}

--- a/src/lib/events.test.ts
+++ b/src/lib/events.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect } from "vitest";
 import {
-  CURATED_EVENTS,
   dateRangesOverlap,
   doesListingMatchEvent,
   filterByEvent,
@@ -72,42 +71,50 @@ function makeListing(
   };
 }
 
-describe("CURATED_EVENTS data integrity", () => {
-  it("has 14 curated events", () => {
-    expect(CURATED_EVENTS.length).toBe(14);
-  });
+// Sample event fixtures used across tests (replicate DB-shape events).
+const springBreakEast: CuratedEvent = {
+  slug: "spring-break-east",
+  name: "Spring Break (East Coast)",
+  category: "school_break",
+  dateRange: { start: "2026-03-07", end: "2026-03-21" },
+  year: 2026,
+  destinations: ["Orlando", "Miami", "Tampa", "Myrtle Beach", "Daytona Beach"],
+  nationwide: false,
+  icon: "Sun",
+};
 
-  it("all events have unique slugs", () => {
-    const slugs = CURATED_EVENTS.map((e) => e.slug);
-    expect(new Set(slugs).size).toBe(slugs.length);
-  });
+const fourthOfJuly: CuratedEvent = {
+  slug: "fourth-of-july-2026",
+  name: "Fourth of July",
+  category: "major_holiday",
+  dateRange: { start: "2026-06-27", end: "2026-07-06" },
+  year: 2026,
+  destinations: [],
+  nationwide: true,
+  icon: "Sparkles",
+};
 
-  it("all events have valid date ranges (start <= end)", () => {
-    for (const event of CURATED_EVENTS) {
-      expect(event.dateRange.start <= event.dateRange.end).toBe(true);
-    }
-  });
+const superBowl: CuratedEvent = {
+  slug: "super-bowl-lx",
+  name: "Super Bowl LX",
+  category: "sports",
+  dateRange: { start: "2026-02-04", end: "2026-02-10" },
+  year: 2026,
+  destinations: ["Santa Clara"],
+  nationwide: false,
+  icon: "Trophy",
+};
 
-  it("nationwide events have empty destinations array", () => {
-    const nationwide = CURATED_EVENTS.filter((e) => e.nationwide);
-    for (const event of nationwide) {
-      expect(event.destinations).toEqual([]);
-    }
-  });
-
-  it("non-nationwide events have at least one destination", () => {
-    const local = CURATED_EVENTS.filter((e) => !e.nationwide);
-    for (const event of local) {
-      expect(event.destinations.length).toBeGreaterThan(0);
-    }
-  });
-
-  it("all events have an icon defined", () => {
-    for (const event of CURATED_EVENTS) {
-      expect(event.icon).toBeTruthy();
-    }
-  });
-});
+const mardiGras: CuratedEvent = {
+  slug: "mardi-gras-2026",
+  name: "Mardi Gras",
+  category: "cultural",
+  dateRange: { start: "2026-02-12", end: "2026-02-18" },
+  year: 2026,
+  destinations: ["New Orleans", "Orlando"],
+  nationwide: false,
+  icon: "PartyPopper",
+};
 
 describe("dateRangesOverlap", () => {
   it("returns true for overlapping ranges", () => {
@@ -132,9 +139,6 @@ describe("dateRangesOverlap", () => {
 });
 
 describe("doesListingMatchEvent", () => {
-  const springBreakEast: CuratedEvent = CURATED_EVENTS.find((e) => e.slug === "spring-break-east")!;
-  const fourthOfJuly: CuratedEvent = CURATED_EVENTS.find((e) => e.slug === "fourth-of-july-2026")!;
-
   it("matches listing with date overlap + destination match", () => {
     const listing = makeListing("1", "2026-03-10", "2026-03-17", "Orlando", "FL");
     expect(doesListingMatchEvent(listing, springBreakEast)).toBe(true);
@@ -168,68 +172,72 @@ describe("filterByEvent", () => {
     makeListing("3", "2026-03-10", "2026-03-17", "Las Vegas", "NV"),
     makeListing("4", "2026-06-01", "2026-06-08", "Orlando", "FL"),
   ];
+  const events = [springBreakEast, fourthOfJuly, superBowl, mardiGras];
 
   it("returns all listings when no event selected", () => {
-    expect(filterByEvent(listings, null)).toHaveLength(4);
+    expect(filterByEvent(listings, null, events)).toHaveLength(4);
   });
 
   it("filters by spring break east (date + destination)", () => {
-    const result = filterByEvent(listings, "spring-break-east");
+    const result = filterByEvent(listings, "spring-break-east", events);
     expect(result).toHaveLength(2);
     expect(result.map((l) => l.id).sort()).toEqual(["1", "2"]);
   });
 
   it("returns all listings for unknown event slug", () => {
-    expect(filterByEvent(listings, "nonexistent")).toHaveLength(4);
+    expect(filterByEvent(listings, "nonexistent", events)).toHaveLength(4);
+  });
+
+  it("returns all listings when events list is empty", () => {
+    expect(filterByEvent(listings, "spring-break-east", [])).toHaveLength(4);
   });
 });
 
 describe("getUpcomingEvents", () => {
+  const events = [springBreakEast, fourthOfJuly, superBowl, mardiGras];
+
   it("returns events with end date >= reference date", () => {
-    const upcoming = getUpcomingEvents("2026-06-01");
+    const upcoming = getUpcomingEvents(events, "2026-06-01");
     expect(upcoming.every((e) => e.dateRange.end >= "2026-06-01")).toBe(true);
   });
 
   it("returns events sorted by start date", () => {
-    const upcoming = getUpcomingEvents("2026-01-01");
+    const upcoming = getUpcomingEvents(events, "2026-01-01");
     for (let i = 1; i < upcoming.length; i++) {
       expect(upcoming[i].dateRange.start >= upcoming[i - 1].dateRange.start).toBe(true);
     }
   });
 
   it("respects limit parameter", () => {
-    const upcoming = getUpcomingEvents("2026-01-01", 3);
-    expect(upcoming).toHaveLength(3);
+    const upcoming = getUpcomingEvents(events, "2026-01-01", 2);
+    expect(upcoming).toHaveLength(2);
   });
 
   it("filters out past events", () => {
-    const upcoming = getUpcomingEvents("2027-12-01");
+    const upcoming = getUpcomingEvents(events, "2027-12-01");
     expect(upcoming).toHaveLength(0);
   });
 });
 
 describe("findEventsByQuery", () => {
+  const events = [springBreakEast, fourthOfJuly, superBowl, mardiGras];
+
   it("finds events by partial name match", () => {
-    const results = findEventsByQuery("super bowl");
+    const results = findEventsByQuery(events, "super bowl");
     expect(results).toHaveLength(1);
     expect(results[0].slug).toBe("super-bowl-lx");
   });
 
-  it("finds multiple matches", () => {
-    const results = findEventsByQuery("spring");
-    expect(results).toHaveLength(2);
-  });
-
   it("returns empty for no match", () => {
-    expect(findEventsByQuery("olympics")).toHaveLength(0);
+    expect(findEventsByQuery(events, "olympics")).toHaveLength(0);
   });
 
   it("returns empty for empty query", () => {
-    expect(findEventsByQuery("")).toHaveLength(0);
+    expect(findEventsByQuery(events, "")).toHaveLength(0);
   });
 
   it("is case insensitive", () => {
-    expect(findEventsByQuery("MARDI GRAS")).toHaveLength(1);
+    expect(findEventsByQuery(events, "MARDI GRAS")).toHaveLength(1);
   });
 });
 

--- a/src/lib/events.ts
+++ b/src/lib/events.ts
@@ -2,12 +2,22 @@ import type { ActiveListing } from "@/hooks/useListings";
 import { getLocation } from "@/components/ListingCard";
 
 /**
- * Curated event data for event-based search filtering.
- * Static for now — structured for easy migration to a DB table later.
- * Update quarterly to keep dates current.
+ * Curated event types and pure utilities for event-based search filtering.
+ *
+ * Event data is now managed in the DB (`seasonal_events` + `event_instances`)
+ * and fetched via the `useCuratedEvents` hook. Admin staff can add/edit/retire
+ * events from RAV Ops → Notification Center → Templates (#338).
+ *
+ * This file intentionally contains no static event data — only type
+ * definitions and pure functions that operate on events.
  */
 
-export type EventCategory = "major_holiday" | "sports" | "cultural" | "school_break" | "peak_season";
+export type EventCategory =
+  | "major_holiday"
+  | "sports"
+  | "cultural"
+  | "school_break"
+  | "peak_season";
 
 export interface CuratedEvent {
   slug: string;
@@ -21,153 +31,6 @@ export interface CuratedEvent {
   nationwide: boolean;
   icon: string; // Lucide icon name
 }
-
-/**
- * Curated events for 2026. Ordered roughly by date.
- * Destinations use city/state names that match resort location strings.
- */
-export const CURATED_EVENTS: CuratedEvent[] = [
-  {
-    slug: "sundance-2026",
-    name: "Sundance Film Festival",
-    category: "cultural",
-    dateRange: { start: "2026-01-22", end: "2026-02-01" },
-    year: 2026,
-    destinations: ["Park City"],
-    nationwide: false,
-    icon: "Film",
-  },
-  {
-    slug: "super-bowl-lx",
-    name: "Super Bowl LX",
-    category: "sports",
-    dateRange: { start: "2026-02-04", end: "2026-02-10" },
-    year: 2026,
-    destinations: ["Santa Clara", "San Francisco", "San Jose"],
-    nationwide: false,
-    icon: "Trophy",
-  },
-  {
-    slug: "mardi-gras-2026",
-    name: "Mardi Gras",
-    category: "cultural",
-    dateRange: { start: "2026-02-12", end: "2026-02-18" },
-    year: 2026,
-    destinations: ["New Orleans", "Orlando", "Miami"],
-    nationwide: false,
-    icon: "PartyPopper",
-  },
-  {
-    slug: "spring-break-east",
-    name: "Spring Break (East Coast)",
-    category: "school_break",
-    dateRange: { start: "2026-03-07", end: "2026-03-21" },
-    year: 2026,
-    destinations: ["Orlando", "Miami", "Tampa", "Myrtle Beach", "Daytona Beach"],
-    nationwide: false,
-    icon: "Sun",
-  },
-  {
-    slug: "spring-break-west",
-    name: "Spring Break (West Coast)",
-    category: "school_break",
-    dateRange: { start: "2026-03-14", end: "2026-03-28" },
-    year: 2026,
-    destinations: ["Cancun", "Cabo San Lucas", "Maui", "Oahu", "San Diego"],
-    nationwide: false,
-    icon: "Sun",
-  },
-  {
-    slug: "masters-golf-2026",
-    name: "The Masters",
-    category: "sports",
-    dateRange: { start: "2026-04-06", end: "2026-04-12" },
-    year: 2026,
-    destinations: ["Hilton Head", "Myrtle Beach", "Charleston"],
-    nationwide: false,
-    icon: "Flag",
-  },
-  {
-    slug: "memorial-day-2026",
-    name: "Memorial Day Weekend",
-    category: "major_holiday",
-    dateRange: { start: "2026-05-22", end: "2026-05-26" },
-    year: 2026,
-    destinations: [],
-    nationwide: true,
-    icon: "Flag",
-  },
-  {
-    slug: "summer-peak-2026",
-    name: "Summer Peak Season",
-    category: "peak_season",
-    dateRange: { start: "2026-06-15", end: "2026-08-15" },
-    year: 2026,
-    destinations: [],
-    nationwide: true,
-    icon: "Sun",
-  },
-  {
-    slug: "fourth-of-july-2026",
-    name: "Fourth of July",
-    category: "major_holiday",
-    dateRange: { start: "2026-06-27", end: "2026-07-06" },
-    year: 2026,
-    destinations: [],
-    nationwide: true,
-    icon: "Sparkles",
-  },
-  {
-    slug: "labor-day-2026",
-    name: "Labor Day Weekend",
-    category: "major_holiday",
-    dateRange: { start: "2026-09-04", end: "2026-09-08" },
-    year: 2026,
-    destinations: [],
-    nationwide: true,
-    icon: "Palmtree",
-  },
-  {
-    slug: "halloween-orlando-2026",
-    name: "Halloween at the Parks",
-    category: "cultural",
-    dateRange: { start: "2026-10-24", end: "2026-11-01" },
-    year: 2026,
-    destinations: ["Orlando"],
-    nationwide: false,
-    icon: "Ghost",
-  },
-  {
-    slug: "thanksgiving-2026",
-    name: "Thanksgiving Week",
-    category: "major_holiday",
-    dateRange: { start: "2026-11-21", end: "2026-11-29" },
-    year: 2026,
-    destinations: [],
-    nationwide: true,
-    icon: "UtensilsCrossed",
-  },
-  {
-    slug: "ski-season-2026",
-    name: "Ski Season",
-    category: "peak_season",
-    dateRange: { start: "2026-12-01", end: "2027-03-31" },
-    year: 2026,
-    destinations: ["Vail", "Breckenridge", "Aspen", "Steamboat Springs", "Park City", "Lake Tahoe"],
-    nationwide: false,
-    icon: "Snowflake",
-  },
-  {
-    slug: "holiday-season-2026",
-    name: "Holiday Season",
-    category: "major_holiday",
-    dateRange: { start: "2026-12-19", end: "2027-01-03" },
-    year: 2026,
-    destinations: [],
-    nationwide: true,
-    icon: "Gift",
-  },
-];
 
 /**
  * Check if two date ranges overlap.
@@ -206,27 +69,33 @@ export function doesListingMatchEvent(listing: ActiveListing, event: CuratedEven
 
 /**
  * Filter listings by a selected event.
- * Returns all listings if no event slug provided.
+ * Requires the caller to supply the pool of events (typically from useCuratedEvents).
  */
 export function filterByEvent(
   listings: ActiveListing[],
-  eventSlug: string | null
+  eventSlug: string | null,
+  events: CuratedEvent[]
 ): ActiveListing[] {
   if (!eventSlug) return listings;
 
-  const event = CURATED_EVENTS.find((e) => e.slug === eventSlug);
+  const event = events.find((e) => e.slug === eventSlug);
   if (!event) return listings;
 
   return listings.filter((listing) => doesListingMatchEvent(listing, event));
 }
 
 /**
- * Get upcoming events (not yet ended), sorted by start date proximity.
+ * Filter the supplied events list to those that have not ended by `referenceDate`,
+ * sorted by start date. Optional `limit` caps the returned count.
  */
-export function getUpcomingEvents(referenceDate?: string, limit?: number): CuratedEvent[] {
+export function getUpcomingEvents(
+  events: CuratedEvent[],
+  referenceDate?: string,
+  limit?: number
+): CuratedEvent[] {
   const ref = referenceDate || new Date().toISOString().split("T")[0];
 
-  const upcoming = CURATED_EVENTS.filter((e) => e.dateRange.end >= ref);
+  const upcoming = events.filter((e) => e.dateRange.end >= ref);
   upcoming.sort((a, b) => a.dateRange.start.localeCompare(b.dateRange.start));
 
   return limit ? upcoming.slice(0, limit) : upcoming;
@@ -234,12 +103,11 @@ export function getUpcomingEvents(referenceDate?: string, limit?: number): Curat
 
 /**
  * Find events matching a search query (for text search integration).
- * Returns matching event slugs.
  */
-export function findEventsByQuery(query: string): CuratedEvent[] {
+export function findEventsByQuery(events: CuratedEvent[], query: string): CuratedEvent[] {
   if (!query.trim()) return [];
   const q = query.toLowerCase();
-  return CURATED_EVENTS.filter((e) => e.name.toLowerCase().includes(q));
+  return events.filter((e) => e.name.toLowerCase().includes(q));
 }
 
 /**

--- a/src/pages/Rentals.tsx
+++ b/src/pages/Rentals.tsx
@@ -74,6 +74,7 @@ import { SaveSearchButton } from "@/components/SaveSearchButton";
 import { Checkbox } from "@/components/ui/checkbox";
 import { ATTRACTION_TAGS, filterByAttractions, type AttractionTag } from "@/lib/attractionTags";
 import { getUpcomingEvents, filterByEvent, formatEventDateRange, type CuratedEvent } from "@/lib/events";
+import { useCuratedEvents } from "@/hooks/useCuratedEvents";
 const ITEMS_PER_PAGE = 6;
 
 // Icon map for attraction tags (keyed by AttractionTagDef.icon)
@@ -128,8 +129,9 @@ const Rentals = () => {
   const [discoveryTab, setDiscoveryTab] = useState<"activity" | "events">("activity");
   const [sortOption, setSortOption] = useState<SortOption>("newest");
 
-  // Upcoming events for pill bar
-  const upcomingEvents = getUpcomingEvents(undefined, 8);
+  // Curated events (DB-backed) for filter pill bar + event banner
+  const { data: curatedEvents = [] } = useCuratedEvents();
+  const upcomingEvents = getUpcomingEvents(curatedEvents, undefined, 8);
 
   // Compare mode
   const [compareMode, setCompareMode] = useState(false);
@@ -245,7 +247,8 @@ const Rentals = () => {
   // Apply attraction + event filters
   const filteredListings = filterByEvent(
     filterByAttractions(baseFiltered, selectedAttractions),
-    selectedEvent
+    selectedEvent,
+    curatedEvents
   );
 
   // Sort

--- a/supabase/functions/sms-scheduler/index.ts
+++ b/supabase/functions/sms-scheduler/index.ts
@@ -69,6 +69,15 @@ const handler = async (req: Request): Promise<Response> => {
         );
       }
 
+      if (!instance.destination) {
+        return new Response(
+          JSON.stringify({
+            error: "Instance has no destination (search-only event) — cannot send SMS",
+          }),
+          { status: 400, headers: { "Content-Type": "application/json", ...corsHeaders } },
+        );
+      }
+
       // Determine which reminder type to use based on proximity
       const today = new Date();
       today.setHours(0, 0, 0, 0);
@@ -102,12 +111,15 @@ const handler = async (req: Request): Promise<Response> => {
 
       const today = new Date().toISOString().split("T")[0]; // YYYY-MM-DD
 
-      // Find all event instances where any reminder date matches today
+      // Find all event instances where any reminder date matches today.
+      // Filter out instances with NULL destination — those are search-only
+      // events (e.g. Park City / Sundance) that have no SMS destination_bucket.
       const { data: instances, error } = await supabase
         .from("event_instances")
         .select("*, seasonal_events(name)")
         .eq("status", "active")
         .eq("date_confirmed", true)
+        .not("destination", "is", null)
         .or(`reminder_12wk.eq.${today},reminder_6wk.eq.${today},reminder_2wk.eq.${today}`);
 
       if (error) {

--- a/supabase/migrations/055_event_unification.sql
+++ b/supabase/migrations/055_event_unification.sql
@@ -1,0 +1,270 @@
+-- ============================================================
+-- Migration 055: Event Unification (#338 / prep for #339)
+-- ------------------------------------------------------------
+-- Unifies the static `src/lib/events.ts` curated events with
+-- the DB-backed seasonal_events / event_instances tables so
+-- staff can manage events from admin UI without code changes.
+--
+-- Changes:
+--   1. seasonal_events gains: slug (unique), icon, is_nationwide,
+--      search_destinations (free-form text[] for renter search).
+--   2. event_instances gains: end_date (nullable; NULL = single day).
+--      destination becomes NULLABLE for events not tied to an SMS
+--      destination_bucket. UNIQUE constraint is replaced with two
+--      partial unique indexes to tolerate NULLs.
+--   3. Backfill: 14 curated events + 2026 instances migrated from
+--      src/lib/events.ts.
+--   4. RPC get_curated_events(p_year) for renter-facing filter.
+-- ============================================================
+
+-- ============================================================
+-- 1. EXTEND seasonal_events
+-- ============================================================
+
+ALTER TABLE public.seasonal_events
+  ADD COLUMN IF NOT EXISTS slug TEXT,
+  ADD COLUMN IF NOT EXISTS icon TEXT,
+  ADD COLUMN IF NOT EXISTS is_nationwide BOOLEAN NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS search_destinations TEXT[] NOT NULL DEFAULT '{}';
+
+-- Unique slug (deferred to an index to allow NULL during backfill for
+-- any legacy rows that pre-dated slugs).
+CREATE UNIQUE INDEX IF NOT EXISTS idx_seasonal_events_slug
+  ON public.seasonal_events(slug)
+  WHERE slug IS NOT NULL;
+
+-- ============================================================
+-- 2. EXTEND event_instances
+-- ============================================================
+
+ALTER TABLE public.event_instances
+  ADD COLUMN IF NOT EXISTS end_date DATE;
+
+-- Make destination nullable (was NOT NULL). Search-only events (e.g.,
+-- Park City / Sundance) have no SMS destination_bucket.
+ALTER TABLE public.event_instances
+  ALTER COLUMN destination DROP NOT NULL;
+
+-- Replace the UNIQUE(event_id, destination, year) constraint with two
+-- partial unique indexes that tolerate NULL destination.
+DO $$
+DECLARE
+  con_name TEXT;
+BEGIN
+  SELECT conname INTO con_name
+  FROM pg_constraint
+  WHERE conrelid = 'public.event_instances'::regclass
+    AND contype = 'u'
+    AND pg_get_constraintdef(oid) LIKE '%(event_id, destination, year)%';
+  IF con_name IS NOT NULL THEN
+    EXECUTE format('ALTER TABLE public.event_instances DROP CONSTRAINT %I', con_name);
+  END IF;
+END $$;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_event_instances_event_dest_year
+  ON public.event_instances(event_id, destination, year)
+  WHERE destination IS NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_event_instances_event_year_nodest
+  ON public.event_instances(event_id, year)
+  WHERE destination IS NULL;
+
+-- ============================================================
+-- 3. BACKFILL — 14 curated events from src/lib/events.ts
+-- ============================================================
+-- Use slug as idempotency key. Only inserts if missing.
+
+DO $$
+DECLARE
+  v_event_id UUID;
+BEGIN
+  -- Sundance Film Festival
+  INSERT INTO public.seasonal_events (name, slug, icon, category, recurrence_type, is_nationwide, is_location_fixed, search_destinations, typical_month, active, notes)
+  VALUES ('Sundance Film Festival', 'sundance-2026', 'Film', 'local_events', 'annual_fixed', false, true, ARRAY['Park City'], 1, true, 'Backfilled from events.ts')
+  ON CONFLICT (slug) WHERE slug IS NOT NULL DO NOTHING;
+  SELECT id INTO v_event_id FROM public.seasonal_events WHERE slug = 'sundance-2026';
+  INSERT INTO public.event_instances (event_id, destination, year, event_date, end_date, priority, status, date_confirmed, notes)
+  VALUES (v_event_id, NULL, 2026, '2026-01-22', '2026-02-01', 'medium', 'active', true, 'Backfilled')
+  ON CONFLICT DO NOTHING;
+
+  -- Super Bowl LX
+  INSERT INTO public.seasonal_events (name, slug, icon, category, recurrence_type, is_nationwide, is_location_fixed, search_destinations, typical_month, active, notes)
+  VALUES ('Super Bowl LX', 'super-bowl-lx', 'Trophy', 'sports_events', 'annual_floating', false, false, ARRAY['Santa Clara', 'San Francisco', 'San Jose'], 2, true, 'Backfilled from events.ts')
+  ON CONFLICT (slug) WHERE slug IS NOT NULL DO NOTHING;
+  SELECT id INTO v_event_id FROM public.seasonal_events WHERE slug = 'super-bowl-lx';
+  INSERT INTO public.event_instances (event_id, destination, year, event_date, end_date, priority, status, date_confirmed, notes)
+  VALUES (v_event_id, NULL, 2026, '2026-02-04', '2026-02-10', 'high', 'active', true, 'Backfilled')
+  ON CONFLICT DO NOTHING;
+
+  -- Mardi Gras
+  INSERT INTO public.seasonal_events (name, slug, icon, category, recurrence_type, is_nationwide, is_location_fixed, search_destinations, typical_month, active, notes)
+  VALUES ('Mardi Gras', 'mardi-gras-2026', 'PartyPopper', 'local_events', 'annual_floating', false, true, ARRAY['New Orleans', 'Orlando', 'Miami'], 2, true, 'Backfilled from events.ts')
+  ON CONFLICT (slug) WHERE slug IS NOT NULL DO NOTHING;
+  SELECT id INTO v_event_id FROM public.seasonal_events WHERE slug = 'mardi-gras-2026';
+  INSERT INTO public.event_instances (event_id, destination, year, event_date, end_date, priority, status, date_confirmed, notes)
+  VALUES
+    (v_event_id, 'orlando', 2026, '2026-02-12', '2026-02-18', 'medium', 'active', true, 'Backfilled'),
+    (v_event_id, 'miami',   2026, '2026-02-12', '2026-02-18', 'medium', 'active', true, 'Backfilled')
+  ON CONFLICT DO NOTHING;
+
+  -- Spring Break East
+  INSERT INTO public.seasonal_events (name, slug, icon, category, recurrence_type, is_nationwide, is_location_fixed, search_destinations, typical_month, active, notes)
+  VALUES ('Spring Break (East Coast)', 'spring-break-east', 'Sun', 'school_breaks', 'annual_floating', false, false, ARRAY['Orlando', 'Miami', 'Tampa', 'Myrtle Beach', 'Daytona Beach'], 3, true, 'Backfilled from events.ts')
+  ON CONFLICT (slug) WHERE slug IS NOT NULL DO NOTHING;
+  SELECT id INTO v_event_id FROM public.seasonal_events WHERE slug = 'spring-break-east';
+  INSERT INTO public.event_instances (event_id, destination, year, event_date, end_date, priority, status, date_confirmed, notes)
+  VALUES
+    (v_event_id, 'orlando',      2026, '2026-03-07', '2026-03-21', 'high', 'active', true, 'Backfilled'),
+    (v_event_id, 'miami',        2026, '2026-03-07', '2026-03-21', 'high', 'active', true, 'Backfilled'),
+    (v_event_id, 'myrtle_beach', 2026, '2026-03-07', '2026-03-21', 'high', 'active', true, 'Backfilled')
+  ON CONFLICT DO NOTHING;
+
+  -- Spring Break West
+  INSERT INTO public.seasonal_events (name, slug, icon, category, recurrence_type, is_nationwide, is_location_fixed, search_destinations, typical_month, active, notes)
+  VALUES ('Spring Break (West Coast)', 'spring-break-west', 'Sun', 'school_breaks', 'annual_floating', false, false, ARRAY['Cancun', 'Cabo San Lucas', 'Maui', 'Oahu', 'San Diego'], 3, true, 'Backfilled from events.ts')
+  ON CONFLICT (slug) WHERE slug IS NOT NULL DO NOTHING;
+  SELECT id INTO v_event_id FROM public.seasonal_events WHERE slug = 'spring-break-west';
+  INSERT INTO public.event_instances (event_id, destination, year, event_date, end_date, priority, status, date_confirmed, notes)
+  VALUES
+    (v_event_id, 'maui_hawaii', 2026, '2026-03-14', '2026-03-28', 'high', 'active', true, 'Backfilled')
+  ON CONFLICT DO NOTHING;
+
+  -- The Masters
+  INSERT INTO public.seasonal_events (name, slug, icon, category, recurrence_type, is_nationwide, is_location_fixed, search_destinations, typical_month, active, notes)
+  VALUES ('The Masters', 'masters-golf-2026', 'Flag', 'sports_events', 'annual_fixed', false, true, ARRAY['Hilton Head', 'Myrtle Beach', 'Charleston'], 4, true, 'Backfilled from events.ts')
+  ON CONFLICT (slug) WHERE slug IS NOT NULL DO NOTHING;
+  SELECT id INTO v_event_id FROM public.seasonal_events WHERE slug = 'masters-golf-2026';
+  INSERT INTO public.event_instances (event_id, destination, year, event_date, end_date, priority, status, date_confirmed, notes)
+  VALUES (v_event_id, 'myrtle_beach', 2026, '2026-04-06', '2026-04-12', 'medium', 'active', true, 'Backfilled')
+  ON CONFLICT DO NOTHING;
+
+  -- Memorial Day
+  INSERT INTO public.seasonal_events (name, slug, icon, category, recurrence_type, is_nationwide, is_location_fixed, search_destinations, typical_month, active, notes)
+  VALUES ('Memorial Day Weekend', 'memorial-day-2026', 'Flag', 'major_holidays', 'annual_floating', true, false, ARRAY[]::TEXT[], 5, true, 'Backfilled from events.ts')
+  ON CONFLICT (slug) WHERE slug IS NOT NULL DO NOTHING;
+  SELECT id INTO v_event_id FROM public.seasonal_events WHERE slug = 'memorial-day-2026';
+  INSERT INTO public.event_instances (event_id, destination, year, event_date, end_date, priority, status, date_confirmed, notes)
+  VALUES (v_event_id, NULL, 2026, '2026-05-22', '2026-05-26', 'high', 'active', true, 'Backfilled')
+  ON CONFLICT DO NOTHING;
+
+  -- Summer Peak
+  INSERT INTO public.seasonal_events (name, slug, icon, category, recurrence_type, is_nationwide, is_location_fixed, search_destinations, typical_month, active, notes)
+  VALUES ('Summer Peak Season', 'summer-peak-2026', 'Sun', 'weather_peak_season', 'annual_fixed', true, false, ARRAY[]::TEXT[], 6, true, 'Backfilled from events.ts')
+  ON CONFLICT (slug) WHERE slug IS NOT NULL DO NOTHING;
+  SELECT id INTO v_event_id FROM public.seasonal_events WHERE slug = 'summer-peak-2026';
+  INSERT INTO public.event_instances (event_id, destination, year, event_date, end_date, priority, status, date_confirmed, notes)
+  VALUES (v_event_id, NULL, 2026, '2026-06-15', '2026-08-15', 'medium', 'active', true, 'Backfilled')
+  ON CONFLICT DO NOTHING;
+
+  -- Fourth of July
+  INSERT INTO public.seasonal_events (name, slug, icon, category, recurrence_type, is_nationwide, is_location_fixed, search_destinations, typical_month, active, notes)
+  VALUES ('Fourth of July', 'fourth-of-july-2026', 'Sparkles', 'major_holidays', 'annual_fixed', true, false, ARRAY[]::TEXT[], 7, true, 'Backfilled from events.ts')
+  ON CONFLICT (slug) WHERE slug IS NOT NULL DO NOTHING;
+  SELECT id INTO v_event_id FROM public.seasonal_events WHERE slug = 'fourth-of-july-2026';
+  INSERT INTO public.event_instances (event_id, destination, year, event_date, end_date, priority, status, date_confirmed, notes)
+  VALUES (v_event_id, NULL, 2026, '2026-06-27', '2026-07-06', 'high', 'active', true, 'Backfilled')
+  ON CONFLICT DO NOTHING;
+
+  -- Labor Day
+  INSERT INTO public.seasonal_events (name, slug, icon, category, recurrence_type, is_nationwide, is_location_fixed, search_destinations, typical_month, active, notes)
+  VALUES ('Labor Day Weekend', 'labor-day-2026', 'Palmtree', 'major_holidays', 'annual_floating', true, false, ARRAY[]::TEXT[], 9, true, 'Backfilled from events.ts')
+  ON CONFLICT (slug) WHERE slug IS NOT NULL DO NOTHING;
+  SELECT id INTO v_event_id FROM public.seasonal_events WHERE slug = 'labor-day-2026';
+  INSERT INTO public.event_instances (event_id, destination, year, event_date, end_date, priority, status, date_confirmed, notes)
+  VALUES (v_event_id, NULL, 2026, '2026-09-04', '2026-09-08', 'high', 'active', true, 'Backfilled')
+  ON CONFLICT DO NOTHING;
+
+  -- Halloween at the Parks
+  INSERT INTO public.seasonal_events (name, slug, icon, category, recurrence_type, is_nationwide, is_location_fixed, search_destinations, typical_month, active, notes)
+  VALUES ('Halloween at the Parks', 'halloween-orlando-2026', 'Ghost', 'local_events', 'annual_fixed', false, true, ARRAY['Orlando'], 10, true, 'Backfilled from events.ts')
+  ON CONFLICT (slug) WHERE slug IS NOT NULL DO NOTHING;
+  SELECT id INTO v_event_id FROM public.seasonal_events WHERE slug = 'halloween-orlando-2026';
+  INSERT INTO public.event_instances (event_id, destination, year, event_date, end_date, priority, status, date_confirmed, notes)
+  VALUES (v_event_id, 'orlando', 2026, '2026-10-24', '2026-11-01', 'medium', 'active', true, 'Backfilled')
+  ON CONFLICT DO NOTHING;
+
+  -- Thanksgiving Week
+  INSERT INTO public.seasonal_events (name, slug, icon, category, recurrence_type, is_nationwide, is_location_fixed, search_destinations, typical_month, active, notes)
+  VALUES ('Thanksgiving Week', 'thanksgiving-2026', 'UtensilsCrossed', 'major_holidays', 'annual_floating', true, false, ARRAY[]::TEXT[], 11, true, 'Backfilled from events.ts')
+  ON CONFLICT (slug) WHERE slug IS NOT NULL DO NOTHING;
+  SELECT id INTO v_event_id FROM public.seasonal_events WHERE slug = 'thanksgiving-2026';
+  INSERT INTO public.event_instances (event_id, destination, year, event_date, end_date, priority, status, date_confirmed, notes)
+  VALUES (v_event_id, NULL, 2026, '2026-11-21', '2026-11-29', 'urgent', 'active', true, 'Backfilled')
+  ON CONFLICT DO NOTHING;
+
+  -- Ski Season (Dec 2026 – Mar 2027)
+  INSERT INTO public.seasonal_events (name, slug, icon, category, recurrence_type, is_nationwide, is_location_fixed, search_destinations, typical_month, active, notes)
+  VALUES ('Ski Season', 'ski-season-2026', 'Snowflake', 'weather_peak_season', 'annual_fixed', false, true, ARRAY['Vail', 'Breckenridge', 'Aspen', 'Steamboat Springs', 'Park City', 'Lake Tahoe'], 12, true, 'Backfilled from events.ts')
+  ON CONFLICT (slug) WHERE slug IS NOT NULL DO NOTHING;
+  SELECT id INTO v_event_id FROM public.seasonal_events WHERE slug = 'ski-season-2026';
+  INSERT INTO public.event_instances (event_id, destination, year, event_date, end_date, priority, status, date_confirmed, notes)
+  VALUES (v_event_id, 'colorado', 2026, '2026-12-01', '2027-03-31', 'high', 'active', true, 'Backfilled')
+  ON CONFLICT DO NOTHING;
+
+  -- Holiday Season
+  INSERT INTO public.seasonal_events (name, slug, icon, category, recurrence_type, is_nationwide, is_location_fixed, search_destinations, typical_month, active, notes)
+  VALUES ('Holiday Season', 'holiday-season-2026', 'Gift', 'major_holidays', 'annual_fixed', true, false, ARRAY[]::TEXT[], 12, true, 'Backfilled from events.ts')
+  ON CONFLICT (slug) WHERE slug IS NOT NULL DO NOTHING;
+  SELECT id INTO v_event_id FROM public.seasonal_events WHERE slug = 'holiday-season-2026';
+  INSERT INTO public.event_instances (event_id, destination, year, event_date, end_date, priority, status, date_confirmed, notes)
+  VALUES (v_event_id, NULL, 2026, '2026-12-19', '2027-01-03', 'urgent', 'active', true, 'Backfilled')
+  ON CONFLICT DO NOTHING;
+END $$;
+
+-- ============================================================
+-- 4. RPC: get_curated_events(p_year)
+-- ============================================================
+-- Returns one row per seasonal_event for the given year, with the
+-- earliest start_date and latest end_date across its instances.
+-- Powers the renter-facing events filter on Rentals page.
+
+CREATE OR REPLACE FUNCTION public.get_curated_events(p_year INT DEFAULT NULL)
+RETURNS TABLE (
+  id UUID,
+  slug TEXT,
+  name TEXT,
+  icon TEXT,
+  category public.event_category,
+  recurrence_type public.recurrence_type,
+  is_nationwide BOOLEAN,
+  search_destinations TEXT[],
+  year INT,
+  start_date DATE,
+  end_date DATE
+)
+LANGUAGE SQL
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  WITH target AS (
+    SELECT COALESCE(p_year, EXTRACT(YEAR FROM CURRENT_DATE)::INT) AS y
+  )
+  SELECT
+    se.id,
+    se.slug,
+    se.name,
+    se.icon,
+    se.category,
+    se.recurrence_type,
+    se.is_nationwide,
+    se.search_destinations,
+    t.y AS year,
+    MIN(ei.event_date) AS start_date,
+    MAX(COALESCE(ei.end_date, ei.event_date)) AS end_date
+  FROM public.seasonal_events se
+  JOIN public.event_instances ei ON ei.event_id = se.id
+  CROSS JOIN target t
+  WHERE se.active = true
+    AND ei.status = 'active'
+    AND ei.year = t.y
+    AND se.slug IS NOT NULL
+  GROUP BY se.id, t.y
+  ORDER BY MIN(ei.event_date);
+$$;
+
+GRANT EXECUTE ON FUNCTION public.get_curated_events(INT) TO authenticated, anon;
+
+-- ============================================================
+-- Done.
+-- ============================================================


### PR DESCRIPTION
## Summary
- Closes #338 — staff can now add/edit/retire events from RAV Ops without code changes.
- Unblocks #339 (multi-year event support).

## What changed
**Schema (migration 055):**
- `seasonal_events` gains `slug` (unique), `icon`, `is_nationwide`, `search_destinations TEXT[]`.
- `event_instances` gains `end_date`. `destination` becomes nullable (search-only events); unique constraint replaced with two partial indexes.
- 14 curated events from `src/lib/events.ts` backfilled with 2026 instances.
- New `get_curated_events(p_year)` RPC aggregates templates + instances for the renter-facing filter.

**Frontend:**
- `useCuratedEvents` hook replaces static `CURATED_EVENTS` array.
- `events.ts` now contains only pure utilities; filter/upcoming/search helpers take events as a parameter.
- `Rentals.tsx` reads curated events from DB.

**Admin (RAV Ops → Notification Center):**
- New **Templates** tab: CRUD on `seasonal_events` with dialog form.
- **Event Calendar** tab: Add Instance button + Edit dialog for `event_instances`.

**Safety:**
- `sms-scheduler` filters `destination IS NOT NULL` in scheduled mode.
- Admin-override mode rejects instances with no destination.

## Test plan
- [x] `npm run test` — 1046 passing
- [x] `npm run build` clean
- [x] `npx tsc --noEmit` clean
- [x] Migration 055 applied to DEV
- [x] `sms-scheduler` redeployed to DEV
- [ ] Manual: visit `/rentals`, verify events pill bar populates from DB
- [ ] Manual: visit Admin → Notification Center → Templates, create/edit/retire a template
- [ ] Manual: Event Calendar → Add Instance, confirm new instance appears
- [ ] Manual: SMS admin-override on a search-only event returns 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)