### PR TITLE
feat(admin): #339 multi-year event generation + CI fix

### DIFF
--- a/.github/workflows/docs-audit.yml
+++ b/.github/workflows/docs-audit.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
 jobs:
   docs-audit:
     name: Audit Documentation

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 ---
-last_updated: "2026-04-11T04:04:36"
-change_ref: "902990b"
-change_type: "session-39-docs-update"
+last_updated: "2026-04-14T11:02:20"
+change_ref: "44cd934"
+change_type: "session-50"
 status: "active"
 ---
 # Rent-A-Vacation — Architecture & Developer Guide
@@ -575,6 +575,10 @@ auth.users (Supabase managed)
 | 050 | `subscription_metrics_rpc.sql` | `get_subscription_metrics` RPC for admin MRR dashboard |
 | 051 | `unified_conversations.sql` | `conversations`, `conversation_messages`, `conversation_events` + 4 RPCs + 12-step backfill |
 | 052 | `terms_acceptance_audit.sql` | `terms_acceptance_log` + 3 profile columns (onboarding_completed_at, current_terms_version, current_privacy_version) + backfill of 60 approved users |
+| 053 | `attraction_tags.sql` | Attraction tag taxonomy on resorts |
+| 054 | `price_drop_alerts.sql` | Saved-search price drop notification tracking |
+| 055 | `event_unification.sql` | `seasonal_events` gains slug/icon/is_nationwide/search_destinations; `event_instances` gains end_date + nullable destination; backfill of 14 curated events; `get_curated_events(p_year)` RPC |
+| 056 | `multi_year_event_generation.sql` | `generate_event_instances_for_year(p_year, p_source_year)` RPC — copies annual_fixed/annual_floating instances forward |
 
 Additional non-numbered migrations:
 - `20260211_resort_master_data.sql` — Resort master data seed

--- a/docs/COMPLETED-PHASES.md
+++ b/docs/COMPLETED-PHASES.md
@@ -1,13 +1,69 @@
 ---
-last_updated: "2026-04-12T22:57:23"
-change_ref: "a521368"
-change_type: "session-39-docs-update"
+last_updated: "2026-04-14T11:02:20"
+change_ref: "44cd934"
+change_type: "session-50"
 status: "active"
 ---
 # Completed Phases Archive
 
 > Detailed records of completed project phases, moved from [PROJECT-HUB.md](PROJECT-HUB.md) to keep the hub concise.
 > **Last Archived:** March 10, 2026
+
+---
+
+## Session 50: Event Unification + Multi-Year Generation (#338, #339)
+
+**Completed:** April 14, 2026
+**PR:** #350 (#338), follow-up PR (#339)
+
+### Problem closed
+The 14 curated vacation events that power the Rentals page filter lived in a static file (`src/lib/events.ts`), requiring a code deploy and release to add, edit, or retire an event. A parallel DB schema (`seasonal_events` + `event_instances` from migration 046) existed for SMS reminders but used a different shape and could not serve the renter search filter.
+
+### What was built
+
+**Migration 055 — schema unification**
+- `seasonal_events` extended with `slug` (unique), `icon`, `is_nationwide`, `search_destinations TEXT[]`.
+- `event_instances` extended with `end_date` (nullable). `destination` made nullable for search-only events (e.g. Sundance at Park City — no SMS destination_bucket).
+- UNIQUE constraint replaced with two partial unique indexes (`event_id, destination, year` WHERE destination IS NOT NULL; `event_id, year` WHERE destination IS NULL).
+- Backfilled 14 curated events + 2026 instances.
+- New RPC `get_curated_events(p_year INT)` aggregates templates + instances for the renter filter.
+
+**Frontend**
+- `useCuratedEvents` hook (React Query against `get_curated_events`) replaces the static `CURATED_EVENTS` const.
+- `src/lib/events.ts` now contains only pure utilities. `filterByEvent`, `getUpcomingEvents`, and `findEventsByQuery` take events as a parameter.
+- `Rentals.tsx` reads curated events from DB.
+
+**Admin (RAV Ops → Notification Center)**
+- New **Templates** tab (`AdminEventTemplates` + `EventTemplateDialog`) — CRUD on `seasonal_events` with add/edit/retire flows.
+- **Event Calendar** tab gains an "Add Instance" button and an Edit dialog (`EventInstanceDialog`). Staff can create instances with or without an SMS destination.
+
+**SMS scheduler safety**
+- Scheduled mode filters `destination IS NOT NULL` so search-only events do not trip SMS dispatch.
+- Admin-override mode rejects instances with no destination (returns 400).
+
+**Migration 056 — multi-year generation (#339)**
+- New RPC `generate_event_instances_for_year(p_year INT, p_source_year INT)` — for each active template that has at least one instance in the source year but none in the target year, copies the instances forward. `annual_fixed` instances keep `date_confirmed = true`; `annual_floating` instances copy structure but reset `date_confirmed = false` and set `auto_generated = true` so staff can confirm the new dates.
+- Admin "Generate {year}" button on the Event Calendar tab triggers the RPC and reports how many instances were created.
+
+### Tests
+- 1046 tests pre-#339 (up from 1041).
+- `useCuratedEvents.test.ts` (5 tests) covers DB→FE row mapping, category translation, null handling, and error surfacing.
+- `events.test.ts` refactored for parameterized signatures (24 tests).
+
+### Files created
+- `supabase/migrations/055_event_unification.sql`
+- `supabase/migrations/056_multi_year_event_generation.sql`
+- `src/hooks/useCuratedEvents.ts` + `.test.ts`
+- `src/components/admin/AdminEventTemplates.tsx`
+- `src/components/admin/EventTemplateDialog.tsx`
+- `src/components/admin/EventInstanceDialog.tsx`
+
+### Files modified
+- `src/lib/events.ts`, `src/lib/events.test.ts`
+- `src/pages/Rentals.tsx`
+- `src/components/admin/AdminNotificationCenter.tsx`
+- `supabase/functions/sms-scheduler/index.ts`
+- `.github/workflows/docs-audit.yml` (permissions fix for PR comment)
 
 ---
 

--- a/src/components/admin/AdminNotificationCenter.tsx
+++ b/src/components/admin/AdminNotificationCenter.tsx
@@ -58,6 +58,7 @@ import {
   MessageSquare,
   Plus,
   LayoutTemplate,
+  CalendarPlus,
 } from "lucide-react";
 import { formatDistanceToNow, format } from "date-fns";
 import { AdminEventTemplates } from "./AdminEventTemplates";
@@ -342,6 +343,8 @@ function EventCalendarTab() {
   const [instanceDialogOpen, setInstanceDialogOpen] = useState(false);
   const [editingInstance, setEditingInstance] = useState<EventInstance | null>(null);
   const [reloadKey, setReloadKey] = useState(0);
+  const [generating, setGenerating] = useState(false);
+  const [confirmGenerate, setConfirmGenerate] = useState<{ target: number; source: number } | null>(null);
 
   useEffect(() => {
     async function load() {
@@ -400,6 +403,32 @@ function EventCalendarTab() {
     setSendingId(null);
   };
 
+  const handleGenerateYear = async (targetYear: number, sourceYear: number) => {
+    setConfirmGenerate(null);
+    setGenerating(true);
+    try {
+      const { data, error } = await supabase.rpc("generate_event_instances_for_year", {
+        p_year: targetYear,
+        p_source_year: sourceYear,
+      });
+      if (error) throw error;
+      const row = Array.isArray(data) ? data[0] : data;
+      toast({
+        title: `Generated ${targetYear} instances`,
+        description: `Created ${row?.created_count ?? 0} (${row?.confirmed_count ?? 0} confirmed, ${row?.unconfirmed_count ?? 0} need date confirmation). Skipped ${row?.skipped_count ?? 0} existing.`,
+      });
+      setYearFilter(String(targetYear));
+      setReloadKey((k) => k + 1);
+    } catch (e) {
+      toast({
+        title: "Generation failed",
+        description: e instanceof Error ? e.message : "Unknown error",
+        variant: "destructive",
+      });
+    }
+    setGenerating(false);
+  };
+
   const handleCancelInstance = async (instanceId: string) => {
     const { error } = await supabase
       .from("event_instances")
@@ -442,17 +471,34 @@ function EventCalendarTab() {
             ))}
           </SelectContent>
         </Select>
-        <Button
-          size="sm"
-          className="ml-auto"
-          onClick={() => {
-            setEditingInstance(null);
-            setInstanceDialogOpen(true);
-          }}
-        >
-          <Plus className="h-4 w-4 mr-1.5" />
-          Add Instance
-        </Button>
+        <div className="ml-auto flex items-center gap-2">
+          <Button
+            size="sm"
+            variant="outline"
+            disabled={generating}
+            onClick={() => {
+              const target = parseInt(yearFilter) + 1;
+              setConfirmGenerate({ target, source: parseInt(yearFilter) });
+            }}
+          >
+            {generating ? (
+              <Loader2 className="h-4 w-4 mr-1.5 animate-spin" />
+            ) : (
+              <CalendarPlus className="h-4 w-4 mr-1.5" />
+            )}
+            Generate {parseInt(yearFilter) + 1}
+          </Button>
+          <Button
+            size="sm"
+            onClick={() => {
+              setEditingInstance(null);
+              setInstanceDialogOpen(true);
+            }}
+          >
+            <Plus className="h-4 w-4 mr-1.5" />
+            Add Instance
+          </Button>
+        </div>
       </div>
 
       {loading ? (
@@ -572,6 +618,32 @@ function EventCalendarTab() {
           </Table>
         </div>
       )}
+
+      {/* Generate year confirm dialog */}
+      <AlertDialog open={!!confirmGenerate} onOpenChange={() => setConfirmGenerate(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Generate {confirmGenerate?.target} event instances?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This copies every active annual_fixed and annual_floating event from{" "}
+              {confirmGenerate?.source} to {confirmGenerate?.target}. Existing{" "}
+              {confirmGenerate?.target} instances are preserved. Floating events will need date
+              confirmation before SMS reminders fire.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() =>
+                confirmGenerate &&
+                handleGenerateYear(confirmGenerate.target, confirmGenerate.source)
+              }
+            >
+              Generate
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
 
       {/* Add / Edit instance dialog */}
       <EventInstanceDialog

--- a/supabase/migrations/056_multi_year_event_generation.sql
+++ b/supabase/migrations/056_multi_year_event_generation.sql
@@ -1,0 +1,118 @@
+-- ============================================================
+-- Migration 056: Multi-Year Event Generation (#339)
+-- ------------------------------------------------------------
+-- Adds the RPC that copies event_instances forward from a source
+-- year to a target year for every active template, so staff don't
+-- have to hand-create 30+ rows every December.
+--
+-- Semantics:
+--   * annual_fixed     — dates carry over cleanly; date_confirmed = true.
+--   * annual_floating  — structure copies over but date_confirmed = false
+--                        and auto_generated = true. Staff confirms each
+--                        new date via the existing "Confirm date" badge.
+--   * one_time         — never auto-generated.
+--
+-- Idempotent: skips instances that already exist for
+--   (event_id, destination, year). Safe to re-run.
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.generate_event_instances_for_year(
+  p_year         INT,
+  p_source_year  INT DEFAULT NULL
+)
+RETURNS TABLE (
+  created_count   INT,
+  skipped_count   INT,
+  confirmed_count INT,
+  unconfirmed_count INT
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_source_year     INT := COALESCE(p_source_year, p_year - 1);
+  v_created         INT := 0;
+  v_skipped         INT := 0;
+  v_confirmed       INT := 0;
+  v_unconfirmed     INT := 0;
+  r                 RECORD;
+  v_new_start       DATE;
+  v_new_end         DATE;
+  v_confirmed_flag  BOOL;
+  v_exists          BOOL;
+BEGIN
+  -- Admin-only
+  IF NOT public.is_rav_team(auth.uid()) THEN
+    RAISE EXCEPTION 'Only RAV staff can generate event instances';
+  END IF;
+
+  IF p_year <= v_source_year THEN
+    RAISE EXCEPTION 'Target year (%) must be after source year (%)', p_year, v_source_year;
+  END IF;
+
+  FOR r IN
+    SELECT
+      ei.event_id,
+      ei.destination,
+      ei.event_date,
+      ei.end_date,
+      ei.priority,
+      ei.notes,
+      se.recurrence_type
+    FROM public.event_instances ei
+    JOIN public.seasonal_events se ON se.id = ei.event_id
+    WHERE ei.year = v_source_year
+      AND ei.status = 'active'
+      AND se.active = true
+      AND se.recurrence_type IN ('annual_fixed', 'annual_floating')
+  LOOP
+    -- Dedup: skip if a row already exists for (event_id, destination, year).
+    -- Use IS NOT DISTINCT FROM so NULL destinations compare equal.
+    SELECT EXISTS(
+      SELECT 1 FROM public.event_instances
+      WHERE event_id = r.event_id
+        AND destination IS NOT DISTINCT FROM r.destination
+        AND year = p_year
+    ) INTO v_exists;
+
+    IF v_exists THEN
+      v_skipped := v_skipped + 1;
+      CONTINUE;
+    END IF;
+
+    -- Shift dates forward by (p_year - v_source_year) years.
+    v_new_start := r.event_date + ((p_year - v_source_year) || ' years')::INTERVAL;
+    v_new_end   := CASE
+      WHEN r.end_date IS NULL THEN NULL
+      ELSE r.end_date + ((p_year - v_source_year) || ' years')::INTERVAL
+    END;
+
+    -- Fixed events carry their confirmed status forward; floating events
+    -- need a human to re-check the shifted date.
+    v_confirmed_flag := (r.recurrence_type = 'annual_fixed');
+
+    INSERT INTO public.event_instances (
+      event_id, destination, year, event_date, end_date,
+      priority, status, auto_generated, date_confirmed, notes
+    ) VALUES (
+      r.event_id, r.destination, p_year, v_new_start, v_new_end,
+      r.priority, 'active', true, v_confirmed_flag,
+      COALESCE(r.notes, '') ||
+        CASE WHEN COALESCE(r.notes, '') = '' THEN '' ELSE E'\n' END ||
+        format('Auto-generated from %s instance on %s', v_source_year, NOW()::DATE)
+    );
+
+    v_created := v_created + 1;
+    IF v_confirmed_flag THEN
+      v_confirmed := v_confirmed + 1;
+    ELSE
+      v_unconfirmed := v_unconfirmed + 1;
+    END IF;
+  END LOOP;
+
+  RETURN QUERY SELECT v_created, v_skipped, v_confirmed, v_unconfirmed;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.generate_event_instances_for_year(INT, INT) TO authenticated;


### PR DESCRIPTION
## Summary
- Closes #339 — staff can roll the event calendar forward one year with a single click.
- Fixes Audit Documentation CI failure (permissions issue on PR comment).
- Adds event-system entries to ARCHITECTURE.md and COMPLETED-PHASES.md.

## What changed
**Migration 056 — generate_event_instances_for_year RPC**
- For every active template with a source-year instance, copies it forward to the target year.
- `annual_fixed` → `date_confirmed = true`, dates shift cleanly.
- `annual_floating` → `date_confirmed = false`, `auto_generated = true` (staff must re-confirm).
- Idempotent via `IS NOT DISTINCT FROM` on destination (handles NULLs).
- `is_rav_team(auth.uid())` gate.

**Admin UI**
- "Generate {year+1}" button on Event Calendar tab.
- Confirmation dialog explaining the semantics.
- Toast reports created / skipped / confirmed / unconfirmed counts.

**CI fix**
- `docs-audit.yml` gains `pull-requests: write` and `issues: write` permissions so the workflow can post its audit comment.

**Docs**
- `ARCHITECTURE.md` migrations table refreshed through 056.
- `COMPLETED-PHASES.md` has a new Session 50 entry covering #338 + #339.

## Test plan
- [x] `npm run build` clean
- [x] `npx tsc --noEmit` clean
- [x] Migration 056 applied to DEV
- [ ] Manual: Event Calendar → Generate 2027 → confirm 15+ instances appear with floating events unconfirmed
- [ ] Manual: re-click Generate 2027 → all 15 skipped, 0 created
- [ ] Manual: verify docs-audit CI comment now posts successfully on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)