### PR TITLE
feat(ui): #349 site-wide UI polish — spacing, demarcation, hierarchy

### DIFF
--- a/docs/PRIORITY-ROADMAP.md
+++ b/docs/PRIORITY-ROADMAP.md
@@ -1,6 +1,6 @@
 ---
-last_updated: "2026-04-14T10:45:32"
-change_ref: "e45e7fb"
+last_updated: "2026-04-14T11:11:02"
+change_ref: "077c2c2"
 change_type: "session-50"
 status: "active"
 ---
@@ -27,7 +27,6 @@ These require decisions, walkthroughs, or external dependencies before coding.
 | #187 | Pre-launch manual verification | Needs systematic walkthrough. Partially done. |
 | #257 | Resort data compliance audit | Legal review of seed data sources. |
 | #322 | RAV Wishes proposal enforcement | Deferred until 30+ days of real proposal data. Post-beta. |
-| #339 | Multi-year event support | Recurring templates + 2027+ dates. Depends on #338 (now unblocked). |
 | #349 | UI polish audit — spacing, sections, visual hierarchy | Aggressive site-wide pass. Can run in parallel with feature work. |
 
 ### Tier C: Tier Feature Differentiation (Bundle as Sprint)
@@ -95,7 +94,7 @@ These unblock when the LLC is formed. Not code-dependent.
 
 | Date | Session | Changes |
 |------|---------|---------|
-| Apr 14, 2026 | 50 | #338 completed. Events unified: static `lib/events.ts` migrated to DB (seasonal_events + event_instances). Migration 055 (slug/icon/is_nationwide/search_destinations columns, end_date, nullable destination, 14 events backfilled, get_curated_events RPC). Admin Templates tab + Add/Edit instance dialogs. `useCuratedEvents` hook. 1046 tests. #339 now unblocked. |
+| Apr 14, 2026 | 50 | #338 + #339 completed. Events unified into DB (migration 055) + multi-year generator RPC (migration 056). Admin Templates tab + Add/Edit Instance dialogs + "Generate {next year}" button. `useCuratedEvents` hook. docs-audit CI permissions fix. ARCHITECTURE + COMPLETED-PHASES refreshed. PRs #350, #351. 1046 tests. |
 | Apr 13, 2026 | 49 | Tier A cleared: #259, #283, #285, #286, #327, #328, #337. Logos. Discovery bar. Tax form. Social proof. 1047 tests. PRs #334-#348. |
 | Apr 13, 2026 | 48 | #326 RAV Deals completed + closed. #273 Homepage completed (Session 47). Header nav consistency fix. Renumbered Tier A. |
 | Apr 12, 2026 | 47 | Initial creation. Brand rebrand completed. Search & Discovery epic created (#325-#328). Full 5-tier prioritization. |

--- a/docs/PRIORITY-ROADMAP.md
+++ b/docs/PRIORITY-ROADMAP.md
@@ -1,6 +1,6 @@
 ---
-last_updated: "2026-04-14T11:11:02"
-change_ref: "077c2c2"
+last_updated: "2026-04-15T01:20:24"
+change_ref: "fc6f491"
 change_type: "session-50"
 status: "active"
 ---
@@ -27,7 +27,6 @@ These require decisions, walkthroughs, or external dependencies before coding.
 | #187 | Pre-launch manual verification | Needs systematic walkthrough. Partially done. |
 | #257 | Resort data compliance audit | Legal review of seed data sources. |
 | #322 | RAV Wishes proposal enforcement | Deferred until 30+ days of real proposal data. Post-beta. |
-| #349 | UI polish audit — spacing, sections, visual hierarchy | Aggressive site-wide pass. Can run in parallel with feature work. |
 
 ### Tier C: Tier Feature Differentiation (Bundle as Sprint)
 
@@ -94,6 +93,7 @@ These unblock when the LLC is formed. Not code-dependent.
 
 | Date | Session | Changes |
 |------|---------|---------|
+| Apr 14, 2026 | 51 | #349 UI polish audit completed. New `Section` + `SectionHeader` layout primitives. Tightened vertical rhythm, headings, and section demarcation across Homepage, PropertyDetail, Rentals, BiddingMarketplace, OwnerDashboard, MyBookings, ListProperty. Build clean, P0 tests passing. |
 | Apr 14, 2026 | 50 | #338 + #339 completed. Events unified into DB (migration 055) + multi-year generator RPC (migration 056). Admin Templates tab + Add/Edit Instance dialogs + "Generate {next year}" button. `useCuratedEvents` hook. docs-audit CI permissions fix. ARCHITECTURE + COMPLETED-PHASES refreshed. PRs #350, #351. 1046 tests. |
 | Apr 13, 2026 | 49 | Tier A cleared: #259, #283, #285, #286, #327, #328, #337. Logos. Discovery bar. Tax form. Social proof. 1047 tests. PRs #334-#348. |
 | Apr 13, 2026 | 48 | #326 RAV Deals completed + closed. #273 Homepage completed (Session 47). Header nav consistency fix. Renumbered Tier A. |

--- a/src/components/FeaturedResorts.tsx
+++ b/src/components/FeaturedResorts.tsx
@@ -32,7 +32,7 @@ const FeaturedResorts = () => {
 
   if (isLoading) {
     return (
-      <section className="py-12 bg-background">
+      <section className="py-12 md:py-16 bg-background border-t border-border/60">
         <div className="container mx-auto px-4 text-center">
           <Loader2 className="w-8 h-8 animate-spin text-primary mx-auto" />
         </div>
@@ -42,7 +42,7 @@ const FeaturedResorts = () => {
 
   if (featured.length === 0) {
     return (
-      <section className="py-12 bg-background">
+      <section className="py-12 md:py-16 bg-background border-t border-border/60">
         <div className="container mx-auto px-4">
           <div className="text-center">
             <h2 className="font-display text-2xl md:text-3xl font-bold text-foreground mb-3">
@@ -70,16 +70,16 @@ const FeaturedResorts = () => {
     <section className="py-12 bg-background">
       <div className="container mx-auto px-4">
         {/* Section Header */}
-        <div className="flex flex-col md:flex-row md:items-end justify-between mb-8">
-          <div>
-            <h2 className="font-display text-2xl md:text-3xl font-bold text-foreground mb-1">
+        <div className="flex flex-col gap-3 md:flex-row md:items-end md:justify-between mb-8 md:mb-10">
+          <div className="max-w-2xl">
+            <h2 className="font-display text-2xl md:text-3xl font-bold text-foreground tracking-tight">
               Explore vacation rentals
             </h2>
-            <p className="text-muted-foreground">
+            <p className="mt-2 text-muted-foreground">
               117 resorts from 9 brands — verified owners, protected payments
             </p>
           </div>
-          <Link to="/rentals" className="mt-3 md:mt-0">
+          <Link to="/rentals" className="shrink-0">
             <Button variant="outline" size="sm">
               View all rentals
               <ChevronRight className="w-4 h-4 ml-1" />

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -37,10 +37,10 @@ const HeroSection = () => {
       </div>
 
       {/* Content */}
-      <div className="relative z-10 container mx-auto px-4 pt-28 pb-16 md:pt-36 md:pb-20">
+      <div className="relative z-10 container mx-auto px-4 pt-24 pb-14 md:pt-32 md:pb-20">
         <div className="max-w-3xl mx-auto text-center">
           {/* Tagline */}
-          <h1 className="font-display text-3xl sm:text-4xl md:text-5xl font-bold text-white mb-3 animate-slide-up">
+          <h1 className="font-display text-3xl sm:text-4xl md:text-5xl lg:text-6xl font-bold text-white tracking-tight mb-4 animate-slide-up">
             Name Your Price. Book Your Paradise.
           </h1>
           <p className="text-base md:text-lg text-white/90 font-medium mb-8 max-w-xl mx-auto animate-fade-in">

--- a/src/components/HowItWorks.tsx
+++ b/src/components/HowItWorks.tsx
@@ -54,14 +54,14 @@ const HowItWorks = () => {
   const steps = activeTab === "renters" ? renterSteps : ownerSteps;
 
   return (
-    <section className="py-20 bg-gradient-warm">
+    <section className="py-14 md:py-20 bg-gradient-warm border-t border-border/60">
       <div className="container mx-auto px-4">
         {/* Header */}
-        <div className="text-center mb-12">
-          <h2 className="font-display text-3xl md:text-4xl font-bold text-foreground mb-4">
+        <div className="text-center mb-10 md:mb-12 max-w-2xl mx-auto">
+          <h2 className="font-display text-3xl md:text-4xl font-bold text-foreground tracking-tight mb-3">
             How Direct-from-Owner Rentals Work
           </h2>
-          <p className="text-muted-foreground text-lg max-w-2xl mx-auto mb-8">
+          <p className="text-muted-foreground text-lg mb-8">
             Skip the resort markup. Rent directly from verified owners, bid on listings, 
             or post your travel needs and let owners compete for your booking.
           </p>

--- a/src/components/TopDestinations.tsx
+++ b/src/components/TopDestinations.tsx
@@ -18,13 +18,16 @@ const destinations = [
 
 const TopDestinations = () => {
   return (
-    <section className="py-8 md:py-12 bg-background">
+    <section className="py-12 md:py-16 bg-background border-t border-border/60">
       <div className="container mx-auto px-4">
         {/* Header */}
-        <div className="flex items-center justify-between mb-5">
-          <h2 className="font-display text-xl md:text-2xl font-bold text-foreground">
-            Popular destinations
-          </h2>
+        <div className="flex items-end justify-between mb-6 md:mb-8">
+          <div>
+            <h2 className="font-display text-2xl md:text-3xl font-bold text-foreground tracking-tight">
+              Popular destinations
+            </h2>
+            <p className="mt-1 text-sm text-muted-foreground">Find your next stay by location.</p>
+          </div>
           <Link
             to="/destinations"
             className="text-sm text-primary hover:underline flex items-center gap-1"
@@ -42,7 +45,7 @@ const TopDestinations = () => {
               to={`/rentals?location=${encodeURIComponent(dest.name)}`}
               className="flex-shrink-0 snap-start group"
             >
-              <div className="w-24 h-24 md:w-28 md:h-28 rounded-2xl overflow-hidden mb-2 shadow-card group-hover:shadow-card-hover transition-shadow">
+              <div className="w-32 h-32 md:w-36 md:h-36 rounded-2xl overflow-hidden mb-2 shadow-card group-hover:shadow-card-hover transition-shadow">
                 <img
                   src={dest.image}
                   alt={dest.name}

--- a/src/components/TrustBadges.tsx
+++ b/src/components/TrustBadges.tsx
@@ -35,16 +35,16 @@ const badges = [
 
 const TrustBadges = () => {
   return (
-    <section className="py-16 bg-primary text-primary-foreground">
+    <section className="py-12 md:py-14 bg-primary text-primary-foreground">
       <div className="container mx-auto px-4">
-        <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-8">
+        <div className="grid grid-cols-3 md:grid-cols-6 gap-6 md:gap-8">
           {badges.map((badge, index) => (
             <div key={index} className="text-center group">
-              <div className="w-14 h-14 mx-auto mb-3 rounded-full bg-white/10 flex items-center justify-center group-hover:bg-white/20 transition-colors">
-                <badge.icon className="w-7 h-7 opacity-90" />
+              <div className="w-12 h-12 md:w-14 md:h-14 mx-auto mb-2 rounded-full bg-white/10 flex items-center justify-center group-hover:bg-white/20 transition-colors">
+                <badge.icon className="w-6 h-6 md:w-7 md:h-7 opacity-90" />
               </div>
-              <div className="font-display text-2xl md:text-3xl font-bold mb-1">{badge.value}</div>
-              <div className="text-sm opacity-80">{badge.label}</div>
+              <div className="font-display text-xl md:text-2xl font-bold leading-tight">{badge.value}</div>
+              <div className="text-xs md:text-sm opacity-80 mt-0.5">{badge.label}</div>
             </div>
           ))}
         </div>

--- a/src/components/layout/Section.tsx
+++ b/src/components/layout/Section.tsx
@@ -1,0 +1,124 @@
+import { forwardRef, type HTMLAttributes, type ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+type SectionTone = "default" | "muted" | "primary" | "warm";
+type SectionSpacing = "sm" | "md" | "lg";
+
+interface SectionProps extends HTMLAttributes<HTMLElement> {
+  tone?: SectionTone;
+  spacing?: SectionSpacing;
+  bordered?: boolean;
+  containerClassName?: string;
+  fullBleed?: boolean;
+}
+
+const toneClass: Record<SectionTone, string> = {
+  default: "bg-background text-foreground",
+  muted: "bg-muted/40 text-foreground",
+  primary: "bg-primary text-primary-foreground",
+  warm: "bg-gradient-warm text-foreground",
+};
+
+const spacingClass: Record<SectionSpacing, string> = {
+  sm: "py-10 md:py-12",
+  md: "py-12 md:py-16",
+  lg: "py-16 md:py-20",
+};
+
+export const Section = forwardRef<HTMLElement, SectionProps>(
+  (
+    {
+      tone = "default",
+      spacing = "md",
+      bordered = false,
+      containerClassName,
+      fullBleed = false,
+      className,
+      children,
+      ...rest
+    },
+    ref,
+  ) => (
+    <section
+      ref={ref}
+      className={cn(
+        toneClass[tone],
+        spacingClass[spacing],
+        bordered && "border-t border-border/60",
+        className,
+      )}
+      {...rest}
+    >
+      {fullBleed ? (
+        children
+      ) : (
+        <div className={cn("container mx-auto px-4", containerClassName)}>
+          {children}
+        </div>
+      )}
+    </section>
+  ),
+);
+Section.displayName = "Section";
+
+interface SectionHeaderProps {
+  eyebrow?: string;
+  title: ReactNode;
+  description?: ReactNode;
+  align?: "left" | "center";
+  action?: ReactNode;
+  className?: string;
+  size?: "sm" | "md" | "lg";
+}
+
+const titleSizeClass: Record<NonNullable<SectionHeaderProps["size"]>, string> = {
+  sm: "text-xl md:text-2xl",
+  md: "text-2xl md:text-3xl",
+  lg: "text-3xl md:text-4xl",
+};
+
+export const SectionHeader = ({
+  eyebrow,
+  title,
+  description,
+  align = "left",
+  action,
+  className,
+  size = "md",
+}: SectionHeaderProps) => {
+  const isCenter = align === "center";
+  return (
+    <div
+      className={cn(
+        "mb-8 md:mb-10",
+        isCenter
+          ? "text-center max-w-2xl mx-auto"
+          : "flex flex-col gap-4 md:flex-row md:items-end md:justify-between",
+        className,
+      )}
+    >
+      <div className={cn(isCenter ? "" : "max-w-2xl")}>
+        {eyebrow && (
+          <div className="mb-2 text-xs font-semibold uppercase tracking-wider text-primary">
+            {eyebrow}
+          </div>
+        )}
+        <h2
+          className={cn(
+            "font-display font-bold text-foreground tracking-tight",
+            titleSizeClass[size],
+          )}
+        >
+          {title}
+        </h2>
+        {description && (
+          <p className="mt-2 text-muted-foreground leading-relaxed">
+            {description}
+          </p>
+        )}
+      </div>
+      {!isCenter && action && <div className="shrink-0">{action}</div>}
+      {isCenter && action && <div className="mt-6">{action}</div>}
+    </div>
+  );
+};

--- a/src/pages/AccountSettings.tsx
+++ b/src/pages/AccountSettings.tsx
@@ -184,8 +184,8 @@ const AccountSettings = () => {
       <main className="pt-20 md:pt-24 pb-16">
         <div className="container mx-auto px-4 max-w-3xl">
           {/* Page heading */}
-          <div className="mb-8">
-            <h1 className="font-display text-3xl md:text-4xl font-bold text-foreground">
+          <div className="mb-8 md:mb-10">
+            <h1 className="font-display text-3xl md:text-4xl font-bold text-foreground tracking-tight">
               Account Settings
             </h1>
             <p className="text-muted-foreground mt-2">

--- a/src/pages/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard.tsx
@@ -154,20 +154,20 @@ const AdminDashboard = () => {
     <div className="min-h-screen bg-background">
       <Header />
       {/* Page Header */}
-      <header className="border-b bg-card mt-16 md:mt-20">
-        <div className="container mx-auto px-4 py-4">
+      <header className="border-b border-border/60 bg-card mt-16 md:mt-20">
+        <div className="container mx-auto px-4 py-5 md:py-6">
           <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
-            <div className="flex items-center gap-4">
+            <div className="flex items-center gap-3">
               <Button variant="ghost" size="icon" onClick={() => navigate("/")} className="flex-shrink-0">
                 <ArrowLeft className="h-5 w-5" />
               </Button>
               <div>
                 <div className="flex items-center gap-2">
-                  <h1 className="text-xl sm:text-2xl font-bold">RAV Ops</h1>
+                  <h1 className="font-display text-xl sm:text-2xl font-bold tracking-tight">RAV Ops</h1>
                   <ShieldCheck className="h-5 w-5 text-primary" />
                 </div>
                 <p className="text-sm text-muted-foreground">
-                  Platform management and oversight
+                  Platform management and oversight.
                 </p>
               </div>
             </div>
@@ -188,9 +188,9 @@ const AdminDashboard = () => {
       </header>
 
       {/* Main Content */}
-      <main className="container mx-auto px-4 py-6">
+      <main className="container mx-auto px-4 py-6 md:py-8">
         <Tabs value={activeTab} onValueChange={setActiveTab}>
-          <TabsList className="flex flex-wrap gap-1 h-auto w-full mb-6">
+          <TabsList className="flex flex-wrap gap-1 h-auto w-full mb-6 md:mb-8">
             <TabsTrigger value="overview" className="gap-2">
               <LayoutDashboard className="h-4 w-4" />
               <span className="hidden sm:inline">Overview</span>

--- a/src/pages/BiddingMarketplace.tsx
+++ b/src/pages/BiddingMarketplace.tsx
@@ -82,17 +82,17 @@ const BiddingMarketplace = () => {
       <Header />
 
       {/* Hero Section */}
-      <section className="pt-24 pb-12 bg-gradient-warm">
+      <section className="pt-20 md:pt-24 pb-10 md:pb-12 bg-gradient-warm border-b border-border/60">
         <div className="container mx-auto px-4">
           <div className="max-w-3xl mx-auto text-center">
-            <Badge className="mb-4 bg-accent text-accent-foreground">
+            <Badge className="mb-3 bg-accent text-accent-foreground">
               <Store className="h-3 w-3 mr-1" />
               Direct from Owners
             </Badge>
-            <h1 className="font-display text-4xl md:text-5xl font-bold text-foreground mb-4">
+            <h1 className="font-display text-4xl md:text-5xl font-bold text-foreground tracking-tight mb-3">
               Name Your Price
             </h1>
-            <p className="text-lg text-muted-foreground mb-8">
+            <p className="text-lg text-muted-foreground mb-8 max-w-2xl mx-auto">
               The flexible pricing marketplace for vacation rentals. Make an offer on owner-listed properties
               or post your travel plans and let verified owners compete for your booking.
             </p>
@@ -124,9 +124,9 @@ const BiddingMarketplace = () => {
       </section>
 
       {/* Main Content */}
-      <section className="py-12">
+      <section className="py-10 md:py-12">
         <div className="container mx-auto px-4">
-          <Tabs defaultValue={defaultTab} className="space-y-8">
+          <Tabs defaultValue={defaultTab} className="space-y-6 md:space-y-8">
             <TabsList className="grid w-full max-w-md mx-auto grid-cols-2">
               <TabsTrigger value="listings" className="gap-2">
                 <Gavel className="h-4 w-4" />
@@ -251,9 +251,9 @@ const BiddingMarketplace = () => {
       </section>
 
       {/* How the Marketplace Works */}
-      <section className="py-16 bg-muted/50">
+      <section className="py-14 md:py-16 bg-muted/40 border-t border-border/60">
         <div className="container mx-auto px-4">
-          <h2 className="text-2xl font-bold text-center mb-12">How the Marketplace Works</h2>
+          <h2 className="font-display text-2xl md:text-3xl font-bold text-foreground tracking-tight text-center mb-10 md:mb-12">How the Marketplace Works</h2>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-8 md:gap-12 max-w-4xl mx-auto">
             {/* Renter Flow */}
             <div className="space-y-6">

--- a/src/pages/BookingSuccess.tsx
+++ b/src/pages/BookingSuccess.tsx
@@ -129,11 +129,11 @@ const BookingSuccess = () => {
   return (
     <div className="min-h-screen bg-background">
       <Header />
-      <div className="pt-16 md:pt-20 py-12 px-4">
+      <div className="pt-20 md:pt-24 pb-12 md:pb-16 px-4">
       <div className="container max-w-2xl mx-auto">
-        <div className="text-center mb-8">
+        <div className="text-center mb-8 md:mb-10">
           <CheckCircle2 className="h-16 w-16 text-green-500 mx-auto mb-4" />
-          <h1 className="text-3xl font-bold mb-2">Booking Confirmed!</h1>
+          <h1 className="font-display text-3xl md:text-4xl font-bold tracking-tight mb-2">Booking Confirmed!</h1>
           <p className="text-muted-foreground">
             Your vacation is booked. You'll receive a confirmation email shortly.
           </p>

--- a/src/pages/BudgetPlanner.tsx
+++ b/src/pages/BudgetPlanner.tsx
@@ -122,16 +122,16 @@ export default function BudgetPlanner() {
             Back to Free Tools
           </Link>
 
-          <div className="text-center mb-10">
-            <div className="inline-flex items-center gap-2 bg-indigo-50 text-indigo-700 px-4 py-1.5 rounded-full text-sm font-medium mb-4">
-              <Wallet className="h-4 w-4" />
+          <div className="text-center mb-8 md:mb-10 max-w-3xl mx-auto">
+            <div className="inline-flex items-center gap-2 bg-primary/10 text-primary px-3 py-1 rounded-full text-xs font-semibold uppercase tracking-wider mb-4">
+              <Wallet className="h-3.5 w-3.5" />
               RAV SmartBudget
             </div>
-            <h1 className="font-display text-3xl sm:text-4xl font-bold text-foreground mb-3">
+            <h1 className="font-display text-3xl sm:text-4xl font-bold text-foreground tracking-tight mb-3">
               What will your whole trip cost?
             </h1>
-            <p className="text-muted-foreground text-lg max-w-2xl mx-auto">
-              Plan beyond accommodation — estimate flights, dining, activities, and more
+            <p className="text-muted-foreground text-lg">
+              Plan beyond accommodation — estimate flights, dining, activities, and more.
             </p>
           </div>
 

--- a/src/pages/Checkout.tsx
+++ b/src/pages/Checkout.tsx
@@ -162,24 +162,24 @@ const Checkout = () => {
     <div className="min-h-screen bg-background">
       <Header />
 
-      <main className="pt-24 pb-16">
+      <main className="pt-20 md:pt-24 pb-12 md:pb-16">
         <div className="container mx-auto px-4">
           {/* Breadcrumb */}
-          <div className="flex items-center gap-2 text-sm text-muted-foreground mb-8">
+          <div className="flex items-center gap-2 text-xs md:text-sm text-muted-foreground mb-6">
             <Link to="/" className="hover:text-foreground">Home</Link>
             <span>/</span>
             <Link to="/rentals" className="hover:text-foreground">Rentals</Link>
             <span>/</span>
-            <Link to={`/property/${listing.id}`} className="hover:text-foreground">{displayName}</Link>
+            <Link to={`/property/${listing.id}`} className="hover:text-foreground truncate max-w-[200px]">{displayName}</Link>
             <span>/</span>
             <span className="text-foreground">Checkout</span>
           </div>
 
-          <h1 className="font-display text-3xl font-bold text-foreground mb-8">
+          <h1 className="font-display text-3xl md:text-4xl font-bold text-foreground tracking-tight mb-8">
             Confirm Your Booking
           </h1>
 
-          <div className="grid lg:grid-cols-3 gap-8">
+          <div className="grid lg:grid-cols-3 gap-8 lg:gap-10">
             {/* Booking Details Form */}
             <div className="lg:col-span-2 space-y-6">
               {/* Property Summary */}

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -67,12 +67,12 @@ const Contact = () => {
       <Header />
 
       {/* Hero */}
-      <section className="pt-32 pb-16 bg-gradient-warm">
+      <section className="pt-28 md:pt-32 pb-12 md:pb-16 bg-gradient-warm border-b border-border/60">
         <div className="container mx-auto px-4 text-center">
-          <h1 className="font-display text-4xl md:text-5xl font-bold text-foreground mb-6">
+          <h1 className="font-display text-4xl md:text-5xl font-bold text-foreground tracking-tight mb-4">
             Contact Us
           </h1>
-          <p className="text-xl text-muted-foreground max-w-2xl mx-auto">
+          <p className="text-lg md:text-xl text-muted-foreground max-w-2xl mx-auto">
             Have a question or need help? We're here for you. Send us a message
             and we'll get back to you as soon as possible.
           </p>
@@ -80,14 +80,14 @@ const Contact = () => {
       </section>
 
       {/* Contact Content */}
-      <section className="py-16">
+      <section className="py-12 md:py-16">
         <div className="container mx-auto px-4">
-          <div className="grid lg:grid-cols-3 gap-12 max-w-6xl mx-auto">
+          <div className="grid lg:grid-cols-3 gap-8 lg:gap-12 max-w-6xl mx-auto">
 
             {/* Contact Form */}
             <div className="lg:col-span-2">
-              <div className="bg-card rounded-xl p-8 shadow-card">
-                <h2 className="font-display text-2xl font-bold text-foreground mb-6">
+              <div className="bg-card rounded-xl p-6 sm:p-8 shadow-card border border-border/60">
+                <h2 className="font-display text-2xl md:text-3xl font-bold text-foreground tracking-tight mb-6">
                   Send Us a Message
                 </h2>
 

--- a/src/pages/CostComparator.tsx
+++ b/src/pages/CostComparator.tsx
@@ -99,16 +99,16 @@ export default function CostComparator() {
           </Link>
 
           {/* Header */}
-          <div className="text-center mb-10">
-            <div className="inline-flex items-center gap-2 bg-green-50 text-green-700 px-4 py-1.5 rounded-full text-sm font-medium mb-4">
-              <BarChart3 className="h-4 w-4" />
+          <div className="text-center mb-8 md:mb-10 max-w-3xl mx-auto">
+            <div className="inline-flex items-center gap-2 bg-primary/10 text-primary px-3 py-1 rounded-full text-xs font-semibold uppercase tracking-wider mb-4">
+              <BarChart3 className="h-3.5 w-3.5" />
               RAV SmartCompare
             </div>
-            <h1 className="font-display text-3xl sm:text-4xl font-bold text-foreground mb-3">
+            <h1 className="font-display text-3xl sm:text-4xl font-bold text-foreground tracking-tight mb-3">
               How much can you save with a timeshare rental?
             </h1>
-            <p className="text-muted-foreground text-lg max-w-2xl mx-auto">
-              Compare RAV timeshare rentals against hotels and Airbnb — same destination, same dates
+            <p className="text-muted-foreground text-lg">
+              Compare RAV timeshare rentals against hotels and Airbnb — same destination, same dates.
             </p>
           </div>
 

--- a/src/pages/DestinationDetail.tsx
+++ b/src/pages/DestinationDetail.tsx
@@ -85,7 +85,7 @@ const DestinationDetail = () => {
       <Header />
 
       {/* Hero */}
-      <section className="pt-32 pb-12 bg-gradient-warm">
+      <section className="pt-24 md:pt-28 pb-10 md:pb-12 bg-gradient-warm border-b border-border/60">
         <div className="container mx-auto px-4">
           {/* Breadcrumb */}
           <nav className="flex items-center gap-1.5 text-sm text-muted-foreground mb-6">

--- a/src/pages/Destinations.tsx
+++ b/src/pages/Destinations.tsx
@@ -58,12 +58,12 @@ const Destinations = () => {
       <Header />
 
       {/* Hero */}
-      <section className="pt-32 pb-16 bg-gradient-warm">
+      <section className="pt-28 md:pt-32 pb-12 md:pb-16 bg-gradient-warm border-b border-border/60">
         <div className="container mx-auto px-4 text-center">
-          <h1 className="font-display text-4xl md:text-5xl font-bold text-foreground mb-6">
+          <h1 className="font-display text-4xl md:text-5xl font-bold text-foreground tracking-tight mb-4">
             Explore Destinations
           </h1>
-          <p className="text-xl text-muted-foreground max-w-2xl mx-auto">
+          <p className="text-lg md:text-xl text-muted-foreground max-w-2xl mx-auto">
             Discover amazing vacation spots worldwide. From tropical beaches to mountain
             retreats, find your perfect getaway.
           </p>
@@ -71,9 +71,9 @@ const Destinations = () => {
       </section>
 
       {/* Featured Destinations */}
-      <section className="py-16">
+      <section className="py-12 md:py-16">
         <div className="container mx-auto px-4">
-          <h2 className="font-display text-2xl font-bold text-foreground mb-8">
+          <h2 className="font-display text-2xl md:text-3xl font-bold text-foreground tracking-tight mb-6 md:mb-8">
             Featured Destinations
           </h2>
           <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
@@ -126,9 +126,9 @@ const Destinations = () => {
       </section>
 
       {/* All Destinations */}
-      <section className="py-16 bg-muted/50">
+      <section className="py-12 md:py-16 bg-muted/40 border-t border-border/60">
         <div className="container mx-auto px-4">
-          <h2 className="font-display text-2xl font-bold text-foreground mb-8">
+          <h2 className="font-display text-2xl md:text-3xl font-bold text-foreground tracking-tight mb-6 md:mb-8">
             All Destinations
           </h2>
           <div className="grid md:grid-cols-3 lg:grid-cols-4 gap-6">
@@ -177,9 +177,9 @@ const Destinations = () => {
       </section>
 
       {/* Popular Resort Brands */}
-      <section className="py-16">
+      <section className="py-12 md:py-16">
         <div className="container mx-auto px-4">
-          <h2 className="font-display text-2xl font-bold text-foreground mb-8">
+          <h2 className="font-display text-2xl md:text-3xl font-bold text-foreground tracking-tight mb-6 md:mb-8">
             Browse by Resort Brand
           </h2>
           <div className="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-6 gap-4">

--- a/src/pages/Developers.tsx
+++ b/src/pages/Developers.tsx
@@ -62,9 +62,9 @@ export default function Developers() {
     <div className="min-h-screen flex flex-col">
       <Header />
       <main className="flex-1 pt-16 md:pt-20">
-        <div className="max-w-screen-xl mx-auto px-4 py-8">
-          <div className="mb-6">
-            <h1 className="text-3xl font-bold text-gray-900">
+        <div className="max-w-screen-xl mx-auto px-4 py-8 md:py-10">
+          <div className="mb-6 md:mb-8">
+            <h1 className="font-display text-3xl md:text-4xl font-bold text-foreground tracking-tight">
               Developer API
             </h1>
             <p className="text-muted-foreground mt-2">

--- a/src/pages/Documentation.tsx
+++ b/src/pages/Documentation.tsx
@@ -166,7 +166,7 @@ const Documentation = () => {
     <div className="min-h-screen bg-background">
       <Header />
       {/* Page Header */}
-      <header className="sticky top-16 md:top-20 z-40 border-b bg-card/95 backdrop-blur supports-[backdrop-filter]:bg-card/60 print:hidden">
+      <header className="sticky top-16 md:top-20 z-40 border-b border-border/60 bg-card/95 backdrop-blur supports-[backdrop-filter]:bg-card/60 print:hidden">
         <div className="flex h-16 items-center px-4 md:px-6">
           <Button
             variant="ghost"
@@ -241,7 +241,7 @@ const Documentation = () => {
         </aside>
 
         {/* Main Content */}
-        <main className="flex-1 min-w-0 p-6 md:p-8 lg:p-12">
+        <main className="flex-1 min-w-0 p-5 md:p-8 lg:p-10">
           <div className="max-w-4xl mx-auto">
             
             {/* Print Cover Page */}

--- a/src/pages/ExecutiveDashboard.tsx
+++ b/src/pages/ExecutiveDashboard.tsx
@@ -43,12 +43,12 @@ const ExecutiveDashboard = () => {
       <div className="hidden lg:block pt-16 md:pt-20">
         <HeadlineBar />
 
-        <main className="container mx-auto px-6 py-8 space-y-0">
+        <main className="container mx-auto px-6 py-8 md:py-10 space-y-0">
           {/* Page header */}
-          <div className="flex items-center justify-between mb-8">
+          <div className="flex items-start justify-between mb-8 md:mb-10 gap-6">
             <div>
-              <h1 className="text-2xl font-bold text-white">RAV Insights</h1>
-              <p className="text-sm text-slate-400 mt-1 max-w-2xl">
+              <h1 className="font-display text-2xl md:text-3xl font-bold tracking-tight text-white">RAV Insights</h1>
+              <p className="text-sm text-slate-400 mt-2 max-w-2xl">
                 Boardroom-grade intelligence. Real-time marketplace performance, proprietary metrics like Liquidity Score and Bid Spread Index,
                 competitive benchmarking, and industry intelligence — all in one boardroom-ready view.
               </p>

--- a/src/pages/FAQ.tsx
+++ b/src/pages/FAQ.tsx
@@ -200,13 +200,13 @@ const FAQ = () => {
       <Header />
 
       {/* Hero */}
-      <section className="pt-32 pb-16 bg-gradient-warm">
+      <section className="pt-28 md:pt-32 pb-12 md:pb-16 bg-gradient-warm border-b border-border/60">
         <div className="container mx-auto px-4 text-center">
-          <h1 className="font-display text-4xl md:text-5xl font-bold text-foreground mb-6">
+          <h1 className="font-display text-4xl md:text-5xl font-bold text-foreground tracking-tight mb-4">
             Frequently Asked Questions
           </h1>
-          <p className="text-xl text-muted-foreground max-w-2xl mx-auto mb-8">
-            Find answers to common questions about renting and listing vacation properties
+          <p className="text-lg md:text-xl text-muted-foreground max-w-2xl mx-auto mb-8">
+            Find answers to common questions about renting and listing vacation properties.
           </p>
           <div className="max-w-md mx-auto relative">
             <Search className="absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 text-muted-foreground" />
@@ -221,7 +221,7 @@ const FAQ = () => {
       </section>
 
       {/* FAQ Content */}
-      <section className="py-16">
+      <section className="py-12 md:py-16">
         <div className="container mx-auto px-4">
           <div className="grid lg:grid-cols-4 gap-8">
             {/* Category Sidebar */}
@@ -295,10 +295,10 @@ const FAQ = () => {
       </section>
 
       {/* Contact CTA */}
-      <section className="py-16 bg-muted/50">
+      <section className="py-12 md:py-16 bg-muted/40 border-t border-border/60">
         <div className="container mx-auto px-4 text-center">
           <MessageSquare className="w-12 h-12 mx-auto text-primary mb-4" />
-          <h2 className="font-display text-2xl font-bold text-foreground mb-4">
+          <h2 className="font-display text-2xl md:text-3xl font-bold text-foreground tracking-tight mb-3">
             Still Have Questions?
           </h2>
           <p className="text-muted-foreground mb-6 max-w-md mx-auto">

--- a/src/pages/ForgotPassword.tsx
+++ b/src/pages/ForgotPassword.tsx
@@ -47,19 +47,19 @@ const ForgotPassword = () => {
     <div className="min-h-screen bg-background">
       <Header />
 
-      <main className="pt-32 pb-20">
+      <main className="pt-24 md:pt-28 pb-16 md:pb-20">
         <div className="container mx-auto px-4">
           <div className="max-w-md mx-auto">
-            <div className="text-center mb-8">
-              <h1 className="font-display text-3xl font-bold text-foreground mb-2">
+            <div className="text-center mb-6 md:mb-8">
+              <h1 className="font-display text-3xl md:text-4xl font-bold text-foreground tracking-tight mb-2">
                 Reset Your Password
               </h1>
               <p className="text-muted-foreground">
-                Enter your email and we'll send you a reset link
+                Enter your email and we'll send you a reset link.
               </p>
             </div>
 
-            <div className="bg-card rounded-2xl shadow-card-hover p-8">
+            <div className="bg-card rounded-2xl shadow-card-hover p-6 sm:p-8 border border-border/60">
               {isSubmitted ? (
                 <div className="text-center py-4">
                   <CheckCircle className="w-12 h-12 text-primary mx-auto mb-4" />

--- a/src/pages/HowItWorksPage.tsx
+++ b/src/pages/HowItWorksPage.tsx
@@ -198,12 +198,12 @@ const HowItWorksPage = () => {
       <Header />
 
       {/* Hero */}
-      <section className="pt-32 pb-16 bg-gradient-warm">
+      <section className="pt-28 md:pt-32 pb-12 md:pb-16 bg-gradient-warm border-b border-border/60">
         <div className="container mx-auto px-4 text-center">
-          <h1 className="font-display text-4xl md:text-5xl font-bold text-foreground mb-6">
+          <h1 className="font-display text-4xl md:text-5xl font-bold text-foreground tracking-tight mb-4">
             How Rent-A-Vacation Works
           </h1>
-          <p className="text-xl text-muted-foreground max-w-2xl mx-auto mb-6">
+          <p className="text-lg md:text-xl text-muted-foreground max-w-2xl mx-auto mb-6">
             Whether you're looking to book an amazing vacation or earn from your
             timeshare, we make it simple, secure, and rewarding.
           </p>
@@ -217,7 +217,7 @@ const HowItWorksPage = () => {
       </section>
 
       {/* For Renters */}
-      <section id="for-travelers" className="py-20">
+      <section id="for-travelers" className="py-14 md:py-20">
         <div className="container mx-auto px-4">
           <div className="text-center mb-12">
             <span className="inline-block px-4 py-2 bg-primary/10 text-primary rounded-full text-sm font-medium mb-4">
@@ -263,7 +263,7 @@ const HowItWorksPage = () => {
       </section>
 
       {/* For Owners */}
-      <section id="for-owners" className="py-20 bg-muted/50">
+      <section id="for-owners" className="py-14 md:py-20 bg-muted/40 border-t border-border/60">
         <div className="container mx-auto px-4">
           <div className="text-center mb-12">
             <span className="inline-block px-4 py-2 bg-accent/20 text-accent-foreground rounded-full text-sm font-medium mb-4">
@@ -309,7 +309,7 @@ const HowItWorksPage = () => {
       </section>
 
       {/* Pricing & Fees */}
-      <section id="pricing" className="py-20">
+      <section id="pricing" className="py-14 md:py-20 border-t border-border/60">
         <div className="container mx-auto px-4">
           <div className="text-center mb-12">
             <span className="inline-block px-4 py-2 bg-primary/10 text-primary rounded-full text-sm font-medium mb-4">

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -17,14 +17,14 @@ const WelcomeBanner = () => {
   const firstName = profile?.full_name?.split(" ")[0] || "there";
 
   return (
-    <div className="bg-card border-b border-border shadow-sm">
-      <div className="container mx-auto px-4 py-5">
-        <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-3">
-          <div>
-            <h2 className="text-lg font-bold text-foreground">
-              Welcome back, {firstName}!
+    <div className="bg-card border-b border-border/60">
+      <div className="container mx-auto px-4 py-3.5">
+        <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-2.5">
+          <div className="leading-tight">
+            <h2 className="text-base font-semibold text-foreground">
+              Welcome back, {firstName}
             </h2>
-            <p className="text-sm text-muted-foreground font-medium">
+            <p className="text-xs text-muted-foreground">
               Where to next? Pick up where you left off.
             </p>
           </div>

--- a/src/pages/ListProperty.tsx
+++ b/src/pages/ListProperty.tsx
@@ -356,12 +356,12 @@ const ListProperty = () => {
       <Header />
 
       {/* Hero */}
-      <section className="pt-32 pb-16 hero-gradient text-white">
+      <section className="pt-28 md:pt-32 pb-12 md:pb-16 hero-gradient text-white">
         <div className="container mx-auto px-4 text-center">
-          <h1 className="font-display text-4xl md:text-5xl font-bold mb-6">
+          <h1 className="font-display text-4xl md:text-5xl font-bold tracking-tight mb-4">
             Turn Your Timeshare Into Income
           </h1>
-          <p className="text-xl text-white/80 max-w-2xl mx-auto mb-8">
+          <p className="text-lg md:text-xl text-white/85 max-w-2xl mx-auto mb-8">
             List your vacation ownership for free. Rent out your unused weeks and
             offset your maintenance fees or earn extra income.
           </p>
@@ -379,9 +379,9 @@ const ListProperty = () => {
       </section>
 
       {/* Benefits */}
-      <section className="py-16 bg-muted/50">
+      <section className="py-12 md:py-14 bg-muted/40 border-b border-border/60">
         <div className="container mx-auto px-4">
-          <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-6">
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-4 md:gap-6">
             {benefits.map((benefit, index) => (
               <div key={index} className="bg-card rounded-xl p-6 shadow-card text-center">
                 <div className="w-14 h-14 rounded-full bg-primary/10 flex items-center justify-center mx-auto mb-4">
@@ -398,10 +398,10 @@ const ListProperty = () => {
       </section>
 
       {/* How It Works */}
-      <section className="py-20">
+      <section className="py-14 md:py-20">
         <div className="container mx-auto px-4">
-          <div className="text-center mb-12">
-            <h2 className="font-display text-3xl md:text-4xl font-bold text-foreground mb-4">
+          <div className="text-center mb-10 md:mb-12 max-w-2xl mx-auto">
+            <h2 className="font-display text-3xl md:text-4xl font-bold text-foreground tracking-tight mb-3">
               How to List Your Property
             </h2>
             <p className="text-muted-foreground text-lg">
@@ -444,11 +444,11 @@ const ListProperty = () => {
       </section>
 
       {/* Listing Form */}
-      <section id="listing-form" className="py-20 bg-muted/50">
+      <section id="listing-form" className="py-14 md:py-20 bg-muted/40 border-t border-border/60">
         <div className="container mx-auto px-4">
           <div className="max-w-2xl mx-auto">
             <div className="text-center mb-8">
-              <h2 className="font-display text-3xl font-bold text-foreground mb-4">
+              <h2 className="font-display text-3xl font-bold text-foreground tracking-tight mb-3">
                 Start Your Listing
               </h2>
               <p className="text-muted-foreground">
@@ -950,9 +950,9 @@ const ListProperty = () => {
       </section>
 
       {/* Testimonials */}
-      <section className="py-20">
+      <section className="py-14 md:py-20">
         <div className="container mx-auto px-4 text-center">
-          <h2 className="font-display text-3xl font-bold text-foreground mb-12">
+          <h2 className="font-display text-3xl md:text-4xl font-bold text-foreground tracking-tight mb-10 md:mb-12">
             What Owners Are Saying
           </h2>
           <div className="grid md:grid-cols-3 gap-8 max-w-4xl mx-auto">

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -103,19 +103,19 @@ const Login = () => {
     <div className="min-h-screen bg-background">
       <Header />
 
-      <main id="main-content" className="pt-32 pb-20">
+      <main id="main-content" className="pt-24 md:pt-28 pb-16 md:pb-20">
         <div className="container mx-auto px-4">
           <div className="max-w-md mx-auto">
-            <div className="text-center mb-8">
-              <h1 className="font-display text-3xl font-bold text-foreground mb-2">
+            <div className="text-center mb-6 md:mb-8">
+              <h1 className="font-display text-3xl md:text-4xl font-bold text-foreground tracking-tight mb-2">
                 Welcome Back
               </h1>
               <p className="text-muted-foreground">
-                Log in to access your bookings and saved properties
+                Log in to access your bookings and saved properties.
               </p>
             </div>
 
-            <div className="bg-card rounded-2xl shadow-card-hover p-4 sm:p-6 md:p-8">
+            <div className="bg-card rounded-2xl shadow-card-hover p-6 sm:p-8 border border-border/60">
               {/* Social Login */}
               <div className="space-y-3 mb-6">
                 <Button

--- a/src/pages/MaintenanceFeeCalculator.tsx
+++ b/src/pages/MaintenanceFeeCalculator.tsx
@@ -178,7 +178,7 @@ export default function MaintenanceFeeCalculator() {
       <Header />
 
       <main className="flex-1 pt-16 md:pt-20">
-        <div className="max-w-5xl mx-auto px-4 py-12">
+        <div className="max-w-5xl mx-auto px-4 py-10 md:py-12">
           {/* Breadcrumb */}
           <Link to="/tools" className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground mb-6">
             <ArrowLeft className="h-3 w-3" />
@@ -186,16 +186,16 @@ export default function MaintenanceFeeCalculator() {
           </Link>
 
           {/* Header */}
-          <div className="text-center mb-10">
-            <div className="inline-flex items-center gap-2 bg-blue-50 text-blue-700 px-4 py-1.5 rounded-full text-sm font-medium mb-4">
-              <Calculator className="h-4 w-4" />
+          <div className="text-center mb-8 md:mb-10 max-w-3xl mx-auto">
+            <div className="inline-flex items-center gap-2 bg-primary/10 text-primary px-3 py-1 rounded-full text-xs font-semibold uppercase tracking-wider mb-4">
+              <Calculator className="h-3.5 w-3.5" />
               RAV SmartEarn
             </div>
-            <h1 className="font-display text-3xl sm:text-4xl font-bold text-foreground mb-3">
+            <h1 className="font-display text-3xl sm:text-4xl font-bold text-foreground tracking-tight mb-3">
               Will renting your timeshare cover your maintenance fees?
             </h1>
-            <p className="text-muted-foreground text-lg max-w-2xl mx-auto">
-              Find out in 30 seconds — free, no account needed
+            <p className="text-muted-foreground text-lg">
+              Find out in 30 seconds — free, no account needed.
             </p>
           </div>
 

--- a/src/pages/Messages.tsx
+++ b/src/pages/Messages.tsx
@@ -30,15 +30,15 @@ export default function Messages() {
       <Header />
 
       <main id="main-content" className="flex-1 pt-16 md:pt-20">
-        <div className="container mx-auto px-4 py-6 max-w-7xl">
+        <div className="container mx-auto px-4 py-6 md:py-8 max-w-7xl">
           {/* Page heading */}
-          <div className="mb-4">
-            <h1 className="text-2xl font-bold flex items-center gap-2">
+          <div className="mb-5 md:mb-6">
+            <h1 className="font-display text-2xl md:text-3xl font-bold tracking-tight flex items-center gap-2">
               <MessageSquare className="h-6 w-6 text-primary" />
               Messages
             </h1>
-            <p className="text-sm text-muted-foreground mt-1">
-              Your conversations with owners and travelers
+            <p className="text-sm text-muted-foreground mt-1.5">
+              Your conversations with owners and travelers.
             </p>
           </div>
 

--- a/src/pages/MyBidsDashboard.tsx
+++ b/src/pages/MyBidsDashboard.tsx
@@ -91,9 +91,9 @@ const MyBidsDashboard = ({ embedded }: { embedded?: boolean }) => {
     <>
           {!embedded && (
             <>
-            <h1 className="font-display text-3xl font-bold mb-2">My Offers & Requests</h1>
-            <p className="text-muted-foreground mb-8">
-              Track your offers, travel requests, and proposals
+            <h1 className="font-display text-3xl md:text-4xl font-bold tracking-tight mb-2">My Offers & Requests</h1>
+            <p className="text-muted-foreground mb-8 md:mb-10">
+              Track your offers, travel requests, and proposals.
             </p>
             </>
           )}
@@ -404,7 +404,7 @@ const MyBidsDashboard = ({ embedded }: { embedded?: boolean }) => {
   return (
     <div className="min-h-screen bg-background">
       <Header />
-      <section className="pt-24 pb-12">
+      <section className="pt-20 md:pt-24 pb-12">
         <div className="container mx-auto px-4">
           {tabsContent}
         </div>

--- a/src/pages/MyBookings.tsx
+++ b/src/pages/MyBookings.tsx
@@ -434,9 +434,9 @@ const MyBookings = ({ embedded }: { embedded?: boolean }) => {
   const content = (
     <>
           {!embedded && (
-          <div className="mb-6">
-            <h1 className="text-3xl font-bold">My Bookings</h1>
-            <p className="text-muted-foreground mt-1">
+          <div className="mb-6 md:mb-8">
+            <h1 className="font-display text-3xl md:text-4xl font-bold tracking-tight">My Bookings</h1>
+            <p className="text-muted-foreground mt-2">
               View and manage your vacation reservations.
             </p>
           </div>

--- a/src/pages/Notifications.tsx
+++ b/src/pages/Notifications.tsx
@@ -155,12 +155,12 @@ const Notifications = () => {
     <div className="min-h-screen flex flex-col">
       <Header />
       <main id="main-content" className="flex-1 pt-16 md:pt-20">
-        <div className="container mx-auto px-4 py-8 max-w-5xl">
-          <div className="flex items-center justify-between mb-6">
+        <div className="container mx-auto px-4 py-8 md:py-10 max-w-5xl">
+          <div className="flex items-center justify-between mb-6 md:mb-8">
             <div>
-              <h1 className="text-2xl font-bold">Notifications</h1>
+              <h1 className="font-display text-3xl md:text-4xl font-bold tracking-tight">Notifications</h1>
               {unreadCount > 0 && (
-                <p className="text-sm text-muted-foreground mt-1">
+                <p className="text-sm text-muted-foreground mt-2">
                   {unreadCount} unread
                 </p>
               )}

--- a/src/pages/OwnerDashboard.tsx
+++ b/src/pages/OwnerDashboard.tsx
@@ -303,17 +303,17 @@ const OwnerDashboard = () => {
     <div className="min-h-screen bg-background">
       <Header />
       {/* Page Header */}
-      <header className="border-b bg-card mt-16 md:mt-20">
-        <div className="container mx-auto px-4 py-4">
+      <header className="border-b border-border/60 bg-card mt-16 md:mt-20">
+        <div className="container mx-auto px-4 py-5 md:py-6">
           <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
-            <div className="flex items-center gap-4">
+            <div className="flex items-center gap-3">
               <Button variant="ghost" size="icon" onClick={() => navigate("/")} className="flex-shrink-0">
                 <ArrowLeft className="h-5 w-5" />
               </Button>
               <div>
-                <h1 className="text-xl sm:text-2xl font-bold">My Rentals</h1>
+                <h1 className="font-display text-xl sm:text-2xl font-bold tracking-tight">My Rentals</h1>
                 <p className="text-sm text-muted-foreground">
-                  Your command center — manage listings, bookings, earnings, and more
+                  Manage listings, bookings, earnings, and more.
                 </p>
               </div>
             </div>
@@ -326,7 +326,7 @@ const OwnerDashboard = () => {
       </header>
 
       {/* Main Content */}
-      <main className="container mx-auto px-4 py-6">
+      <main className="container mx-auto px-4 py-6 md:py-8">
         <Tabs value={activeTab} onValueChange={setActiveTab}>
           <TabsList className="grid w-full grid-cols-4 h-auto">
             <TabsTrigger value="dashboard" className="gap-2">

--- a/src/pages/Privacy.tsx
+++ b/src/pages/Privacy.tsx
@@ -13,10 +13,10 @@ const Privacy = () => {
     <div className="min-h-screen bg-background">
       <Header />
 
-      <main className="pt-32 pb-20">
+      <main className="pt-24 md:pt-28 pb-16 md:pb-20">
         <div className="container mx-auto px-4">
           <div className="max-w-3xl mx-auto">
-            <h1 className="font-display text-4xl font-bold text-foreground mb-4">
+            <h1 className="font-display text-4xl md:text-5xl font-bold text-foreground tracking-tight mb-3">
               Privacy Policy
             </h1>
             <p className="text-muted-foreground mb-8">Last updated: February 2025</p>

--- a/src/pages/PropertyDetail.tsx
+++ b/src/pages/PropertyDetail.tsx
@@ -281,10 +281,10 @@ const PropertyDetail = () => {
     <div className="min-h-screen bg-background">
       <Header />
 
-      <main id="main-content" className="pt-20">
+      <main id="main-content" className="pt-16 md:pt-20">
         {/* Breadcrumb */}
-        <div className="container mx-auto px-4 py-4">
-          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+        <div className="container mx-auto px-4 py-3">
+          <div className="flex items-center gap-2 text-xs md:text-sm text-muted-foreground">
             <Link to="/" className="hover:text-foreground">Home</Link>
             <span>/</span>
             <Link to="/rentals" className="hover:text-foreground">Rentals</Link>
@@ -294,8 +294,8 @@ const PropertyDetail = () => {
         </div>
 
         {/* Image Gallery */}
-        <section className="container mx-auto px-4 mb-8">
-          <div className="relative rounded-2xl overflow-hidden">
+        <section className="container mx-auto px-4 mb-6 md:mb-8">
+          <div className="relative rounded-2xl overflow-hidden shadow-card">
             <div className="aspect-[16/9] md:aspect-[21/9]">
               {images.length > 0 ? (
                 <img
@@ -358,8 +358,8 @@ const PropertyDetail = () => {
         </section>
 
         {/* Content */}
-        <section className="container mx-auto px-4 pb-20">
-          <div className="grid lg:grid-cols-3 gap-8">
+        <section className="container mx-auto px-4 pb-16 md:pb-20">
+          <div className="grid lg:grid-cols-3 gap-8 lg:gap-10">
             {/* Main Content */}
             <div className="lg:col-span-2">
               {/* Header */}
@@ -368,7 +368,7 @@ const PropertyDetail = () => {
                   <MapPin className="w-4 h-4" />
                   {location} {brandLabel && `• ${brandLabel}`}
                 </div>
-                <h1 className="font-display text-3xl md:text-4xl font-bold text-foreground mb-3">
+                <h1 className="font-display text-3xl md:text-4xl font-bold text-foreground tracking-tight mb-3">
                   {displayName}
                 </h1>
                 {/* Social proof badges */}

--- a/src/pages/RavDeals.tsx
+++ b/src/pages/RavDeals.tsx
@@ -129,13 +129,13 @@ const RavDeals = () => {
       <Header />
 
       {/* Hero Section */}
-      <section id="main-content" className="pt-24 pb-8 bg-muted/50">
+      <section id="main-content" className="pt-20 md:pt-24 pb-6 md:pb-8 bg-muted/40 border-b border-border/60">
         <div className="container mx-auto px-4">
           <div className="max-w-2xl">
-            <h1 className="font-display text-3xl md:text-4xl font-bold text-foreground mb-3">
+            <h1 className="font-display text-3xl md:text-4xl font-bold text-foreground tracking-tight mb-2">
               RAV Deals
             </h1>
-            <p className="text-lg text-muted-foreground mb-2">
+            <p className="text-lg text-muted-foreground mb-1">
               Expiring Weeks. Motivated Owners. Your Best Price.
             </p>
             <p className="text-sm text-muted-foreground">

--- a/src/pages/RavTools.tsx
+++ b/src/pages/RavTools.tsx
@@ -116,16 +116,16 @@ const RavTools = () => {
       <Header />
 
       {/* Hero */}
-      <section className="pt-32 pb-16 bg-gradient-warm">
+      <section className="pt-28 md:pt-32 pb-12 md:pb-16 bg-gradient-warm border-b border-border/60">
         <div className="container mx-auto px-4 text-center">
-          <div className="inline-flex items-center gap-2 bg-primary/10 text-primary px-4 py-1.5 rounded-full text-sm font-medium mb-4">
-            <Wrench className="h-4 w-4" />
+          <div className="inline-flex items-center gap-2 bg-primary/10 text-primary px-3 py-1 rounded-full text-xs font-semibold uppercase tracking-wider mb-4">
+            <Wrench className="h-3.5 w-3.5" />
             RAV Tools
           </div>
-          <h1 className="font-display text-4xl md:text-5xl font-bold text-foreground mb-6">
+          <h1 className="font-display text-4xl md:text-5xl font-bold text-foreground tracking-tight mb-4">
             Free Tools for Smarter Vacations
           </h1>
-          <p className="text-xl text-muted-foreground max-w-2xl mx-auto">
+          <p className="text-lg md:text-xl text-muted-foreground max-w-2xl mx-auto">
             Whether you own a timeshare or you're planning your next getaway,
             these tools help you make better decisions — all free, no account required.
           </p>
@@ -133,9 +133,9 @@ const RavTools = () => {
       </section>
 
       {/* Tool Cards */}
-      <section className="py-16">
+      <section className="py-12 md:py-16">
         <div className="container mx-auto px-4">
-          <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
+          <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-5 md:gap-6">
             {TOOLS.map((tool) => {
               const Icon = tool.icon;
               const isBuilt = tool.status === 'built';
@@ -143,9 +143,9 @@ const RavTools = () => {
               return (
                 <div
                   key={tool.id}
-                  className={`bg-card rounded-xl shadow-card p-6 flex flex-col ${
+                  className={`bg-card rounded-xl shadow-card p-6 flex flex-col border border-border/60 ${
                     isBuilt
-                      ? 'hover:shadow-card-hover transition-shadow'
+                      ? 'hover:shadow-card-hover hover:-translate-y-0.5 transition-all'
                       : 'opacity-60'
                   }`}
                 >
@@ -185,9 +185,9 @@ const RavTools = () => {
       </section>
 
       {/* CTA */}
-      <section className="py-16 bg-muted/50">
+      <section className="py-12 md:py-16 bg-muted/40 border-t border-border/60">
         <div className="container mx-auto px-4 text-center">
-          <h2 className="font-display text-2xl font-bold text-foreground mb-4">
+          <h2 className="font-display text-2xl md:text-3xl font-bold text-foreground tracking-tight mb-3">
             Have a Tool Idea?
           </h2>
           <p className="text-muted-foreground mb-6 max-w-md mx-auto">

--- a/src/pages/Rentals.tsx
+++ b/src/pages/Rentals.tsx
@@ -300,14 +300,15 @@ const Rentals = () => {
       <Header />
 
       {/* Search Header */}
-      <section id="main-content" className="pt-24 pb-8 bg-muted/50">
+      <section id="main-content" className="pt-20 md:pt-24 pb-6 md:pb-8 bg-muted/40 border-b border-border/60">
         <div className="container mx-auto px-4">
-          <h1 className="font-display text-3xl md:text-4xl font-bold text-foreground mb-6">
+          <h1 className="font-display text-3xl md:text-4xl font-bold text-foreground tracking-tight mb-1">
             Browse Vacation Rentals
           </h1>
+          <p className="text-muted-foreground mb-5 md:mb-6">Find your next stay across 117 resorts.</p>
 
           {/* Search Bar */}
-          <div className="bg-card rounded-xl shadow-card p-4">
+          <div className="bg-card rounded-xl shadow-card p-4 border border-border/60">
             <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
               <div className="md:col-span-2 relative">
                 <MapPin className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-muted-foreground" />
@@ -408,7 +409,7 @@ const Rentals = () => {
       </section>
 
       {/* Unified Discovery Bar — Airbnb-style horizontal scroll */}
-      <section className="pt-4 pb-0 border-b border-border">
+      <section className="py-3 border-b border-border/60 bg-background">
         <div className="container mx-auto px-4">
           <div className="flex items-center gap-4">
             {/* Tab toggle */}
@@ -539,10 +540,10 @@ const Rentals = () => {
       })()}
 
       {/* Filters & Results */}
-      <section className="py-8">
+      <section className="py-6 md:py-8">
         <div className="container mx-auto px-4">
           {/* Toolbar */}
-          <div className="flex flex-wrap items-center justify-between gap-4 mb-6">
+          <div className="flex flex-wrap items-center justify-between gap-3 mb-6">
             <div className="flex items-center gap-2">
               <Button
                 variant="outline"

--- a/src/pages/RenterDashboard.tsx
+++ b/src/pages/RenterDashboard.tsx
@@ -108,13 +108,13 @@ const RenterDashboard = () => {
     <div className="min-h-screen bg-background">
       <Header />
 
-      <div className="pt-24 pb-12">
+      <div className="pt-20 md:pt-24 pb-12">
         <div className="container mx-auto px-4">
-          <div className="mb-8">
-            <h1 className="font-display text-3xl font-bold text-foreground">
+          <div className="mb-8 md:mb-10">
+            <h1 className="font-display text-3xl md:text-4xl font-bold text-foreground tracking-tight">
               My Trips
             </h1>
-            <p className="text-muted-foreground mt-1">
+            <p className="text-muted-foreground mt-2">
               Your bookings, offers, and saved properties in one place.
             </p>
           </div>

--- a/src/pages/ResetPassword.tsx
+++ b/src/pages/ResetPassword.tsx
@@ -58,19 +58,19 @@ const ResetPassword = () => {
     <div className="min-h-screen bg-background">
       <Header />
 
-      <main className="pt-32 pb-20">
+      <main className="pt-24 md:pt-28 pb-16 md:pb-20">
         <div className="container mx-auto px-4">
           <div className="max-w-md mx-auto">
-            <div className="text-center mb-8">
-              <h1 className="font-display text-3xl font-bold text-foreground mb-2">
+            <div className="text-center mb-6 md:mb-8">
+              <h1 className="font-display text-3xl md:text-4xl font-bold text-foreground tracking-tight mb-2">
                 Set New Password
               </h1>
               <p className="text-muted-foreground">
-                Choose a strong password for your account
+                Choose a strong password for your account.
               </p>
             </div>
 
-            <div className="bg-card rounded-2xl shadow-card-hover p-4 sm:p-6 md:p-8">
+            <div className="bg-card rounded-2xl shadow-card-hover p-6 sm:p-8 border border-border/60">
               <form onSubmit={handleSubmit} className="space-y-4">
                 <div>
                   <label className="block text-sm font-medium mb-2">New Password</label>

--- a/src/pages/ResortQuiz.tsx
+++ b/src/pages/ResortQuiz.tsx
@@ -121,12 +121,12 @@ export default function ResortQuiz() {
           </Link>
 
           {/* Header */}
-          <div className="text-center mb-8">
-            <div className="inline-flex items-center gap-2 bg-purple-50 text-purple-700 px-4 py-1.5 rounded-full text-sm font-medium mb-4">
-              <Compass className="h-4 w-4" />
+          <div className="text-center mb-8 md:mb-10">
+            <div className="inline-flex items-center gap-2 bg-primary/10 text-primary px-3 py-1 rounded-full text-xs font-semibold uppercase tracking-wider mb-4">
+              <Compass className="h-3.5 w-3.5" />
               RAV SmartMatch
             </div>
-            <h1 className="font-display text-3xl sm:text-4xl font-bold text-foreground mb-3">
+            <h1 className="font-display text-3xl sm:text-4xl font-bold text-foreground tracking-tight mb-3">
               {results ? 'Your Perfect Destinations' : 'Find Your Perfect Resort'}
             </h1>
             <p className="text-muted-foreground text-lg">

--- a/src/pages/Signup.tsx
+++ b/src/pages/Signup.tsx
@@ -133,19 +133,19 @@ const Signup = () => {
     <div className="min-h-screen bg-background">
       <Header />
 
-      <main id="main-content" className="pt-32 pb-20">
+      <main id="main-content" className="pt-24 md:pt-28 pb-16 md:pb-20">
         <div className="container mx-auto px-4">
           <div className="max-w-md mx-auto">
-            <div className="text-center mb-8">
-              <h1 className="font-display text-3xl font-bold text-foreground mb-2">
+            <div className="text-center mb-6 md:mb-8">
+              <h1 className="font-display text-3xl md:text-4xl font-bold text-foreground tracking-tight mb-2">
                 Create Your Account
               </h1>
               <p className="text-muted-foreground">
-                Join thousands of travelers and owners on Rent-A-Vacation
+                Join thousands of travelers and owners on Rent-A-Vacation.
               </p>
             </div>
 
-            <div className="bg-card rounded-2xl shadow-card-hover p-4 sm:p-6 md:p-8">
+            <div className="bg-card rounded-2xl shadow-card-hover p-6 sm:p-8 border border-border/60">
               {staffOnlyMode ? (
                 <div className="text-center py-8">
                   <Rocket className="w-12 h-12 mx-auto text-primary mb-4" />

--- a/src/pages/Terms.tsx
+++ b/src/pages/Terms.tsx
@@ -13,10 +13,10 @@ const Terms = () => {
     <div className="min-h-screen bg-background">
       <Header />
 
-      <main className="pt-32 pb-20">
+      <main className="pt-24 md:pt-28 pb-16 md:pb-20">
         <div className="container mx-auto px-4">
           <div className="max-w-3xl mx-auto">
-            <h1 className="font-display text-4xl font-bold text-foreground mb-4">
+            <h1 className="font-display text-4xl md:text-5xl font-bold text-foreground tracking-tight mb-3">
               Terms of Service
             </h1>
             <p className="text-muted-foreground mb-8">Last updated: February 2025</p>

--- a/src/pages/TravelerCheckin.tsx
+++ b/src/pages/TravelerCheckin.tsx
@@ -260,23 +260,23 @@ const TravelerCheckin = () => {
     <div className="min-h-screen bg-background">
       <Header />
       {/* Page Header */}
-      <header className="border-b bg-card mt-16 md:mt-20">
-        <div className="container mx-auto px-4 py-4">
-          <div className="flex items-center gap-4">
+      <header className="border-b border-border/60 bg-card mt-16 md:mt-20">
+        <div className="container mx-auto px-4 py-5 md:py-6">
+          <div className="flex items-center gap-3">
             <Button variant="ghost" size="icon" onClick={() => navigate("/")}>
               <ArrowLeft className="h-5 w-5" />
             </Button>
             <div>
-              <h1 className="text-2xl font-bold">Check-in Confirmation</h1>
+              <h1 className="font-display text-xl md:text-2xl font-bold tracking-tight">Check-in Confirmation</h1>
               <p className="text-sm text-muted-foreground">
-                Confirm your arrival within 24 hours of check-in
+                Confirm your arrival within 24 hours of check-in.
               </p>
             </div>
           </div>
         </div>
       </header>
 
-      <main className="container mx-auto px-4 py-6 max-w-3xl">
+      <main className="container mx-auto px-4 py-6 md:py-8 max-w-3xl">
         {/* Pending Checkins */}
         {pendingCheckins.length > 0 && (
           <div className="space-y-4 mb-8">

--- a/src/pages/UserGuide.tsx
+++ b/src/pages/UserGuide.tsx
@@ -122,7 +122,7 @@ const UserGuide = () => {
     <div className="min-h-screen bg-background">
       <Header />
       {/* Page Header */}
-      <header className="sticky top-16 md:top-20 z-40 border-b bg-card/95 backdrop-blur supports-[backdrop-filter]:bg-card/60 print:hidden">
+      <header className="sticky top-16 md:top-20 z-40 border-b border-border/60 bg-card/95 backdrop-blur supports-[backdrop-filter]:bg-card/60 print:hidden">
         <div className="flex h-16 items-center px-4 md:px-6">
           <Button
             variant="ghost"
@@ -226,7 +226,7 @@ const UserGuide = () => {
         </aside>
 
         {/* Main Content */}
-        <main className="flex-1 min-w-0 p-6 md:p-8 lg:p-12">
+        <main className="flex-1 min-w-0 p-5 md:p-8 lg:p-10">
           <div className="max-w-4xl mx-auto">
             
             {/* Print Cover Page */}


### PR DESCRIPTION
## Summary
Site-wide UI polish — 2 rounds, **27 pages** total. Tightens vertical rhythm, adds clear section borders, standardises heading scale across the entire app. No brand-color changes.

**Round 1 — primary pages (8):** Homepage, PropertyDetail, Rentals, BiddingMarketplace, OwnerDashboard, MyBookings, ListProperty (UserGuide reviewed).

**Round 2 — secondary pages (18):** Login, Signup, ForgotPassword, ResetPassword, RavTools, MaintenanceFeeCalculator, BudgetPlanner, CostComparator, ResortQuiz, Destinations, DestinationDetail, RavDeals, FAQ, AccountSettings, RenterDashboard, MyBidsDashboard, Notifications, Messages, Checkout, BookingSuccess, TravelerCheckin, Contact, Privacy, Terms, HowItWorksPage, Developers.

**Standardisations:**
- New `Section` + `SectionHeader` layout primitives (`src/components/layout/`)
- Hero `pt-28 md:pt-32`, body sections `py-12 md:py-16`, soft `border-border/60` separators
- All h1 / h2 use `font-display tracking-tight`
- Form/auth cards use `border border-border/60 shadow-card-hover`
- Off-brand badges (blue/indigo/purple/green) replaced with `bg-primary/10 text-primary`
- Tighter card padding, alternating bg between sections

## Test plan
- [x] `npm run build` — clean
- [x] `npm run test:p0` — 100 P0 tests passing
- [x] `npm run test` — 1046 tests, 0 failures
- [ ] Visual QA across all 27 pages

Closes #349

🤖 Generated with [Claude Code](https://claude.com/claude-code)