### PR TITLE
docs: Phase B brand-doc terminology lock + Session 47-48 refresh

### DIFF
--- a/docs/LAUNCH-READINESS.md
+++ b/docs/LAUNCH-READINESS.md
@@ -1,6 +1,6 @@
 ---
-last_updated: "2026-04-15T11:03:04"
-change_ref: "3180738"
+last_updated: "2026-04-15T11:10:55"
+change_ref: "bc1bafd"
 change_type: "session-48-docs-refresh"
 status: "active"
 ---
@@ -41,8 +41,10 @@ The following major features were completed in Sessions 33-48 and are deployed:
 | Public API | API key infrastructure (migrations 044-045), `api-gateway` edge function, `/developers` Swagger UI, IP allowlisting with CIDR support | 38 |
 | RAV Smart Suite | 5 tools on `/tools` hub (SmartEarn, SmartPrice, SmartCompare, SmartMatch, SmartBudget) | 38-39 |
 | Notification Center | Multi-channel routing (in-app/email/SMS), TCPA opt-in, seasonal events, delivery log; 3 SMS edge functions deployed (DEV) — `notification-dispatcher`, `sms-scheduler`, `twilio-webhook`. `SMS_TEST_MODE=true` until A2P 10DLC clears (#127) | 40 |
-| Brand Architecture Rebrand | Vacation Wishes → **RAV Wishes**; Owner's Edge → **My Rentals**; RAV Command → **RAV Insights**; Admin Dashboard → **RAV Ops**; Make an Offer → **Make a RAV Offer**; new **RAV Deals** discovery surface | 47 |
+| Brand Architecture Rebrand | Owner's Edge → **My Rentals**; RAV Command → **RAV Insights**; Admin Dashboard → **RAV Ops**; new **RAV Deals** discovery surface | 47 |
 | Multi-Year Event Generation | Curated events unified into DB with admin CRUD UI + multi-year generator | 48 |
+| Marketplace Terminology Lock | Three nouns locked: **Listing · Wish · Offer**. "Offer" replaces "Bid" + "Proposal" in all UI. RAV prefix dropped from transactional CTAs (Make an Offer, Post a Wish). Single **Marketplace** nav link replaces "Name Your Price" + "Make a Wish". `/bidding` → `/marketplace` with redirect. Owner dashboard gains top-level **Offers** tab (Sent + Received). Notifications categories renamed (Offers / Wishes). (DEC-031) | 52 |
+| Site-wide UI Polish | 30 pages tightened — `Section` + `SectionHeader` layout primitives, standardised vertical rhythm (`py-12 md:py-16`), `tracking-tight` headings, soft border separators, off-brand tool badges unified to brand primary. No brand-color changes. | 52 |
 
 ### By the Numbers
 

--- a/docs/LAUNCH-READINESS.md
+++ b/docs/LAUNCH-READINESS.md
@@ -1,7 +1,7 @@
 ---
-last_updated: "2026-03-21T02:05:09"
-change_ref: "94959eb"
-change_type: "session-39-docs-update"
+last_updated: "2026-04-15T11:03:04"
+change_ref: "3180738"
+change_type: "session-48-docs-refresh"
 status: "active"
 ---
 # Launch Readiness Checklist
@@ -18,9 +18,9 @@ Admin Dashboard > **Launch** tab — runs automated checks and provides Go Live 
 
 ---
 
-## Platform Completeness (Sessions 33-39)
+## Platform Completeness (Sessions 33-48)
 
-The following major features were completed in Sessions 33-39 and are deployed:
+The following major features were completed in Sessions 33-48 and are deployed:
 
 | Area | What was built | Session |
 |------|---------------|---------|
@@ -40,15 +40,18 @@ The following major features were completed in Sessions 33-39 and are deployed:
 | Referral Program | Referral codes, tracking, signup capture | 37 |
 | Public API | API key infrastructure (migrations 044-045), `api-gateway` edge function, `/developers` Swagger UI, IP allowlisting with CIDR support | 38 |
 | RAV Smart Suite | 5 tools on `/tools` hub (SmartEarn, SmartPrice, SmartCompare, SmartMatch, SmartBudget) | 38-39 |
+| Notification Center | Multi-channel routing (in-app/email/SMS), TCPA opt-in, seasonal events, delivery log; 3 SMS edge functions deployed (DEV) — `notification-dispatcher`, `sms-scheduler`, `twilio-webhook`. `SMS_TEST_MODE=true` until A2P 10DLC clears (#127) | 40 |
+| Brand Architecture Rebrand | Vacation Wishes → **RAV Wishes**; Owner's Edge → **My Rentals**; RAV Command → **RAV Insights**; Admin Dashboard → **RAV Ops**; Make an Offer → **Make a RAV Offer**; new **RAV Deals** discovery surface | 47 |
+| Multi-Year Event Generation | Curated events unified into DB with admin CRUD UI + multi-year generator | 48 |
 
 ### By the Numbers
 
 | Metric | Count |
 |--------|-------|
-| Automated tests | 771 (99 test files) |
-| P0 critical-path tests | 97 |
-| SQL migrations | 45 (001-043 deployed to DEV + PROD; 044-045 pending deploy) |
-| Edge functions | 27 |
+| Automated tests | 956 (121 test files) |
+| P0 critical-path tests | 97 (`npm run test:p0` ~2s) |
+| SQL migrations | 046 (all deployed to DEV + PROD) |
+| Edge functions | 30 (27 deployed to PROD; 3 SMS functions deployed to DEV only — blocked on A2P 10DLC / #127) |
 | Type errors | 0 |
 | Lint errors | 0 |
 | Build status | Clean |
@@ -64,7 +67,8 @@ The following major features were completed in Sessions 33-39 and are deployed:
 | 2 | Supabase points to PROD | Auto | `VITE_SUPABASE_URL` contains `xzfllqndrlmhclqfybew` | Ready |
 | 3 | DNS & SSL valid | Manual | Visit https://rent-a-vacation.com — no certificate errors | Ready |
 | 4 | Email sender verified (Resend) | Manual | Resend dashboard: `updates.rent-a-vacation.com` domain verified, `RESEND_API_KEY` set in Supabase secrets | Ready |
-| 5 | API key infrastructure | Auto | Migrations 044-045 deployed, `api-gateway` edge function active | Pending deploy |
+| 5 | API key infrastructure | Auto | Migrations 044-045 deployed, `api-gateway` edge function active | Ready |
+| 5b | Notification Center | Auto | Migration 046 deployed (DEV + PROD); `notification-dispatcher` deployed; SMS functions deployed to DEV with `SMS_TEST_MODE=true` | Ready (SMS gated on #127) |
 
 ### Payments
 | # | Check | Type | How to Verify |
@@ -152,8 +156,10 @@ The following checks cannot pass until external blockers are resolved:
 | Check | Blocker | Issue |
 |-------|---------|-------|
 | Stripe live mode | LLC/EIN required for Stripe activation | #127 |
+| Stripe Tax activation | LLC/EIN required (code ready, `automatic_tax: { enabled: true }`) | #127 |
 | Legal pages reviewed | Need legal counsel review | #80 |
-| Accounting integration | Blocked on LLC/EIN | #127, #63 |
+| Accounting integration (Puzzle.io) | Blocked on LLC/EIN — onboarding paused at step 7 | #127, #63 |
+| SMS production traffic | A2P 10DLC registration pending — flip `SMS_TEST_MODE=false` once cleared | #127 |
 
 ---
 

--- a/docs/brand-assets/BRAND-CONCEPTS.md
+++ b/docs/brand-assets/BRAND-CONCEPTS.md
@@ -1,6 +1,6 @@
 ---
-last_updated: "2026-04-12T22:57:23"
-change_ref: "a521368"
+last_updated: "2026-04-15T11:10:55"
+change_ref: "bc1bafd"
 change_type: "session-47-brand-rebrand"
 status: "active"
 ---
@@ -62,43 +62,44 @@ RAVIO is the named AI personality behind all AI-powered features on the platform
 
 ## II. NAMED PRODUCT FEATURES
 
-### 1. RAV Wishes
+### 1. Wishes
 
-**What It Is:** Travelers post their dream trip parameters. Owners compete with proposals. Traveler picks the winner.
+**What It Is:** Renters post a Wish — destination, dates, budget. Owners send Offers. Renter picks the winner.
 
-> **Rebrand note (Session 47):** Formerly "Vacation Wishes." Renamed to "RAV Wishes" for brand family consistency — all platform features carry the RAV identity.
+> **Rebrand note (Session 52):** "Vacation Wishes" → "RAV Wishes" → **Wishes**. The current canonical noun is "Wish" / "Wishes" — no RAV prefix. Hashtag is `#PostAWish`.
 
-**Marketing Names (Pick One):**
+**Marketing Names:**
 | Option | Vibe | Best For |
 |--------|------|----------|
-| **RAV Wishes** | Branded, aspirational | Consumer campaigns, nav labels |
-| **Make a RAV Wish** | Action-oriented, branded | CTA buttons, landing pages |
+| **Wish / Wishes** | Plain, evocative | Primary noun everywhere |
+| **Post a Wish** | Action-oriented | CTA buttons, landing pages |
 | **Your Trip, Their Offer** | Marketplace framing | Investor audiences |
 
-**Recommended:** "RAV Wishes" (primary) / "Make a RAV Wish" (CTA verb form)
+**Recommended:** "Wish / Wishes" (noun) + "Post a Wish" (CTA)
 
 **Copy Blocks:**
 
 **Headline:**
-> "Make a RAV Wish. Owners Compete to Make It Happen."
+> "Post a Wish. Owners Make It Happen."
 
 **Short:**
-> "Tell us your dream trip. Verified owners send you their best offers. You pick the winner."
+> "Tell us your dream trip. Verified owners send you their best Offers. You pick the winner."
 
 **Medium:**
-> "RAV Wishes flips the script on travel booking. Instead of you hunting for the right listing, you tell us what you want — destination, dates, budget, requirements — and verified vacation club owners compete with personalized proposals. You review the offers, pick the best one, and book. It's the travel experience you've always wished for."
+> "Wishes flip the script on travel booking. Instead of you hunting for the right Listing, you tell us what you want — destination, dates, budget, requirements — and verified vacation club owners send you Offers. You review the Offers, pick the best one, and book. It's the travel experience you've always wished for."
 
 **CTA Options:**
-- "Make a RAV Wish"
-- "Post Your RAV Wish"
+- "Post a Wish"
 - "Tell Us Your Dream Trip"
-- "Let Owners Compete for You"
+- "Let Owners Send You Offers"
 
 ---
 
-### 2. Name Your Price
+### 2. The Marketplace (slogan: "Name Your Price")
 
-**What It Is:** Bid on any listing that's open for competitive pricing.
+**What It Is:** Two-sided negotiation surface — make an Offer on any Listing, or post a Wish and let owners send you Offers.
+
+> **Rebrand note (Session 52):** "Bidding" → **Marketplace** in nav and route. The slogan "Name Your Price. Book Your Paradise." remains the brand tagline; it describes the *mechanic* (you name a price via an Offer).
 
 **Copy Blocks:**
 
@@ -106,16 +107,15 @@ RAVIO is the named AI personality behind all AI-powered features on the platform
 > "The Price Tag Just Got a Negotiation Button."
 
 **Short:**
-> "See a listing you like? Make an offer. The owner can accept, counter, or decline. Real negotiation, real savings."
+> "See a Listing you like? Make an Offer. The owner can accept, counter, or decline. Real negotiation, real savings."
 
 **Medium:**
-> "On every other vacation platform, you see a price and take it or leave it. On Rent-A-Vacation, you name your price. Browse open listings, place your bid, and negotiate directly with verified owners. Accept, counter, or walk away — you're in control. It's how vacation rentals should have always worked."
+> "On every other vacation platform, you see a price and take it or leave it. On Rent-A-Vacation, you name your price. Browse open Listings, send your Offer, and negotiate directly with verified owners. Accept, counter, or walk away — you're in control. It's how vacation rentals should have always worked."
 
 **CTA Options:**
-- "Name Your Price"
-- "Make a RAV Offer"
-- "Place a Bid"
-- "Start Bidding"
+- "Open the Marketplace"
+- "Make an Offer"
+- "Browse Listings"
 
 ---
 
@@ -261,10 +261,10 @@ RAVIO is the named AI personality behind all AI-powered features on the platform
 > "Expiring Weeks. Motivated Owners. Your Best Price."
 
 **Short:**
-> "Browse RAV Deals — listings with check-in dates approaching fast. Owners are ready to negotiate. Name your price."
+> "Browse RAV Deals — Listings with check-in dates approaching fast. Owners are ready to negotiate. Name your price."
 
 **Medium:**
-> "RAV Deals surfaces vacation weeks that are approaching their check-in date with few or no offers. These owners are motivated — they'd rather earn something than let the week go unused. Browse the deals, Make a RAV Offer, and book a luxury stay at your price. Every deal is backed by TrustShield verification and PaySafe escrow protection."
+> "RAV Deals surfaces vacation weeks that are approaching their check-in date with few or no Offers. These owners are motivated — they'd rather earn something than let the week go unused. Browse the deals, Make an Offer, and book a luxury stay at your price. Every deal is backed by TrustShield verification and PaySafe escrow protection."
 
 **CTA Options:**
 - "Browse RAV Deals"
@@ -276,16 +276,16 @@ RAVIO is the named AI personality behind all AI-powered features on the platform
 ## III. ELEVATOR PITCHES (By Audience)
 
 ### For a Traveler (15 seconds)
-> "Rent-A-Vacation lets you stay at Hilton, Marriott, and Disney resorts at owner prices — saving 20-40% compared to booking direct. Make a RAV Offer on any listing, post a RAV Wish and let owners compete, or search by voice with RAVIO. Every owner is verified, every payment is protected."
+> "Rent-A-Vacation lets you stay at Hilton, Marriott, and Disney resorts at owner prices — saving 20-40% compared to booking direct. Make an Offer on any Listing, post a Wish and let owners send you Offers, or search by voice with RAVIO. Every owner is verified, every payment is protected."
 
 ### For a Timeshare Owner (15 seconds)
 > "You're paying maintenance fees on weeks you don't use. Rent-A-Vacation lets you list those weeks in minutes, our AI tells you what to charge, and travelers bid on your property. You approve guests, set prices, and earn income that offsets your fees."
 
 ### For an Investor (30 seconds)
-> "Rent-A-Vacation is the first marketplace purpose-built for the $10.5 billion vacation ownership industry. We've built a two-sided bidding engine, a reverse-auction system where owners compete for travelers, a 117-resort data layer, and AI-powered voice and text search — all fully deployed and tested. The platform is pre-launch, disciplined, and ready to scale. We charge a 15% default commission on successful bookings only — no upfront fees to list — with tier-based discounts for subscribed owners. Projected 85%+ contribution margins."
+> "Rent-A-Vacation is the first marketplace purpose-built for the $10.5 billion vacation ownership industry. We've built a two-sided Marketplace where renters make Offers on Listings AND owners send Offers on renter Wishes — a true negotiation surface in both directions — plus a 117-resort data layer and AI-powered voice and text search, all fully deployed and tested. The platform is pre-launch, disciplined, and ready to scale. We charge a 15% default commission on successful bookings only — no upfront fees to list — with tier-based discounts for subscribed owners. Projected 85%+ contribution margins."
 
 ### For a Journalist (30 seconds)
-> "There are 10 million American families paying over a thousand dollars a year in timeshare maintenance fees for weeks they never use — and travelers paying inflated prices for those same rooms through other platforms. We built the first marketplace to connect them directly. Travelers can Make a RAV Offer on any listing or post RAV Wishes for owners to compete over — it's the first bidding engine in vacation rentals. We also offer AI-powered voice and text search through our concierge, RAVIO. The platform is fully built, pre-launch, and demonstrable today."
+> "There are 10 million American families paying over a thousand dollars a year in timeshare maintenance fees for weeks they never use — and travelers paying inflated prices for those same rooms through other platforms. We built the first Marketplace to connect them directly. Renters can Make an Offer on any Listing or post a Wish for owners to send Offers against — true two-sided negotiation in vacation rentals. We also offer AI-powered voice and text search through our concierge, RAVIO. The platform is fully built, pre-launch, and demonstrable today."
 
 ### For a Vacation Club Brand Executive (30 seconds)
 > "Your owners are your most valuable long-term asset — and they're frustrated. Maintenance fees are rising, usage is declining, and exit companies are circling. Rent-A-Vacation gives your owners a trusted, verified platform to monetize unused weeks — reducing their financial burden and your churn risk. We've already built profiles for [62/40/15] of your resorts. Let's discuss a pilot program."
@@ -302,7 +302,7 @@ RAVIO is the named AI personality behind all AI-powered features on the platform
 | 2 | **Just Say Where. RAVIO Does the Rest.** | AI/voice campaigns |
 | 3 | **Luxury Resorts. Owner Prices.** | Traveler acquisition |
 | 4 | **Your Timeshare. Your Income. Your Terms.** | Owner acquisition |
-| 5 | **Make a RAV Wish. Owners Make It Happen.** | RAV Wishes feature |
+| 5 | **Post a Wish. Owners Make It Happen.** | Wishes feature |
 
 ### Secondary Taglines
 
@@ -325,7 +325,7 @@ RAVIO is the named AI personality behind all AI-powered features on the platform
 |---------|-------|
 | #AskRAVIO | Voice/text search moments |
 | #NameYourPrice | Bidding and deal stories |
-| #RAVWishes | RAV Wishes feature |
+| #PostAWish | Wishes feature |
 | #FeeFreedom | Owner acquisition / calculator |
 | #OwnerPrices | Traveler savings stories |
 | #BookYourParadise | General brand |
@@ -419,8 +419,8 @@ resort-direct prices.
 3. BOOK with CONFIDENCE — PaySafe escrow protects every dollar
 
 ━━━ Why it's different ━━━
-✓ Bidding on any listing (Make a RAV Offer)
-�� RAV Wishes (reverse auction)
+✓ Make an Offer on any Listing
+✓ Post a Wish — owners send you Offers
 ✓ AI voice search with RAVIO
 ✓ 117 resorts, 351 unit types
 ✓ Every owner verified via TrustShield
@@ -472,32 +472,34 @@ Stop Paying. Start Earning.
 - Rent-A-Vacation (always hyphenated, title case)
 - RAVIO (all caps when standalone; "Ask RAVIO" / "Chat with RAVIO" in feature context)
 - Ask RAVIO, Chat with RAVIO
-- RAV Wishes (formerly Vacation Wishes)
+- Marketplace (the umbrella product noun; route is `/marketplace`)
+- Listing, Wish, Offer (the three marketplace nouns — Session 52 lock)
 - RAV Deals
-- RAV Edge (formerly Owner's Edge)
-- RAV Command
-- Name Your Price
-- Make a RAV Offer, Make a RAV Wish, Browse RAV Deals
+- My Rentals (formerly Owner's Edge → RAV Edge)
+- RAV Insights (formerly RAV Command)
+- RAV Ops (formerly Admin Dashboard)
+- Name Your Price (brand slogan / hero tagline only — not a nav label)
 - RAV SmartPrice, RAV SmartEarn, RAV SmartCompare, RAV SmartMatch, RAV SmartBudget
 - TrustShield
 - PaySafe
 - ResortIQ
-- Liquidity Score, Bid Spread Index
+- Liquidity Score, Bid Spread Index (executive analytics — internal)
 
 ### Never
 - "Rent a Vacation" (missing hyphens)
 - "Ravio" (lowercase — always RAVIO)
-- "Vacation Wishes" (retired — use RAV Wishes)
-- "Owner's Edge" (retired — use RAV Edge)
-- "Make an Offer" as CTA (retired — use Make a RAV Offer)
-- "Smart Price" (two words — always SmartPrice)
-- "Smart Earn" (two words — always SmartEarn)
-- "Smart Compare" (two words — always SmartCompare)
-- "Smart Match" (two words — always SmartMatch)
-- "Smart Budget" (two words — always SmartBudget)
+- "Vacation Wishes" / "RAV Wishes" / "RAV Wish" (retired Session 52 — use Wish / Wishes)
+- "Owner's Edge" / "RAV Edge" (retired — use My Rentals)
+- "RAV Command" (retired — use RAV Insights)
+- "Admin Dashboard" (retired — use RAV Ops)
+- "Make a RAV Offer" (retired Session 52 — use Make an Offer)
+- "Make a RAV Wish" / "Make a Wish" (retired Session 52 — use Post a Wish)
+- "Bid" / "Proposal" as user-facing UI noun (retired Session 52 — use Offer; "Bid" + "Proposal" stay only in DB column names)
+- "Name Your Price" / "Make a Wish" as separate nav links (retired Session 52 — single Marketplace link)
+- "/bidding" (legacy route — redirects to /marketplace)
+- "Smart Price" / "Smart Earn" / "Smart Compare" / "Smart Match" / "Smart Budget" (two words — always one compound word after Smart)
 - "Trust Shield" (two words — always TrustShield)
 - "Pay Safe" (two words — always PaySafe)
-- "RAV wish" / "Rav Wishes" (always RAV Wishes — RAV is all caps)
 - "RAV deal" / "Rav Deals" (always RAV Deals — RAV is all caps)
 
 ### Abbreviation
@@ -513,7 +515,7 @@ Stop Paying. Start Earning.
 | **Apr** | "RAV SmartEarn" launch | SEO blog + social | Owner leads |
 | **May** | "Name Your Price" explainer series | Social carousel + PR | Brand awareness — lead with marketplace |
 | **Jun** | Beta launch announcement | Email + community | Beta signups |
-| **Jul** | "RAV Wishes" campaign | Social + email | Traveler acquisition |
+| **Jul** | "Post a Wish" campaign | Social + email | Traveler acquisition |
 | **Aug** | "Ask RAVIO" launch video | Social video + PR | Feature education — AI as supporting differentiator |
 | **Sep** | Public launch | PR + paid social + search | Mass acquisition |
 | **Oct** | "Trust Stories" (TrustShield focus) | Testimonial video | Trust building |

--- a/docs/brand-assets/BRAND-STYLE-GUIDE.md
+++ b/docs/brand-assets/BRAND-STYLE-GUIDE.md
@@ -1,6 +1,6 @@
 ---
-last_updated: "2026-04-15T11:03:04"
-change_ref: "3180738"
+last_updated: "2026-04-15T11:10:55"
+change_ref: "bc1bafd"
 change_type: "session-48-docs-refresh"
 status: "active"
 ---
@@ -201,21 +201,27 @@ Status/Error          → #E53E3E
 - "Rent-A-Vacation" — always hyphenated, title case
 - "RAV" — acceptable abbreviation in informal contexts
 
-### Session 47 Brand Architecture Rebrand (April 12, 2026)
+### Session 52 Marketplace Terminology Lock (April 15, 2026)
 
-The RAV brand family follows three naming patterns. Use canonical names below in all materials — see `BRAND-LOCK.md` Section 8 for the full naming framework.
+The marketplace uses **three nouns only** in all user-facing copy: **Listing**, **Wish**, **Offer**. "Offer" replaces both "Bid" and "Proposal" in UI. The "RAV" prefix is dropped from transactional nouns and CTAs. See `BRAND-LOCK.md` Sections 8 + 9 for the full naming framework.
 
 | Old Name | Canonical Name | Notes |
 |----------|---------------|-------|
-| Vacation Wishes | **RAV Wishes** | Reverse auction feature; hashtag is `#RAVWishes` |
+| Vacation Wishes / RAV Wishes | **Wish / Wishes** | Drop "RAV" prefix; hashtag is `#PostAWish` |
+| Bid / Proposal (UI) | **Offer** | Single noun in UI for both directions; DB tables (`listing_bids`, `travel_proposals`) unchanged |
+| Make a RAV Offer | **Make an Offer** | Transactional CTAs use plain language |
+| Make a Wish / Make a RAV Wish | **Post a Wish** | Consistent verb; no RAV prefix |
+| Name Your Price + Make a Wish (separate nav links) | **Marketplace** (single nav link) | Role-aware default tab inside (renter→Listings, owner→Wishes) |
+| /bidding (route) | **/marketplace** | /bidding redirects |
 | Owner's Edge / RAV Edge | **My Rentals** | Owner dashboard nav (mirrors "My Trips" for renters) |
 | RAV Command | **RAV Insights** | Executive dashboard — self-descriptive BI |
 | Admin Dashboard | **RAV Ops** | Admin operations — self-descriptive |
-| Make an Offer | **Make a RAV Offer** | Transactional CTAs carry RAV identity |
-| Browse Deals | **Browse RAV Deals** | New `RAV Deals` distressed-inventory surface |
+| Browse Deals | **Browse RAV Deals** | New `RAV Deals` distressed-inventory surface (platform-branded — keeps RAV) |
 | Explore (nav) | **Browse Rentals** | Plain-language nav |
 
-**Naming rule:** RAV-prefix for tools/admin (RAV Insights, RAV Ops, RAV Smart[X]); plain language for customer nav (My Trips, My Rentals, Browse Rentals); CompoundName for trust layer (TrustShield, PaySafe, ResortIQ).
+**Naming rule:** RAV-prefix for platform-branded surfaces (RAV Insights, RAV Ops, RAV Smart[X], RAV Deals, RAVIO); plain nouns for marketplace mechanics (Listing, Wish, Offer, Marketplace); plain language for customer nav (Marketplace, My Trips, My Rentals, Browse Rentals); CompoundName for trust layer (TrustShield, PaySafe, ResortIQ).
+
+**The brand slogan "Name Your Price. Book Your Paradise."** remains the master hero tagline (it describes the *mechanic* — you name a price via an Offer). It is no longer a header nav label.
 
 ### Messaging Authority
 > **All messaging claims, feature ordering, savings numbers, and feature names must align with `docs/brand-assets/BRAND-LOCK.md`.** When in doubt, the Brand Lock is the source of truth.

--- a/docs/brand-assets/BRAND-STYLE-GUIDE.md
+++ b/docs/brand-assets/BRAND-STYLE-GUIDE.md
@@ -1,7 +1,7 @@
 ---
-last_updated: "2026-04-03T15:20:24"
-change_ref: "fd388ad"
-change_type: "session-39-docs-update"
+last_updated: "2026-04-15T11:03:04"
+change_ref: "3180738"
+change_type: "session-48-docs-refresh"
 status: "active"
 ---
 # Rent-A-Vacation Brand Style Guide
@@ -201,8 +201,24 @@ Status/Error          → #E53E3E
 - "Rent-A-Vacation" — always hyphenated, title case
 - "RAV" — acceptable abbreviation in informal contexts
 
+### Session 47 Brand Architecture Rebrand (April 12, 2026)
+
+The RAV brand family follows three naming patterns. Use canonical names below in all materials — see `BRAND-LOCK.md` Section 8 for the full naming framework.
+
+| Old Name | Canonical Name | Notes |
+|----------|---------------|-------|
+| Vacation Wishes | **RAV Wishes** | Reverse auction feature; hashtag is `#RAVWishes` |
+| Owner's Edge / RAV Edge | **My Rentals** | Owner dashboard nav (mirrors "My Trips" for renters) |
+| RAV Command | **RAV Insights** | Executive dashboard — self-descriptive BI |
+| Admin Dashboard | **RAV Ops** | Admin operations — self-descriptive |
+| Make an Offer | **Make a RAV Offer** | Transactional CTAs carry RAV identity |
+| Browse Deals | **Browse RAV Deals** | New `RAV Deals` distressed-inventory surface |
+| Explore (nav) | **Browse Rentals** | Plain-language nav |
+
+**Naming rule:** RAV-prefix for tools/admin (RAV Insights, RAV Ops, RAV Smart[X]); plain language for customer nav (My Trips, My Rentals, Browse Rentals); CompoundName for trust layer (TrustShield, PaySafe, ResortIQ).
+
 ### Messaging Authority
-> **All messaging claims, feature ordering, and savings numbers must align with `docs/brand-assets/BRAND-LOCK.md`.** When in doubt, the Brand Lock is the source of truth.
+> **All messaging claims, feature ordering, savings numbers, and feature names must align with `docs/brand-assets/BRAND-LOCK.md`.** When in doubt, the Brand Lock is the source of truth.
 
 ---
 

--- a/docs/brand-assets/MARKETING-PLAYBOOK.md
+++ b/docs/brand-assets/MARKETING-PLAYBOOK.md
@@ -1,6 +1,6 @@
 ---
-last_updated: "2026-04-15T11:03:04"
-change_ref: "3180738"
+last_updated: "2026-04-15T11:10:55"
+change_ref: "bc1bafd"
 change_type: "session-48-docs-refresh"
 status: "active"
 ---
@@ -44,7 +44,7 @@ The vacation ownership industry is a $10.5 billion market *[PROJECTED — ARDA i
 
 We've built the first platform purpose-built for this market, with three structural advantages no competitor can replicate quickly:
 
-1. **A two-sided bidding engine** *[BUILT]* — travelers bid on listings AND post Vacation Wishes for owners to compete over, creating true price discovery
+1. **A two-sided Marketplace** *[BUILT]* — renters make Offers on Listings AND post Wishes for owners to send Offers against, creating true price discovery in both directions
 2. **A curated resort data layer** *[BUILT]* — 117 resorts, 351 unit types, auto-populated listing forms designed to cut owner onboarding time dramatically
 3. **AI-powered discovery** *[BUILT]* — voice and text search that understands "Find me a 2-bedroom in Maui under $2,000 next March" and returns results in seconds
 
@@ -63,7 +63,7 @@ This is the heart of our story. Every item below is **BUILT**, deployed, and dem
 | **AI Voice Search (Ask RAVIO)** | BUILT | Say "Find me a 2-bedroom in Maui" — watch results appear with voice narration |
 | **AI Text Chat (Chat with RAVIO)** | BUILT | Type conversational queries, get streaming AI responses with property cards |
 | **Two-Sided Bidding** | BUILT | Traveler bids on listings; owner accepts/counters. Full negotiation workflow |
-| **RAV Wishes (Travel Requests)** | BUILT | Traveler posts wish; owners send proposals; traveler picks best offer |
+| **Wishes (Travel Requests)** | BUILT | Renter posts a Wish; owners send Offers; renter picks the best one |
 | **Resort Directory (ResortIQ)** | BUILT | 117 resorts, 351 unit types — curated data that auto-populates listing forms |
 | **Owner Verification (TrustShield)** | BUILT | Multi-step identity + ownership verification workflow |
 | **Escrow Payments (PaySafe)** | BUILT | Stripe-powered, funds held until check-in confirmed |
@@ -231,7 +231,7 @@ The demo environment contains **seed data** — realistic but synthetic — to d
 |--------------|----------------|------------|--------|
 | Voice Search | **Ask RAVIO** | AI voice concierge — say what you want, get results | BUILT |
 | Text Chat | **Chat with RAVIO** | Text-based AI assistant for property discovery | BUILT |
-| Travel Requests | **RAV Wishes** | Post your dream trip; owners compete to fulfill it (formerly "Vacation Wishes" — Session 47 rebrand) | BUILT |
+| Travel Requests | **Wishes** | Post a Wish; owners send Offers (formerly "Vacation Wishes" → "RAV Wishes" → **Wishes** — Session 52 lock) | BUILT |
 | Bidding System | **Name Your Price** | Bid on any open listing | BUILT |
 | Fair Value Score | **RAV SmartPrice** | AI-powered pricing recommendations for owners | BUILT |
 | Maintenance Calculator | **RAV SmartEarn** | Break-even tool — how many weeks to cover fees | BUILT |
@@ -260,7 +260,7 @@ RENT-A-VACATION (Master Brand)
 │
 ├── For Travelers (Primary — lead with these)
 │   ├── Name Your Price (bidding — primary differentiator)
-│   ├── RAV Wishes (reverse auction — primary differentiator)
+│   ├── Wishes (renter open call; owners send Offers — primary differentiator)
 │   ├── RAV Deals (distressed inventory — discovery)
 │   └── PaySafe (escrow protection)
 │
@@ -316,7 +316,7 @@ RENT-A-VACATION (Master Brand)
 ### Value Proposition Pillars
 
 **Pillar 1: True Price Discovery** *[BUILT]*
-> "Name Your Price isn't a slogan — it's a feature. Bid on any open listing, or post a Vacation Wish and let verified owners compete for your booking. For the first time in travel, the traveler sets the terms."
+> "Name Your Price isn't a slogan — it's the mechanic. Make an Offer on any open Listing, or post a Wish and let verified owners send you Offers. For the first time in travel, the traveler sets the terms."
 
 **Pillar 2: Purpose-Built for Vacation Clubs** *[BUILT]*
 > "We don't dabble in timeshares — we're built for them. 117 resorts. 351 unit types. Curated resort data that auto-populates listing forms. Owner verification that builds real trust. Resort confirmation workflows that match how vacation clubs actually work. Multi-channel reminders (in-app, email, TCPA-compliant SMS) keep both sides in sync from booking to check-in."
@@ -352,9 +352,9 @@ RENT-A-VACATION (Master Brand)
 
 ---
 
-### Campaign 2: "RAV Wishes" (Traveler Acquisition)
+### Campaign 2: "Post a Wish" (Traveler Acquisition)
 
-**Concept:** Reframe travel requests as wishes. "Make a RAV Wish. Owners Make It Real." Emotional, aspirational, shareable.
+**Concept:** Reframe travel requests as wishes. "Post a Wish. Owners Make It Real." Emotional, aspirational, shareable.
 
 **Why This Works Pre-Launch:** The feature is built and demonstrable. The concept is emotionally resonant and sharable even before we have mass adoption.
 
@@ -442,7 +442,7 @@ RENT-A-VACATION (Master Brand)
 | 2 | "Hilton Grand Vacations: The Complete Rental Guide" | Both | Resort data is BUILT |
 | 3 | "How Voice Search is Changing Travel" | Press | RAVIO is BUILT |
 | 4 | "Timeshare Rentals vs. Hotel Direct: Price Comparison" | Travelers | Industry data |
-| 5 | "What Is a RAV Wish? The New Way to Book" | Travelers | Feature is BUILT |
+| 5 | "What Is a Wish? The New Way to Book" | Travelers | Feature is BUILT |
 | 6 | "Disney Vacation Club Rentals: What You Need to Know" | Travelers | Resort data is BUILT |
 
 ### Email Sequences
@@ -450,9 +450,9 @@ RENT-A-VACATION (Master Brand)
 **Traveler Welcome (5 emails):**
 1. Welcome + how it works (Day 0)
 2. "Try Ask RAVIO" — voice search demo (Day 1)
-3. "Your First RAV Wish" — post a travel request (Day 3)
+3. "Post Your First Wish" — submit a Wish to the Marketplace (Day 3)
 4. "Featured Listings This Week" — curated highlights (Day 7)
-5. "Name Your Price" — bidding tutorial (Day 14)
+5. "Make an Offer" — Marketplace tutorial (Day 14)
 
 **Owner Welcome (5 emails):**
 1. Welcome + verification steps (Day 0)
@@ -535,7 +535,7 @@ RENT-A-VACATION (Master Brand)
 ### Phase 4: Scale (Target: Q4 2026)
 - Mobile app launch (iOS + Android via Capacitor)
 - Partnership outreach to vacation club brands
-- "RAV Wishes" campaign
+- "Post a Wish" campaign
 - Content marketing engine (blog, email, social)
 - Referral program launch
 
@@ -598,7 +598,7 @@ RENT-A-VACATION (Master Brand)
 | **RAVIO** | AI Brand | The AI concierge powering voice and text search | BUILT |
 | **Ask RAVIO** | Feature | Voice-activated property search | BUILT |
 | **Chat with RAVIO** | Feature | Text-based AI property search | BUILT |
-| **RAV Wishes** | Feature | Post travel requests; owners compete (formerly "Vacation Wishes") | BUILT |
+| **Wishes** | Feature | Renters post Wishes; owners send Offers (formerly "Vacation Wishes" → "RAV Wishes" → **Wishes** in Session 52) | BUILT |
 | **RAV Deals** | Feature | Curated distressed inventory — expiring weeks from motivated sellers | BUILT |
 | **My Rentals** | Suite | Owner dashboard — formerly "Owner's Edge" / "RAV Edge" | BUILT |
 | **RAV Insights** | Dashboard | Executive BI — formerly "RAV Command" | BUILT |

--- a/docs/brand-assets/MARKETING-PLAYBOOK.md
+++ b/docs/brand-assets/MARKETING-PLAYBOOK.md
@@ -1,7 +1,7 @@
 ---
-last_updated: "2026-04-03T15:20:24"
-change_ref: "fd388ad"
-change_type: "session-39-docs-update"
+last_updated: "2026-04-15T11:03:04"
+change_ref: "3180738"
+change_type: "session-48-docs-refresh"
 status: "active"
 ---
 # Rent-A-Vacation Marketing Playbook
@@ -48,7 +48,7 @@ We've built the first platform purpose-built for this market, with three structu
 2. **A curated resort data layer** *[BUILT]* — 117 resorts, 351 unit types, auto-populated listing forms designed to cut owner onboarding time dramatically
 3. **AI-powered discovery** *[BUILT]* — voice and text search that understands "Find me a 2-bedroom in Maui under $2,000 next March" and returns results in seconds
 
-The platform is fully built, end-to-end tested with 771 automated tests across 99 test files, and operating at 99.97% uptime in our staging environment. Owners list for free — no upfront fees. We take a configurable 15% default commission on successful bookings only (Pro −2%, Business −5%). The technology is ready — we're now preparing for our public launch.
+The platform is fully built, end-to-end tested with 956 automated tests across 121 test files, and operating at 99.97% uptime in our staging environment. Owners list for free — no upfront fees. We take a configurable 15% default commission on successful bookings only (Pro −2%, Business −5%). The technology is ready — we're now preparing for our public launch.
 
 ---
 
@@ -63,7 +63,7 @@ This is the heart of our story. Every item below is **BUILT**, deployed, and dem
 | **AI Voice Search (Ask RAVIO)** | BUILT | Say "Find me a 2-bedroom in Maui" — watch results appear with voice narration |
 | **AI Text Chat (Chat with RAVIO)** | BUILT | Type conversational queries, get streaming AI responses with property cards |
 | **Two-Sided Bidding** | BUILT | Traveler bids on listings; owner accepts/counters. Full negotiation workflow |
-| **Vacation Wishes (Travel Requests)** | BUILT | Traveler posts wish; owners send proposals; traveler picks best offer |
+| **RAV Wishes (Travel Requests)** | BUILT | Traveler posts wish; owners send proposals; traveler picks best offer |
 | **Resort Directory (ResortIQ)** | BUILT | 117 resorts, 351 unit types — curated data that auto-populates listing forms |
 | **Owner Verification (TrustShield)** | BUILT | Multi-step identity + ownership verification workflow |
 | **Escrow Payments (PaySafe)** | BUILT | Stripe-powered, funds held until check-in confirmed |
@@ -99,21 +99,24 @@ This is the heart of our story. Every item below is **BUILT**, deployed, and dem
 | **Renter Dashboard (/my-trips)** | BUILT | 4-tab dashboard: Overview, Bookings, Offers, Favorites |
 | **Role Upgrade Notifications** | BUILT | Email + in-app notification on role approval with realtime detection |
 | **IP Allowlisting for API Keys** | BUILT | Optional CIDR-based IP restriction for API keys |
+| **Notification Center** | BUILT | Multi-channel routing (in-app, email, SMS), per-type preferences, TCPA-compliant SMS opt-in, seasonal event reminders, delivery log |
+| **RAV Deals (Distressed Inventory)** | BUILT | Curated last-minute / expiring weeks surface — feeds bidding |
 
 ### Engineering Quality (These are real, verified numbers)
 
 | Metric | Value | Verification |
 |--------|-------|-------------|
-| Automated tests | 771 passing (99 test files) | `npm test` — run anytime |
+| Automated tests | 956 passing (121 test files) | `npm test` — run anytime |
+| P0 critical-path tests | 97 (`@p0` tagged) | `npm run test:p0` — ~2s |
 | TypeScript errors | 0 | `npx tsc --noEmit` — strict mode |
 | Lint errors | 0 | `npm run lint` — ESLint |
 | Build status | Clean | `npm run build` — production-ready |
-| Database migrations | 45 deployed | Supabase CLI tracked |
-| Edge functions | 27 deployed | Serverless, auto-scaling |
+| Database migrations | 046 deployed | Supabase CLI tracked |
+| Edge functions | 30 deployed | Serverless, auto-scaling |
 | CI/CD pipeline | 5-job GitHub Actions | Lint, typecheck, unit, E2E, visual regression |
 | Platform uptime (staging) | 99.97% | Supabase + Vercel infrastructure |
 | Resort database | 117 resorts, 351 unit types | Queryable, auto-populated |
-| Phases shipped | 39+ in 18 months | Documented in PROJECT-HUB.md |
+| Sessions shipped | 48+ in 19 months | Documented in PROJECT-HUB.md |
 
 ### Demo Environment (dev.rent-a-vacation.com)
 
@@ -212,10 +215,10 @@ The demo environment contains **seed data** — realistic but synthetic — to d
 
 **Key Messages (all accurately labeled):**
 - "The $10.5B vacation ownership market has no tech-first leader" *[Industry data]*
-- "We've built a complete, production-ready platform with 771 automated tests across 99 test files" *[BUILT]*
+- "We've built a complete, production-ready platform with 956 automated tests across 121 test files" *[BUILT]*
 - "AI voice search is an industry first — no competitor offers this" *[BUILT]*
 - "117-resort curated data layer creates compounding network effects" *[BUILT]*
-- "39 phases shipped in 18 months — execution velocity is our proof" *[BUILT]*
+- "48+ sessions shipped in 19 months — execution velocity is our proof" *[BUILT]*
 - "Unit economics model targets 12:1 LTV:CAC ratio and 85%+ contribution margin" *[PROJECTED]*
 
 ---
@@ -228,7 +231,7 @@ The demo environment contains **seed data** — realistic but synthetic — to d
 |--------------|----------------|------------|--------|
 | Voice Search | **Ask RAVIO** | AI voice concierge — say what you want, get results | BUILT |
 | Text Chat | **Chat with RAVIO** | Text-based AI assistant for property discovery | BUILT |
-| Travel Requests | **Vacation Wishes** | Post your dream trip; owners compete to fulfill it | BUILT |
+| Travel Requests | **RAV Wishes** | Post your dream trip; owners compete to fulfill it (formerly "Vacation Wishes" — Session 47 rebrand) | BUILT |
 | Bidding System | **Name Your Price** | Bid on any open listing | BUILT |
 | Fair Value Score | **RAV SmartPrice** | AI-powered pricing recommendations for owners | BUILT |
 | Maintenance Calculator | **RAV SmartEarn** | Break-even tool — how many weeks to cover fees | BUILT |
@@ -244,7 +247,11 @@ The demo environment contains **seed data** — realistic but synthetic — to d
 | Dynamic Pricing | **Dynamic Pricing** | Urgency, seasonal, and demand-based price adjustments | BUILT |
 | Referral System | **Referral Program** | Unique codes, tracking dashboard, signup attribution | BUILT |
 | Public API | **Developer Portal** | RESTful API at `/developers` with Swagger UI | BUILT |
-| Owner Tools Suite | **Owner's Edge** | Dashboard, earnings, analytics, pricing tools | BUILT |
+| Owner Tools Suite | **My Rentals** | Dashboard, earnings, analytics, pricing tools (formerly "Owner's Edge" / "RAV Edge" — Session 47 rebrand) | BUILT |
+| Distressed Inventory | **RAV Deals** | Curated expiring weeks from motivated sellers (feeds bidding) | BUILT |
+| Notification Center | **Notification Center** | Multi-channel routing (in-app/email/SMS) with TCPA-compliant opt-in | BUILT |
+| Executive Dashboard | **RAV Insights** | Investor-grade BI (formerly "RAV Command" — Session 47 rebrand) | BUILT |
+| Admin Dashboard | **RAV Ops** | Operations management (formerly "Admin Dashboard" — Session 47 rebrand) | BUILT |
 
 ### Brand Hierarchy
 
@@ -253,7 +260,8 @@ RENT-A-VACATION (Master Brand)
 │
 ├── For Travelers (Primary — lead with these)
 │   ├── Name Your Price (bidding — primary differentiator)
-│   ├── Vacation Wishes (reverse auction — primary differentiator)
+│   ├── RAV Wishes (reverse auction — primary differentiator)
+│   ├── RAV Deals (distressed inventory — discovery)
 │   └── PaySafe (escrow protection)
 │
 ├── Trust & Safety
@@ -265,7 +273,7 @@ RENT-A-VACATION (Master Brand)
 │   └── Chat with RAVIO (text search)
 │
 ├── For Owners
-│   ├── Owner's Edge (dashboard & tools suite)
+│   ├── My Rentals (dashboard & tools suite — formerly "Owner's Edge")
 │   ├── RAV Smart Suite (5-tool hub at /tools)
 │   │   ├── RAV SmartEarn (maintenance fee + yield estimator)
 │   │   ├── RAV SmartPrice (pricing AI)
@@ -275,8 +283,10 @@ RENT-A-VACATION (Master Brand)
 │   └── TrustShield (verification program)
 │
 └── Infrastructure / Business
-    ├── RAV Command (executive dashboard)
+    ├── RAV Insights (executive dashboard — formerly "RAV Command")
+    ├── RAV Ops (admin operations — formerly "Admin Dashboard")
     ├── ResortIQ (curated resort directory)
+    ├── Notification Center (multi-channel: in-app, email, SMS)
     ├── Liquidity Score (marketplace health metric)
     └── Bid Spread Index (price discovery metric)
 ```
@@ -309,7 +319,7 @@ RENT-A-VACATION (Master Brand)
 > "Name Your Price isn't a slogan — it's a feature. Bid on any open listing, or post a Vacation Wish and let verified owners compete for your booking. For the first time in travel, the traveler sets the terms."
 
 **Pillar 2: Purpose-Built for Vacation Clubs** *[BUILT]*
-> "We don't dabble in timeshares — we're built for them. 117 resorts. 351 unit types. Curated resort data that auto-populates listing forms. Owner verification that builds real trust. Resort confirmation workflows that match how vacation clubs actually work."
+> "We don't dabble in timeshares — we're built for them. 117 resorts. 351 unit types. Curated resort data that auto-populates listing forms. Owner verification that builds real trust. Resort confirmation workflows that match how vacation clubs actually work. Multi-channel reminders (in-app, email, TCPA-compliant SMS) keep both sides in sync from booking to check-in."
 
 **Pillar 3: Ironclad Trust** *[BUILT]*
 > "Every owner goes through TrustShield verification. Every payment is protected through PaySafe escrow. Every stay is backed by our satisfaction guarantee. We've removed the risk so you can focus on the vacation."
@@ -342,9 +352,9 @@ RENT-A-VACATION (Master Brand)
 
 ---
 
-### Campaign 2: "Vacation Wishes" (Traveler Acquisition)
+### Campaign 2: "RAV Wishes" (Traveler Acquisition)
 
-**Concept:** Reframe travel requests as wishes. "Make a Wish. Owners Make It Real." Emotional, aspirational, shareable.
+**Concept:** Reframe travel requests as wishes. "Make a RAV Wish. Owners Make It Real." Emotional, aspirational, shareable.
 
 **Why This Works Pre-Launch:** The feature is built and demonstrable. The concept is emotionally resonant and sharable even before we have mass adoption.
 
@@ -432,7 +442,7 @@ RENT-A-VACATION (Master Brand)
 | 2 | "Hilton Grand Vacations: The Complete Rental Guide" | Both | Resort data is BUILT |
 | 3 | "How Voice Search is Changing Travel" | Press | RAVIO is BUILT |
 | 4 | "Timeshare Rentals vs. Hotel Direct: Price Comparison" | Travelers | Industry data |
-| 5 | "What Is a Vacation Wish? The New Way to Book" | Travelers | Feature is BUILT |
+| 5 | "What Is a RAV Wish? The New Way to Book" | Travelers | Feature is BUILT |
 | 6 | "Disney Vacation Club Rentals: What You Need to Know" | Travelers | Resort data is BUILT |
 
 ### Email Sequences
@@ -440,7 +450,7 @@ RENT-A-VACATION (Master Brand)
 **Traveler Welcome (5 emails):**
 1. Welcome + how it works (Day 0)
 2. "Try Ask RAVIO" — voice search demo (Day 1)
-3. "Your First Vacation Wish" — post a travel request (Day 3)
+3. "Your First RAV Wish" — post a travel request (Day 3)
 4. "Featured Listings This Week" — curated highlights (Day 7)
 5. "Name Your Price" — bidding tutorial (Day 14)
 
@@ -525,7 +535,7 @@ RENT-A-VACATION (Master Brand)
 ### Phase 4: Scale (Target: Q4 2026)
 - Mobile app launch (iOS + Android via Capacitor)
 - Partnership outreach to vacation club brands
-- "Vacation Wishes" campaign
+- "RAV Wishes" campaign
 - Content marketing engine (blog, email, social)
 - Referral program launch
 
@@ -537,18 +547,19 @@ RENT-A-VACATION (Master Brand)
 
 | Metric | Value | How to Verify |
 |--------|-------|---------------|
-| Automated tests passing | 771 (99 test files) | Run `npm test` |
+| Automated tests passing | 956 (121 test files) | Run `npm test` |
+| P0 critical-path tests | 97 (`@p0` tagged) | Run `npm run test:p0` |
 | TypeScript errors | 0 | Run `npx tsc --noEmit` |
 | Lint errors | 0 | Run `npm run lint` |
 | Production build | Clean | Run `npm run build` |
-| Database migrations deployed | 45 | Supabase dashboard |
-| Edge functions deployed | 27 | Supabase dashboard |
+| Database migrations deployed | 046 | Supabase dashboard |
+| Edge functions deployed | 30 | Supabase dashboard |
 | CI/CD pipeline jobs | 5 (all green) | GitHub Actions |
 | Resorts in database | 117 | Query `resorts` table |
 | Unit types in database | 351 | Query `resort_unit_types` table |
 | Countries covered | 10+ | Query resort locations |
-| Phases shipped | 39+ | PROJECT-HUB.md |
-| Development timeline | 18 months | Git history |
+| Sessions shipped | 48+ | PROJECT-HUB.md |
+| Development timeline | 19 months | Git history |
 
 ### Projected Business Metrics (Post-Launch Targets)
 
@@ -587,7 +598,12 @@ RENT-A-VACATION (Master Brand)
 | **RAVIO** | AI Brand | The AI concierge powering voice and text search | BUILT |
 | **Ask RAVIO** | Feature | Voice-activated property search | BUILT |
 | **Chat with RAVIO** | Feature | Text-based AI property search | BUILT |
-| **Vacation Wishes** | Feature | Post travel requests; owners compete | BUILT |
+| **RAV Wishes** | Feature | Post travel requests; owners compete (formerly "Vacation Wishes") | BUILT |
+| **RAV Deals** | Feature | Curated distressed inventory — expiring weeks from motivated sellers | BUILT |
+| **My Rentals** | Suite | Owner dashboard — formerly "Owner's Edge" / "RAV Edge" | BUILT |
+| **RAV Insights** | Dashboard | Executive BI — formerly "RAV Command" | BUILT |
+| **RAV Ops** | Dashboard | Admin operations — formerly "Admin Dashboard" | BUILT |
+| **Notification Center** | Platform | Multi-channel routing (in-app, email, SMS) + TCPA opt-in | BUILT |
 | **Name Your Price** | Feature | Bid on open listings | BUILT |
 | **RAV SmartPrice** | Feature | AI-powered pricing recommendations | BUILT |
 | **RAV SmartEarn** | Tool | Maintenance fee break-even calculator | BUILT |
@@ -597,7 +613,6 @@ RENT-A-VACATION (Master Brand)
 | **RAV Command** | Dashboard | Executive business intelligence | BUILT |
 | **Liquidity Score** | Metric | Proprietary marketplace health index | BUILT |
 | **Bid Spread Index** | Metric | Proprietary price discovery efficiency | BUILT |
-| **Owner's Edge** | Suite | Owner dashboard and business tools | BUILT |
 | **RAV SmartCompare** | Tool | Side-by-side cost comparison across platforms | BUILT |
 | **RAV SmartMatch** | Tool | Resort quiz — find your ideal vacation club | BUILT |
 | **RAV SmartBudget** | Tool | Budget planner for vacation planning | BUILT |
@@ -619,7 +634,8 @@ RENT-A-VACATION (Master Brand)
 
 | Category | Metric | Value | Type |
 |----------|--------|-------|------|
-| **Technology** | Automated tests | 771 (99 test files) | BUILT |
+| **Technology** | Automated tests | 956 (121 test files) | BUILT |
+| **Technology** | P0 critical-path tests | 97 | BUILT |
 | **Technology** | Type errors | 0 | BUILT |
 | **Technology** | Platform uptime (staging) | 99.97% | BUILT |
 | **Technology** | CI/CD pipeline | 5 jobs, all green | BUILT |
@@ -632,7 +648,7 @@ RENT-A-VACATION (Master Brand)
 | **Market** | Avg maintenance fee | $1,120/yr | INDUSTRY DATA |
 | **Business** | Commission model | 15% (default; Pro −2%, Business −5%) | BUILT (configurable) |
 | **Business** | Membership tiers | 6 (3+3) | BUILT |
-| **Business** | Phases shipped | 39+ | BUILT |
+| **Business** | Sessions shipped | 48+ | BUILT |
 
 ---
 

--- a/docs/brand-assets/PITCH-DECK-SCRIPT.md
+++ b/docs/brand-assets/PITCH-DECK-SCRIPT.md
@@ -1,7 +1,7 @@
 ---
-last_updated: "2026-04-03T15:20:24"
-change_ref: "fd388ad"
-change_type: "session-39-docs-update"
+last_updated: "2026-04-15T11:03:04"
+change_ref: "3180738"
+change_type: "session-48-docs-refresh"
 status: "active"
 ---
 # Rent-A-Vacation Pitch Deck Script
@@ -146,16 +146,19 @@ RENT-A-VACATION
 The first marketplace purpose-built
 for vacation club owners and travelers.
 
-✓ Name Your Price — bid on any listing       [BUILT]
-✓ Vacation Wishes — reverse auction          [BUILT]
-✓ TrustShield + PaySafe — verified & secure  [BUILT]
-✓ Ask RAVIO — AI voice & text search         [BUILT]
-✓ ResortIQ — 117 resorts, 351 unit types     [BUILT]
-✓ RAV Smart Suite — 5 tools                  [BUILT]
+✓ Name Your Price — bid on any listing            [BUILT]
+✓ RAV Wishes — reverse auction                    [BUILT]
+✓ RAV Deals — distressed/expiring inventory       [BUILT]
+✓ TrustShield + PaySafe — verified & secure       [BUILT]
+✓ Ask RAVIO — AI voice & text search              [BUILT]
+✓ ResortIQ — 117 resorts, 351 unit types          [BUILT]
+✓ RAV Smart Suite — 5 tools                       [BUILT]
   (SmartEarn, SmartPrice, SmartCompare, SmartMatch, SmartBudget)
-✓ Dynamic Pricing — urgency, seasonal, demand [BUILT]
-✓ Public API & Developer Portal              [BUILT]
-✓ Referral Program — owner growth engine      [BUILT]
+✓ Dynamic Pricing — urgency, seasonal, demand     [BUILT]
+✓ Notification Center — in-app, email, SMS        [BUILT]
+✓ Public API & Developer Portal (/developers)     [BUILT]
+✓ Referral Program — owner growth engine          [BUILT]
+✓ Renter Dashboard /my-trips + Saved Searches     [BUILT]
 
 Everything listed above is deployed and demonstrable today.
 ```
@@ -220,13 +223,13 @@ Features:
 
 ---
 
-## SLIDE 8: Deep Dive — Vacation Wishes (Reverse Auction)
+## SLIDE 8: Deep Dive — RAV Wishes (Reverse Auction)
 
 **Visual:** Flow diagram: Traveler posts wish -> Owners see demand signal -> Owners send proposals -> Traveler picks best offer.
 
 **Text:**
 ```
-VACATION WISHES — Let Owners Compete for You          [BUILT]
+RAV WISHES — Let Owners Compete for You               [BUILT]
 
 Traditional:  Traveler browses → picks a listing → pays the price
 RAV:          Traveler posts a wish → owners compete → traveler picks
@@ -243,7 +246,7 @@ How it works:
 ```
 
 **Speaker Notes:**
-> "This is the other side of our marketplace innovation. We call them Vacation Wishes. Instead of the traveler hunting through listings, they simply describe what they want — destination, dates, budget, requirements. We then surface that wish to relevant property owners, who can send personalized proposals. The traveler picks the best offer. This creates real price discovery — owners see actual demand, travelers get competitive offers, and the platform learns what the market really values. The entire workflow is built — wishes, proposals, matching, notifications."
+> "This is the other side of our marketplace innovation. We call them RAV Wishes. Instead of the traveler hunting through listings, they simply describe what they want — destination, dates, budget, requirements. We then surface that wish to relevant property owners, who can send personalized proposals. The traveler picks the best offer. This creates real price discovery — owners see actual demand, travelers get competitive offers, and the platform learns what the market really values. The entire workflow is built — wishes, proposals, matching, notifications."
 
 ---
 
@@ -338,13 +341,14 @@ Impact: Listing creation designed to take ~8 minutes vs. industry ~22 minutes
 
 ---
 
-## SLIDE 12: Deep Dive — Owner's Edge (RAV Smart Suite + Dynamic Pricing)
+## SLIDE 12: Deep Dive — My Rentals (Owner Suite: Smart Suite + Dynamic Pricing + Notification Center)
 
 **Visual:** Split screen. Left: SmartPrice badge on a listing. Right: Calculator results showing break-even.
 
 **Text:**
 ```
-OWNER'S EDGE — Empowering Owners to Earn More          [BUILT]
+MY RENTALS — Empowering Owners to Earn More            [BUILT]
+(formerly "Owner's Edge" / "RAV Edge" — Session 47 rebrand)
 
 RAV SMARTPRICE:
 • AI-powered pricing recommendation on every listing
@@ -365,7 +369,13 @@ DYNAMIC PRICING ENGINE:
 • Seasonal adjustment factors
 • Demand-based pricing (bids + search volume)
 
-OWNER DASHBOARD:
+NOTIFICATION CENTER:
+• Multi-channel routing (in-app, email, SMS)
+• Per-type, per-channel preferences
+• TCPA-compliant SMS opt-in + STOP keyword
+• Seasonal event reminders + cron-driven scheduling
+
+OWNER DASHBOARD ("My Rentals"):
 • Earnings tracking (lifetime, YTD, monthly)
 • Booking management with confirmation workflow
 • Bid activity feed (real-time)
@@ -386,13 +396,14 @@ OWNER DASHBOARD:
 ```
 ENGINEERING EXCELLENCE                                  [ALL BUILT & VERIFIABLE]
 
-771 automated tests (99 test files) — all passing
+956 automated tests (121 test files) — all passing
+ 97 P0 critical-path tests — `npm run test:p0` (~2s)
   0 TypeScript errors — strict mode
   0 lint errors — ESLint enforced
   5-job CI/CD pipeline — GitHub Actions
- 45 database migrations — deployed
- 27 edge functions — serverless, auto-scaling
- 39 sessions shipped
+ 46 database migrations — deployed
+ 30 edge functions — serverless, auto-scaling
+ 48 sessions shipped — 19 months
 
 Tech Stack:
 React 18 + TypeScript + Vite | Tailwind CSS + shadcn/ui
@@ -405,7 +416,7 @@ Vitest + Playwright + Percy (Testing)
 ```
 
 **Speaker Notes:**
-> "A few words about our engineering foundation, because execution matters. We have 771 automated tests across 99 test files — all passing. Zero type errors, zero lint errors, a 5-job CI/CD pipeline that runs on every commit. 45 database migrations, 27 serverless edge functions, row-level security on every table. We shipped 39 development sessions. Every number on this slide is real and verifiable right now. This isn't a prototype — it's a production-grade platform."
+> "A few words about our engineering foundation, because execution matters. We have 956 automated tests across 121 test files — all passing, including 97 P0 critical-path tests that run in about two seconds. Zero type errors, zero lint errors, a 5-job CI/CD pipeline that runs on every commit. 46 database migrations, 30 serverless edge functions, row-level security on every table. We've shipped 48 development sessions over 19 months. Every number on this slide is real and verifiable right now. This isn't a prototype — it's a production-grade platform."
 
 ---
 
@@ -513,28 +524,30 @@ Q4:   SCALE
 ```
 WHY WE WIN                                              [BUILT CAPABILITIES]
 
-                        RAV     VRBO    Airbnb  RedWeek  TUG
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-Vacation Club Focus      ✓       —       —       ~        ~
-AI Voice Search          ✓       —       —       —        —
-AI Text Chat             ✓       —       —       —        —
-Bidding / Negotiation    ✓       —       —       —        —
-Reverse Auction (Wishes) ✓       —       —       —        —
-Resort Master Data       ✓       —       —       —        —
-Owner Verification       ✓       ~       ~       ~        —
-Escrow Protection        ✓       ✓       ✓       —        —
-Fair Value AI            ✓       —       —       —        —
-Smart Suite (5 tools)    ✓       —       —       —        —
-Dynamic Pricing          ✓       ~       ~       —        —
-Public API / Dev Portal  ✓       —       —       —        —
-Owner Dashboard          ✓       ✓       ✓       —        —
-Executive BI             ✓       —       —       —        —
+                              RAV     VRBO    Airbnb  RedWeek  TUG
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Vacation Club Focus            ✓       —       —       ~        ~
+AI Voice Search                ✓       —       —       —        —
+AI Text Chat                   ✓       —       —       —        —
+Bidding / Negotiation          ✓       —       —       —        —
+Reverse Auction (RAV Wishes)   ✓       —       —       —        —
+Distressed Inventory (Deals)   ✓       —       —       ~        —
+Resort Master Data             ✓       —       —       —        —
+Owner Verification             ✓       ~       ~       ~        —
+Escrow Protection              ✓       ✓       ✓       —        —
+Fair Value AI                  ✓       —       —       —        —
+Smart Suite (5 tools)          ✓       —       —       —        —
+Dynamic Pricing                ✓       ~       ~       —        —
+Notification Ctr (in-app/email/SMS) ✓  ~       ~       —        —
+Public API / Dev Portal        ✓       —       —       —        —
+Owner Dashboard (My Rentals)   ✓       ✓       ✓       —        —
+Executive BI (RAV Insights)    ✓       —       —       —        —
 
-9 capabilities that no competitor offers today.
+11 capabilities that no competitor offers today.
 ```
 
 **Speaker Notes:**
-> "This is our competitive position. Nine of our core capabilities are industry firsts — AI voice search, AI text chat, bidding marketplace, reverse auction, resort master data, fair value scoring, a five-tool Smart Suite, dynamic pricing, and a public developer API. VRBO and Airbnb are horizontal platforms with hundreds of millions in engineering resources, but they're not purpose-built for vacation clubs. They don't understand resort confirmation workflows, maintenance fee economics, or owner verification needs. RedWeek and TUG are community sites, not technology platforms. Our moat is the combination of AI, data, and vacation-club-specific workflows — and it compounds over time."
+> "This is our competitive position. Eleven of our core capabilities are industry firsts — AI voice search, AI text chat, bidding marketplace, RAV Wishes reverse auction, RAV Deals distressed inventory surface, resort master data, fair value scoring, a five-tool Smart Suite, dynamic pricing, multi-channel notification center, and a public developer API. VRBO and Airbnb are horizontal platforms with hundreds of millions in engineering resources, but they're not purpose-built for vacation clubs. They don't understand resort confirmation workflows, maintenance fee economics, or owner verification needs. RedWeek and TUG are community sites, not technology platforms. Our moat is the combination of AI, data, and vacation-club-specific workflows — and it compounds over time."
 
 ---
 
@@ -555,6 +568,7 @@ MID TERM (Q3-Q4 2026):
 • Voice-assisted listing creation, booking, and bidding
 • iOS + Android app (Capacitor native shells)
 • Brand partnerships (Hilton, Marriott, Disney outreach)
+• A2P 10DLC SMS activation (post LLC/EIN — flips `SMS_TEST_MODE=false`)
 • Content marketing engine
 
 LONG TERM (2027):
@@ -592,7 +606,7 @@ Name Your Price. Book Your Paradise.
 **Speaker Notes (adjust based on audience):**
 
 *For investors:*
-> "We've built a complete, production-grade marketplace for a $10.5 billion industry with no tech-first leader. 39 sessions shipped, 771 automated tests, industry-first AI capabilities. We're looking for [investment amount] to fund our public launch, initial marketing, and first 12 months of operation. I'd love to walk you through the live demo and discuss how we can work together."
+> "We've built a complete, production-grade marketplace for a $10.5 billion industry with no tech-first leader. 48 sessions shipped, 956 automated tests, industry-first AI + bidding + multi-channel notification capabilities. We're looking for [investment amount] to fund our public launch, initial marketing, and first 12 months of operation. I'd love to walk you through the live demo and discuss how we can work together."
 
 *For partners:*
 > "We've built a platform that serves your owners better than anything on the market today. I'd love to discuss a pilot program where we can demonstrate value to your owner community — reduced churn, increased satisfaction, and a new revenue channel. Let's set up a demo with your team."
@@ -610,7 +624,8 @@ Name Your Price. Book Your Paradise.
 
 **Text:**
 ```
-RAV COMMAND — Investor-Grade Business Intelligence      [BUILT]
+RAV INSIGHTS — Investor-Grade Business Intelligence      [BUILT]
+(formerly "RAV Command" — Session 47 rebrand)
 
 6 Sections:
 1. HeadlineBar — 5 real-time KPI pills
@@ -628,7 +643,7 @@ Proprietary Metrics:
 ```
 
 **Speaker Notes:**
-> "For our leadership and investors, we built RAV Command — an executive dashboard with 6 sections covering business performance, marketplace health, market intelligence, industry news, and unit economics. It includes two platform-specific metrics: the Liquidity Score, a composite marketplace health index, and the Bid Spread Index, which measures how efficiently our bidding system discovers fair prices. The dashboard also supports a 'Bring Your Own Key' pattern for third-party data sources like AirDNA and STR — demo mode by default, connected when API keys are provided. This entire dashboard is built and live in our demo environment."
+> "For our leadership and investors, we built RAV Insights — an executive dashboard with 6 sections covering business performance, marketplace health, market intelligence, industry news, and unit economics. It includes two platform-specific metrics: the Liquidity Score, a composite marketplace health index, and the Bid Spread Index, which measures how efficiently our bidding system discovers fair prices. The dashboard also supports a 'Bring Your Own Key' pattern for third-party data sources like AirDNA and STR — demo mode by default, connected when API keys are provided. This entire dashboard is built and live in our demo environment."
 
 ---
 

--- a/docs/brand-assets/PITCH-DECK-SCRIPT.md
+++ b/docs/brand-assets/PITCH-DECK-SCRIPT.md
@@ -1,6 +1,6 @@
 ---
-last_updated: "2026-04-15T11:03:04"
-change_ref: "3180738"
+last_updated: "2026-04-15T11:10:55"
+change_ref: "bc1bafd"
 change_type: "session-48-docs-refresh"
 status: "active"
 ---
@@ -146,8 +146,8 @@ RENT-A-VACATION
 The first marketplace purpose-built
 for vacation club owners and travelers.
 
-✓ Name Your Price — bid on any listing            [BUILT]
-✓ RAV Wishes — reverse auction                    [BUILT]
+✓ Marketplace — Listings, Wishes, Offers          [BUILT]
+  (renters offer on Listings; owners offer on Wishes)
 ✓ RAV Deals — distressed/expiring inventory       [BUILT]
 ✓ TrustShield + PaySafe — verified & secure       [BUILT]
 ✓ Ask RAVIO — AI voice & text search              [BUILT]
@@ -180,12 +180,12 @@ FOR TRAVELERS                    FOR OWNERS
 ━━━━━━━━━━━━━━━                  ━━━━━━━━━━━━
 
 1. SEARCH or WISH               1. LIST
-   Ask RAVIO by voice/text,        Create a listing in minutes.
-   or post a Vacation Wish.        ResortIQ auto-fills details.
+   Ask RAVIO by voice/text,        Create a Listing in minutes.
+   or post a Wish.                 ResortIQ auto-fills details.
 
-2. BID or BOOK                   2. GET VERIFIED
-   Name your price on any           TrustShield confirms your
-   listing, or book instantly.      identity and ownership.
+2. OFFER or BOOK                 2. GET VERIFIED
+   Make an Offer at your price      TrustShield confirms your
+   on any Listing, or book direct.  identity and ownership.
 
 3. ENJOY                         3. EARN
    Check in at the resort.         Get paid via PaySafe escrow.
@@ -223,30 +223,30 @@ Features:
 
 ---
 
-## SLIDE 8: Deep Dive — RAV Wishes (Reverse Auction)
+## SLIDE 8: Deep Dive — Wishes (Renter Open Call)
 
 **Visual:** Flow diagram: Traveler posts wish -> Owners see demand signal -> Owners send proposals -> Traveler picks best offer.
 
 **Text:**
 ```
-RAV WISHES — Let Owners Compete for You               [BUILT]
+WISHES — Let Owners Compete for You                   [BUILT]
 
 Traditional:  Traveler browses → picks a listing → pays the price
-RAV:          Traveler posts a wish → owners compete → traveler picks
+RAV:          Renter posts a Wish → owners send Offers → renter picks
 
 How it works:
-1. Traveler says: "I want Maui, March 15-22, 2BR, under $1,800"
-2. Matching owners see the wish + demand signal
-3. Owners send proposals with their best price
-4. Traveler reviews all proposals and picks the winner
+1. Renter says: "I want Maui, March 15-22, 2BR, under $1,800"
+2. Matching owners see the Wish + demand signal
+3. Owners send Offers with their best price
+4. Renter reviews all Offers and picks the winner
 
 → Owners get demand intelligence (what travelers actually want)
-→ Travelers get personalized offers (not one-size-fits-all search)
+→ Renters get personalized Offers (not one-size-fits-all search)
 → The platform gets price discovery data
 ```
 
 **Speaker Notes:**
-> "This is the other side of our marketplace innovation. We call them RAV Wishes. Instead of the traveler hunting through listings, they simply describe what they want — destination, dates, budget, requirements. We then surface that wish to relevant property owners, who can send personalized proposals. The traveler picks the best offer. This creates real price discovery — owners see actual demand, travelers get competitive offers, and the platform learns what the market really values. The entire workflow is built — wishes, proposals, matching, notifications."
+> "This is the other side of our Marketplace. We call them Wishes. Instead of the renter hunting through listings, they describe what they want — destination, dates, budget, requirements. We surface the Wish to relevant property owners, who send Offers. The renter picks the best Offer. This creates real price discovery — owners see actual demand, renters get competitive Offers, and the platform learns what the market really values. The entire workflow is built — Wishes, Offers, matching, notifications."
 
 ---
 
@@ -507,7 +507,7 @@ Q3:   PUBLIC LAUNCH
 
 Q4:   SCALE
       iOS + Android app (Capacitor)
-      Brand partnerships | "Vacation Wishes" campaign
+      Brand partnerships | "Post a Wish" campaign
       Content marketing engine | Referral program
 ```
 
@@ -530,7 +530,7 @@ Vacation Club Focus            ✓       —       —       ~        ~
 AI Voice Search                ✓       —       —       —        —
 AI Text Chat                   ✓       —       —       —        —
 Bidding / Negotiation          ✓       —       —       —        —
-Reverse Auction (RAV Wishes)   ✓       —       —       —        —
+Wishes (renter open call)      ✓       —       —       —        —
 Distressed Inventory (Deals)   ✓       —       —       ~        —
 Resort Master Data             ✓       —       —       —        —
 Owner Verification             ✓       ~       ~       ~        —
@@ -547,7 +547,7 @@ Executive BI (RAV Insights)    ✓       —       —       —        —
 ```
 
 **Speaker Notes:**
-> "This is our competitive position. Eleven of our core capabilities are industry firsts — AI voice search, AI text chat, bidding marketplace, RAV Wishes reverse auction, RAV Deals distressed inventory surface, resort master data, fair value scoring, a five-tool Smart Suite, dynamic pricing, multi-channel notification center, and a public developer API. VRBO and Airbnb are horizontal platforms with hundreds of millions in engineering resources, but they're not purpose-built for vacation clubs. They don't understand resort confirmation workflows, maintenance fee economics, or owner verification needs. RedWeek and TUG are community sites, not technology platforms. Our moat is the combination of AI, data, and vacation-club-specific workflows — and it compounds over time."
+> "This is our competitive position. Eleven of our core capabilities are industry firsts — AI voice search, AI text chat, two-sided Marketplace, Wishes (renter open call), RAV Deals distressed inventory surface, resort master data, fair value scoring, a five-tool Smart Suite, dynamic pricing, multi-channel notification center, and a public developer API. VRBO and Airbnb are horizontal platforms with hundreds of millions in engineering resources, but they're not purpose-built for vacation clubs. They don't understand resort confirmation workflows, maintenance fee economics, or owner verification needs. RedWeek and TUG are community sites, not technology platforms. Our moat is the combination of AI, data, and vacation-club-specific workflows — and it compounds over time."
 
 ---
 

--- a/docs/exports/generate_platform_overview.py
+++ b/docs/exports/generate_platform_overview.py
@@ -111,20 +111,29 @@ def generate_platform_overview():
     doc.add_heading("What It Is", level=1)
     add_body(
         doc,
-        "A marketplace where timeshare owners can rent out their unused vacation weeks "
-        "to travelers, with RAV earning a 15% commission. Think Airbnb, but specifically "
+        "An AI-powered marketplace where vacation club owners rent directly to travelers, "
+        "and travelers name their price. RAV earns a 15% default commission "
+        "(Pro \u22122%, Business \u22125%) on successful bookings. Think Airbnb, but purpose-built "
         "for timeshare inventory across Hilton, Marriott, Disney, and 6 other vacation "
-        "club brands (117 resorts total).",
+        "club brands (117 resorts, 351 unit types). Two marketplace primitives no "
+        "competitor offers: Name Your Price (bidding on any listing) and RAV Wishes "
+        "(travelers post dream trips; verified owners compete with proposals).",
+    )
+    add_body(
+        doc,
+        "Tagline: \u201cName Your Price. Book Your Paradise.\u201d",
     )
 
     # ── Tech Stack ──
     doc.add_heading("Tech Stack", level=1)
     add_bullet_list(doc, [
-        "Frontend: React + TypeScript + Vite + Tailwind + shadcn/ui",
+        "Frontend: React 18 + TypeScript + Vite + Tailwind + shadcn/ui",
         "Backend: Supabase (PostgreSQL, Auth, Edge Functions, RLS)",
-        "Payments: Stripe (checkout, Connect payouts, webhooks)",
-        "Voice: VAPI (Deepgram STT + GPT-4o-mini + ElevenLabs TTS)",
-        "Text Chat: OpenRouter (RAVIO assistant)",
+        "Payments: Stripe (checkout, Connect payouts, webhooks, Tax-ready)",
+        "Voice: VAPI (Deepgram Nova-3 STT + GPT-4o-mini + ElevenLabs TTS)",
+        "Text Chat: OpenRouter (RAVIO assistant, SSE streaming)",
+        "Notifications: Resend (email) + Twilio (SMS, TCPA-compliant)",
+        "Observability: Sentry (errors + session replay) + GA4 (consent-gated)",
         "Deployment: Vercel (frontend) + Supabase (backend)",
     ])
 
@@ -151,41 +160,67 @@ def generate_platform_overview():
         "Track booking in My Bookings, file disputes if needed",
     ])
 
-    doc.add_heading("Admin Flow", level=2)
+    doc.add_heading("Admin Flow (RAV Ops)", level=2)
     add_numbered_list(doc, [
-        "Dashboard with tabs: Users, Listings, Bookings, Escrow, Payouts, Financials, Disputes, Voice",
-        "Approve/reject listings and users (now with bulk actions)",
+        "Unified operations dashboard: Users, Listings, Bookings, Escrow, Payouts, Financials, Disputes, Voice, Resorts, API Keys, Notifications, Events",
+        "Approve/reject listings and users with bulk actions + audit trail",
         "Manage escrow lifecycle (verify, hold, release, refund)",
-        "Dispute resolution queue with assignment",
-        "Voice search monitoring and quota management",
+        "Dispute resolution queue with assignment + evidence review",
+        "Voice search monitoring, tier/user quota overrides, usage dashboard",
+        "Resort CSV import with validation + duplicate detection",
+        "Notification catalog, seasonal event calendar, delivery log",
+    ])
+
+    doc.add_heading("Executive Flow (RAV Insights)", level=2)
+    add_numbered_list(doc, [
+        "6-section BI dashboard at /executive-dashboard",
+        "Headline KPIs, GMV trend, revenue waterfall, bid activity",
+        "Marketplace health: Liquidity Score, supply/demand map",
+        "Market intelligence with BYOK pattern (AirDNA, STR)",
+        "Industry feed + regulatory radar + unit economics",
     ])
 
     add_horizontal_rule(doc)
 
     # ── Features Built ──
-    doc.add_heading("Features Built Across 24+ Sessions", level=1)
+    doc.add_heading("Features Built Across 48+ Sessions", level=1)
 
     features_data = [
-        ("Auth", "Email/password + Google OAuth, role-based access (6 roles), email verification, user approval workflow"),
-        ("Listings", "Create/edit listings, nightly pricing, fair value scoring, photo uploads, per-night rate with auto price calculation"),
-        ("Bidding", "Bid on listings, propose alternate dates, 24hr expiry, owner accept/reject/counter"),
-        ("Booking", "Stripe Checkout, fee breakdown (base + service + cleaning + tax), booking confirmation flow"),
-        ("Payments", "Stripe Connect (owner onboarding + payouts), webhooks (6 events), escrow management"),
-        ("Cancellation", "Policy-based (flexible/moderate/strict/super_strict) renter cancellation, owner cancellation with full refund, Stripe refunds"),
-        ("Escrow", "6-status lifecycle, owner confirmation, RAV verification, auto-release after checkout+5d, hold/unhold, refund"),
-        ("Disputes", "Renter can file disputes, admin queue with assignment, resolution with refund"),
-        ("Voice Search", "VAPI integration, tier-based quotas, admin overrides, usage dashboard, search logging"),
-        ("Text Chat", "RAVIO AI assistant via OpenRouter"),
-        ("Calculator", "Maintenance fee breakeven calculator for 9 brands"),
-        ("Travel Requests", "Travelers post what they want, auto-matched when listings appear"),
-        ("Owner Dashboard", "Earnings, bookings, listings management, Stripe Connect status, escrow visibility"),
-        ("Admin Dashboard", "8-tab dashboard with cross-entity linking, search, date filters, bulk actions, notes, age badges, dispute assignment"),
-        ("Executive Dashboard", "Marketplace health metrics, industry feed"),
-        ("SEO", "Meta tags, sitemap, robots.txt, FAQ JSON-LD, OG images"),
-        ("Security", "CSP headers, rate limiting (7 edge functions), RLS policies"),
+        ("Auth", "Email/password + Google OAuth, role-based access (6 roles), email verification, user approval workflow, realtime role upgrade"),
+        ("Listings", "Create/edit listings, nightly pricing, fair value scoring, photo uploads, dynamic pricing (urgency/seasonal/demand), admin edit with audit trail"),
+        ("Name Your Price (Bidding)", "Bid on any listing, propose alternate dates, 24hr expiry, owner accept/reject/counter, Bid Spread Index"),
+        ("RAV Wishes (Reverse Auction)", "Travelers post dream trips; verified owners send proposals; traveler picks winner. Formerly \u201cVacation Wishes\u201d (Session 47 rebrand)"),
+        ("RAV Deals", "Curated distressed/expiring-week inventory surface, feeds directly into bidding"),
+        ("Booking", "Stripe Checkout, fee breakdown (base + service + cleaning + tax), 5-step booking timeline, cancellation policy UI"),
+        ("Payments", "Stripe Connect (owner onboarding + payouts), webhooks (6 events), escrow lifecycle, Stripe Tax-ready (awaiting #127)"),
+        ("Cancellation", "Policy-based (flexible/moderate/strict/super_strict) renter cancellation, owner cancellation with full refund, automated Stripe refunds"),
+        ("Escrow (PaySafe)", "6-status lifecycle, owner confirmation timer, RAV verification, auto-release after checkout+5d, hold/unhold, refund"),
+        ("Disputes", "Expanded dispute categories (renter + owner), evidence upload, admin queue with assignment + resolution"),
+        ("Voice Search (Ask RAVIO)", "VAPI integration, Deepgram Nova-3, tier-based quotas, admin overrides, usage dashboard, observability + alert thresholds"),
+        ("Text Chat (Chat with RAVIO)", "Streaming AI assistant via OpenRouter with property cards"),
+        ("RAV Smart Suite", "5 free public tools at /tools: SmartEarn, SmartPrice, SmartCompare, SmartMatch, SmartBudget"),
+        ("TrustShield", "Multi-step owner identity + ownership verification; trust-level progression"),
+        ("ResortIQ", "117 resorts, 351 unit types, 9 brands; auto-populates listing forms, powers voice search"),
+        ("Renter Dashboard (My Trips)", "/my-trips \u2014 4 tabs (Overview, Bookings, Offers, Favorites) with check-in countdown"),
+        ("My Rentals (Owner Dashboard)", "Consolidated 11 tabs \u2192 4: Dashboard, My Listings, Bookings & Earnings, Account. Formerly \u201cOwner\u2019s Edge\u201d"),
+        ("RAV Ops (Admin)", "Unified operations: Users, Listings, Bookings, Escrow, Payouts, Financials, Disputes, Voice, Resorts, API Keys, Notifications, Events"),
+        ("RAV Insights (Executive BI)", "6-section dashboard: KPIs, GMV, marketplace health, market intel (BYOK), industry feed, unit economics. Formerly \u201cRAV Command\u201d"),
+        ("Notification Center", "Multi-channel routing (in-app/email/SMS), per-type preferences, TCPA opt-in, seasonal events, delivery log"),
+        ("SMS Infrastructure", "Twilio integration: notification-dispatcher, sms-scheduler, twilio-webhook. SMS_TEST_MODE=true \u2014 prod gated on A2P 10DLC (#127)"),
+        ("Public API + Developer Portal", "OpenAPI 3.0 spec, /developers Swagger UI, API key management, tiered rate limits, IP allowlisting (CIDR)"),
+        ("Referral Program", "Unique codes, tracking dashboard, signup attribution via ?ref=CODE"),
+        ("Pre-Booking Messaging", "Inquiry threads between travelers and owners before booking"),
+        ("Saved Searches", "Save criteria + price drop alerts"),
+        ("Destinations Explorer", "10 destinations, 35 cities \u2014 curated discovery pages"),
+        ("Compare Properties", "Up to 3 listings side-by-side with best-value badges"),
+        ("iCal Export", "RFC 5545 calendar export for owner bookings"),
+        ("Realtime", "useRealtimeSubscription replaced all polling (notifications, messages, unread counts)"),
+        ("SEO", "Meta tags, sitemap, robots.txt, FAQ JSON-LD, OG images, JSON-LD on /tools"),
+        ("Security", "CSP headers, rate limiting, RLS on every table, IP allowlisting for API keys"),
         ("GDPR", "Data export, account deletion with 14-day grace period, cookie consent"),
-        ("Architecture", "Auto-generated flow diagrams from declarative manifests"),
+        ("Architecture Docs", "Auto-generated flow diagrams from declarative Flow Manifests at /architecture"),
         ("PWA", "Service worker, installable, offline-capable"),
+        ("Observability", "Sentry (errors + session replay) + GA4 (consent-gated, G-G2YCVHNS25)"),
     ]
 
     add_table_from_data(
@@ -203,12 +238,17 @@ def generate_platform_overview():
         doc,
         ["Metric", "Count"],
         [
-            ("Automated tests", "402 (all passing)"),
-            ("Database migrations", "31 (DEV), 23 (PROD)"),
-            ("Edge functions", "24"),
-            ("Supabase RLS policies", "Extensive across all tables"),
-            ("Pages / routes", "~20"),
-            ("Commits on dev ahead of main", "Many \u2014 needs a PR to merge"),
+            ("Automated tests", "956 passing (121 test files)"),
+            ("P0 critical-path tests", "97 (`@p0` tagged, ~2s run)"),
+            ("Database migrations", "046 (all deployed to DEV + PROD)"),
+            ("Edge functions", "30 (27 in PROD; 3 SMS functions DEV-only until A2P 10DLC)"),
+            ("Resorts / unit types", "117 / 351 across 9 brands"),
+            ("Routes (pages)", "~35 (incl. /developers, /tools, /destinations, /notifications)"),
+            ("Type errors / Lint errors", "0 / 0"),
+            ("Build status", "Clean"),
+            ("Sessions shipped", "48+ in 19 months"),
+            ("Platform uptime (staging)", "99.97%"),
+            ("dev vs main", "In sync (PR #239 merged Apr 1)"),
         ],
     )
 
@@ -216,19 +256,27 @@ def generate_platform_overview():
 
     # ── Remaining Pre-Launch Items ──
     doc.add_heading("Remaining Pre-Launch Items", level=1)
-    add_body(doc, "6 open issues remain before the platform can go live:")
+    add_body(
+        doc,
+        "The platform is feature-complete. Remaining blockers are external (legal, "
+        "business formation, and third-party verification) rather than engineering work.",
+    )
 
     add_table_from_data(
         doc,
         ["#", "Issue", "Status"],
         [
-            ("#127", "Business Formation & Stripe Tax Activation", "Blocked on LLC / EIN"),
-            ("#87", "Launch readiness checklist", "Ready when other items close"),
-            ("#80", "Legal review: ToS and Privacy Policy", "Needs lawyer review"),
-            ("#74", "Google Analytics (GA4) Integration", "Not started"),
-            ("#64", "1099-K Compliance", "Not started"),
-            ("#62", "Admin Tax Reporting", "Not started"),
+            ("#127", "Business Formation (LLC + EIN)", "BLOCKER \u2014 gates Stripe Tax, Puzzle.io, Mercury bank, A2P 10DLC SMS"),
+            ("#80", "Legal review: ToS and Privacy Policy", "Awaiting legal counsel review"),
+            ("#187", "Manual verification workflow (TrustShield)", "Operational process to document"),
+            ("#230-234", "Social media account setup", "Facebook, Instagram, LinkedIn, Twitter, GBP"),
+            ("#87", "Launch readiness checklist", "Ready when #127 and #80 close"),
         ],
+    )
+    add_body(
+        doc,
+        "Already shipped (previously on this list): GA4 (#74), Admin Tax Reporting (#62), "
+        "1099-K Compliance (#64), Stripe Connect webhooks, Sentry, CSP/rate-limits, GDPR.",
     )
 
     add_horizontal_rule(doc)
@@ -236,11 +284,41 @@ def generate_platform_overview():
     # ── Current Platform State ──
     doc.add_heading("Current Platform State", level=1)
     add_bullet_list(doc, [
-        "PROD: Staff Only Mode enabled \u2014 platform locked for internal testing",
-        "Stripe Tax: Code ready but not activated in Stripe Dashboard (blocked on #127)",
-        "GitHub Actions: Issue Notifications workflow temporarily disabled (Resend quota)",
+        "PROD: Staff Only Mode enabled \u2014 platform locked for pre-launch control",
+        "Stripe Tax: Code ready (automatic_tax enabled), not activated pending LLC/EIN (#127)",
+        "SMS: Deployed to DEV with SMS_TEST_MODE=true; production traffic gated on A2P 10DLC",
+        "Puzzle.io accounting: Onboarding paused at step 7 pending LLC/EIN (#127)",
+        "Repository: Private (changed Mar 4, 2026) \u2014 branch protection requires GitHub Team plan",
         "Supabase CLI: Currently linked to DEV project",
+        "dev and main: In sync (PR #239 merged Apr 1, 2026)",
     ])
+
+    add_horizontal_rule(doc)
+
+    # ── Brand Architecture ──
+    doc.add_heading("Brand Architecture (Session 47 Rebrand \u2014 Apr 12, 2026)", level=1)
+    add_body(
+        doc,
+        "The RAV brand family follows three naming patterns: RAV-prefix for platform "
+        "features and internal tools; CompoundName for the trust/infrastructure layer; "
+        "plain language for customer-facing navigation.",
+    )
+    add_table_from_data(
+        doc,
+        ["Canonical Name", "Type", "Notes"],
+        [
+            ("Name Your Price", "Primary \u2014 bidding", "Hero feature, master tagline"),
+            ("RAV Wishes", "Primary \u2014 reverse auction", "Formerly \u201cVacation Wishes\u201d"),
+            ("RAV Deals", "Primary \u2014 discovery", "New distressed-inventory surface"),
+            ("TrustShield + PaySafe", "Supporting \u2014 trust", "Verification + escrow"),
+            ("Ask RAVIO / Chat with RAVIO", "Supporting \u2014 AI", "Voice + text search"),
+            ("RAV Smart[X]", "Supporting \u2014 tools", "SmartEarn, SmartPrice, SmartCompare, SmartMatch, SmartBudget"),
+            ("My Trips / My Rentals", "Nav \u2014 customer", "Plain-language dashboards"),
+            ("RAV Insights", "Infrastructure \u2014 BI", "Formerly \u201cRAV Command\u201d"),
+            ("RAV Ops", "Infrastructure \u2014 admin", "Formerly \u201cAdmin Dashboard\u201d"),
+            ("ResortIQ", "Infrastructure \u2014 data", "117 resorts, 351 unit types"),
+        ],
+    )
 
     # Footer
     add_footer(doc, "Rent-A-Vacation \u2022 Confidential \u2022 Generated " + datetime.now().strftime("%B %d, %Y"))

--- a/docs/guides/COMPLETE-USER-JOURNEY-MAP.md
+++ b/docs/guides/COMPLETE-USER-JOURNEY-MAP.md
@@ -1,6 +1,6 @@
 ---
-last_updated: "2026-04-15T11:03:04"
-change_ref: "3180738"
+last_updated: "2026-04-15T11:10:55"
+change_ref: "bc1bafd"
 change_type: "session-48-docs-refresh"
 status: "active"
 ---
@@ -12,22 +12,28 @@ status: "active"
 
 ---
 
-## 🔔 Session 48 Addendum — What's Current (April 2026)
+## 🔔 Session 48-52 Addendum — What's Current (April 2026)
 
 The detailed journey flows below were authored post-Phase 4 and remain structurally accurate. The platform has shipped substantial additional capability since. Reference this addendum for what's live as of April 2026; individual journeys below still describe the core mechanics correctly.
 
-### Canonical brand names (Session 47 rebrand — April 12, 2026)
+### Canonical vocabulary (Session 52 Marketplace Terminology Lock — April 15, 2026)
 
-Replace older terms wherever they appear in this document with the canonical Session 47 names. See `docs/brand-assets/BRAND-LOCK.md` for the full naming framework.
+The marketplace uses **three nouns only** in all user-facing copy: **Listing**, **Wish**, **Offer**. "Offer" replaces both "Bid" and "Proposal" in UI. The "RAV" prefix is dropped from transactional nouns and CTAs. See `docs/brand-assets/BRAND-LOCK.md` Sections 8 + 9 for the full framework.
 
-| Old term in this doc | Canonical name | Nav label |
-|----------------------|----------------|-----------|
-| Vacation Wishes / Travel Requests | **RAV Wishes** | "Make a Wish" |
+| Old term in this doc | Canonical name (Session 52) | Nav label / route |
+|----------------------|-----------------------------|-------------------|
+| Vacation Wishes / RAV Wishes / Travel Requests | **Wish / Wishes** | Inside Marketplace (Wishes tab) |
+| Bid / Proposal (UI) | **Offer** | — (single noun for both directions) |
+| Make a RAV Offer / Make an Offer | **Make an Offer** | Button on every Listing |
+| Make a Wish / Make a RAV Wish | **Post a Wish** | Renter CTA |
+| Name Your Price + Make a Wish (separate nav) | **Marketplace** (single nav link) | `/marketplace` (renter default = Listings, owner default = Wishes) |
+| /bidding (route) | **/marketplace** (with redirect) | — |
 | Owner's Edge | **My Rentals** | "My Rentals" |
 | RAV Command | **RAV Insights** | "RAV Insights" |
 | Admin Dashboard | **RAV Ops** | "RAV Ops" |
-| Make an Offer (CTA) | **Make a RAV Offer** | — |
-| (new) | **RAV Deals** | "Browse RAV Deals" |
+| (new) | **RAV Deals** | "Browse RAV Deals" (platform-branded — keeps RAV) |
+
+The brand slogan **"Name Your Price. Book Your Paradise."** remains as the master hero tagline (it describes the *mechanic* — you name the price via an Offer). It is no longer a header nav label.
 
 ### Major journeys added since v2.0
 

--- a/docs/guides/COMPLETE-USER-JOURNEY-MAP.md
+++ b/docs/guides/COMPLETE-USER-JOURNEY-MAP.md
@@ -1,36 +1,98 @@
 ---
-last_updated: "2026-03-21T02:05:09"
-change_ref: "94959eb"
-change_type: "session-39-docs-update"
+last_updated: "2026-04-15T11:03:04"
+change_ref: "3180738"
+change_type: "session-48-docs-refresh"
 status: "active"
 ---
 # Complete User Journey Map - Rent-A-Vacation Platform
 
-**Document Version:** 2.0
-**Last Updated:** February 16, 2026
-**Status:** Post Phase 4 Track A (Voice Auth & Approval System complete)
+**Document Version:** 3.0
+**Last Updated:** April 14, 2026 (Session 48 refresh)
+**Status:** Post Session 48 — platform feature-complete pending A2P 10DLC + LLC/EIN blockers (#127)
 
 ---
 
-## 🎯 Overview
+## 🔔 Session 48 Addendum — What's Current (April 2026)
+
+The detailed journey flows below were authored post-Phase 4 and remain structurally accurate. The platform has shipped substantial additional capability since. Reference this addendum for what's live as of April 2026; individual journeys below still describe the core mechanics correctly.
+
+### Canonical brand names (Session 47 rebrand — April 12, 2026)
+
+Replace older terms wherever they appear in this document with the canonical Session 47 names. See `docs/brand-assets/BRAND-LOCK.md` for the full naming framework.
+
+| Old term in this doc | Canonical name | Nav label |
+|----------------------|----------------|-----------|
+| Vacation Wishes / Travel Requests | **RAV Wishes** | "Make a Wish" |
+| Owner's Edge | **My Rentals** | "My Rentals" |
+| RAV Command | **RAV Insights** | "RAV Insights" |
+| Admin Dashboard | **RAV Ops** | "RAV Ops" |
+| Make an Offer (CTA) | **Make a RAV Offer** | — |
+| (new) | **RAV Deals** | "Browse RAV Deals" |
+
+### Major journeys added since v2.0
+
+| Journey / Feature | Route | Shipped | Notes |
+|-------------------|-------|---------|-------|
+| **Renter Dashboard** | `/my-trips` | Session 34 | 4 tabs: Overview, Bookings, Offers, Favorites + saved-search alerts |
+| **My Rentals (consolidated owner dashboard)** | `/owner-dashboard` | Session 33 | 11 tabs → 4 (Dashboard, My Listings, Bookings & Earnings, Account) |
+| **Pre-Booking Messaging ("Ask the Owner")** | PropertyDetail → Inquiry dialog | Session 34 | Inquiry threads before booking |
+| **Saved Searches + Price Drop Alerts** | `/rentals` → Save button | Session 34 | Notifies renter when matching listing drops in price |
+| **Destinations Explorer** | `/destinations`, `/destinations/:slug` | Session 34 | 10 destinations / 35 cities discovery |
+| **Cancellation Policy UI + Booking Timeline** | PropertyDetail, Checkout, MyBookings | Session 33 | 4-tier color-coded refund policy + 5-step timeline |
+| **Compare Properties** | `/rentals` → Compare toggle | Session 33 | Up to 3 listings side-by-side with "Best" badges |
+| **Dynamic Pricing** | Owner listing flow | Session 37 | Urgency/seasonal/demand adjustments on owner price suggestions |
+| **Referral Program** | `/owner-dashboard` → Account tab | Session 37 | Unique codes, signup attribution on `?ref=CODE` |
+| **Public API + Developer Portal** | `/developers` (public), `/admin` → API Keys | Session 38 | RESTful API, Swagger UI, IP allowlisting (CIDR) |
+| **RAV Smart Suite (5 free tools)** | `/tools` | Session 38-39 | SmartEarn, SmartPrice, SmartCompare, SmartMatch, SmartBudget |
+| **RAV Insights (executive dashboard)** | `/executive-dashboard` | earlier | Rebranded from "RAV Command" in Session 47 |
+| **Notification Center** | `/notifications`, `/settings/notifications` | Session 40 | Multi-channel (in-app, email, SMS) with TCPA opt-in, per-type preferences, seasonal event reminders, delivery log |
+| **Admin Property/Listing Editing + Resort Import** | `/admin` → Properties/Resorts tabs | Session 36 | CSV import with validation, audit-trail editing |
+| **Dispute Evidence Upload** | MyBookings/OwnerBookings → Report Issue | Session 36 | Role-aware categories, evidence thumbnails in RAV Ops |
+| **iCal Export** | `/owner-dashboard` → Bookings | Session 35 | RFC 5545 calendar export |
+| **Realtime Subscriptions** | Platform-wide | Session 34 | `useRealtimeSubscription` replaced all polling (notifications, messages, unread counts) |
+| **Voice Admin Controls (Tracks C-D)** | `/admin` → Voice tab | Session 16 | Tier/user overrides, observability dashboard, search log |
+| **RAV Deals (distressed inventory)** | `/deals` (planned nav) | Session 47 | New discovery surface for expiring weeks; feeds bidding |
+| **Multi-Year Event Generation** | `/admin` → Events | Session 48 | Curated events unified into DB with admin CRUD + multi-year generator |
+
+### Voice quota (corrected)
+
+The legacy "10/day per user" note below is superseded. Current quota is **tier-based**:
+- Free: 5/day
+- Plus / Pro: 25/day
+- Premium / Business: unlimited
+- RAV team: unlimited
+
+### SMS status
+
+SMS infrastructure (Twilio + `notification-dispatcher`, `sms-scheduler`, `twilio-webhook`) is deployed to DEV with `SMS_TEST_MODE=true`. Production SMS traffic is gated on A2P 10DLC registration, which is blocked on LLC/EIN (#127).
+
+### Numbers as of Session 48
+
+956 automated tests (121 files) · 97 P0 tests · 46 migrations · 30 edge functions · 117 resorts / 351 unit types · 48 sessions shipped in 19 months · 0 type errors / 0 lint errors / clean build.
+
+---
+
+## 🎯 Overview (Original v2.0 — still accurate for core flows)
 
 This document maps the complete user experience across all user types, features, and touchpoints on the Rent-A-Vacation platform.
 
 ### User Types Covered
 1. **Traveler** - Searching and booking vacation properties
 2. **Property Owner** - Listing and managing their vacation club properties
-3. **RAV Admin** - Platform administration and oversight
+3. **RAV Admin** - Platform administration and oversight (nav label: "RAV Ops")
 4. **RAV Staff** - Customer support and operations
-5. **RAV Owner** - Business owner and strategic decision maker
+5. **RAV Owner** - Business owner and strategic decision maker (nav label: "RAV Insights")
 
-### Features Mapped
+### Features Mapped (expanded in Session 48 Addendum above)
 - ✅ **Phase 1:** Voice Search (DEPLOYED)
 - ✅ **Phase 2:** Resort Master Data (DEPLOYED)
 - ✅ **Phase 4 Track A:** Voice Auth & Approval System (DEPLOYED)
   - Authentication gate on voice search
   - User approval system (signup → pending → approved/rejected)
-  - Voice usage limits (10/day per user, RAV team unlimited)
-- 🚀 **Phase 3:** Voice Everywhere (PLANNED Q2 2026)
+  - Voice usage limits — **tier-based** (see Session 48 addendum for current quotas)
+- ✅ **Voice Tracks C-D:** Admin controls + observability (Session 16)
+- ✅ **Phase 20:** Notification Center (Session 40)
+- ✅ **Session 47:** Brand architecture rebrand (see addendum)
 - 📊 **Analytics & Reporting** (ONGOING)
 - 🛡️ **Trust & Safety** (ONGOING)
 


### PR DESCRIPTION
## Summary
Two-commit doc PR closing out the Session 52 vocabulary lock across the brand & platform docs.

### Commit 1 — Session 47-48 refresh (your in-progress local edits)
Test counts, migration counts, edge function counts updated. New rows for Notification Center, Multi-Year Event Generation, Brand Architecture Rebrand. Pitch deck slides expanded with new features. Complete-User-Journey-Map gets a Session 48 addendum with all journeys added since v2.0 (Renter Dashboard, Pre-Booking Messaging, Saved Searches, Destinations, Cancellation UI, Compare Properties, Dynamic Pricing, Referral, Public API, RAV Smart Suite, Notification Center, RAV Deals, etc.).

### Commit 2 — Phase B terminology scrub
Layered the Session 52 vocabulary lock onto the refresh:
- **BRAND-STYLE-GUIDE.md** — Session 47 rebrand subsection replaced with Session 52 lock table; explicit naming-rule guidance + slogan note
- **MARKETING-PLAYBOOK.md** — two-sided engine description, brand hierarchy, content series, email sequence, campaign calendar all scrubbed; glossary feature row notes the full retirement chain
- **PITCH-DECK-SCRIPT.md** — Slide 5 capability list, Slide 6 traveler/owner journey, Slide 8 retitled "Wishes (Renter Open Call)", Slide 16 Q4 calendar, Slide 17 competitive moat row all updated; speaker notes refreshed
- **BRAND-CONCEPTS.md** — Section II.1 ("Wishes"), Section II.2 ("The Marketplace"), all CTA examples, three of five elevator pitches, taglines, hashtags, and Section VIII naming conventions completely rewritten with the new Always-Capitalize / Never lists
- **COMPLETE-USER-JOURNEY-MAP.md** — Session 48 Addendum extended to Session 52 with the canonical vocabulary table
- **LAUNCH-READINESS.md** — Session 47 brand row trimmed; new Session 52 rows added (Marketplace Terminology Lock + Site-wide UI Polish)

All occurrences of "RAV Wishes" / "Make a RAV Offer" / "Make a RAV Wish" remaining in these docs are now historical/retirement annotations only — no live canonical usage.

## Out of scope
- `docs/exports/__pycache__/generate_docx.cpython-312.pyc` (Python bytecode — left dirty in working dir; should be added to .gitignore in a separate cleanup PR)
- `docs/exports/RAV-Platform-Overview-04142026.{docx,md}` (generated export artifacts — left untracked)

## Test plan
- [x] No code changes
- [x] BRAND-LOCK Section 9 remains the canonical reference
- [ ] Skim MARKETING-PLAYBOOK Section 6 Brand Hierarchy and BRAND-CONCEPTS Section II to confirm the new copy reads cleanly
- [ ] Spot-check the pitch deck speaker notes for tone

🤖 Generated with [Claude Code](https://claude.com/claude-code)