### PR TITLE
fix(marketplace): #353 nicer name fallback + #354 MyBidsDashboard crash

### DIFF
--- a/src/components/bidding/BidsManagerDialog.tsx
+++ b/src/components/bidding/BidsManagerDialog.tsx
@@ -27,6 +27,7 @@ import {
 } from 'lucide-react';
 import { format, formatDistanceToNow } from 'date-fns';
 import type { BidOnListing } from '@/types/bidding';
+import { getRenterDisplayName } from '@/lib/displayName';
 
 interface BidsManagerDialogProps {
   listingId: string;
@@ -199,9 +200,18 @@ function BidCard({
   isUpdating,
   showActions = true 
 }: BidCardProps) {
-  const initials = bid.bidder?.full_name
-    ?.split(' ')
+  const bidderName = getRenterDisplayName({
+    fullName: bid.bidder?.full_name,
+    email: bid.bidder?.email,
+    userId: bid.bidder?.id ?? bid.bidder_id,
+  });
+  const initials = bidderName
+    .replace(/^(Renter|Owner|User)\s+/, '')
+    .replace(/^#/, '')
+    .split(/\s+/)
     .map((n) => n[0])
+    .filter(Boolean)
+    .slice(0, 2)
     .join('')
     .toUpperCase() || '?';
 
@@ -227,7 +237,7 @@ function BidCard({
 
           <div className="flex-1">
             <div className="flex items-center gap-2 mb-1">
-              <span className="font-medium">{bid.bidder?.full_name || 'Anonymous'}</span>
+              <span className="font-medium">{bidderName}</span>
               <Badge className={statusColors[bid.status]}>
                 {bid.status}
               </Badge>

--- a/src/components/bidding/TravelRequestCard.tsx
+++ b/src/components/bidding/TravelRequestCard.tsx
@@ -20,6 +20,7 @@ import {
 import { format, formatDistanceToNow, differenceInDays } from 'date-fns';
 import { ProposalFormDialog } from './ProposalFormDialog';
 import type { TravelRequestWithDetails } from '@/types/bidding';
+import { getRenterDisplayName } from '@/lib/displayName';
 
 interface TravelRequestCardProps {
   request: TravelRequestWithDetails;
@@ -51,9 +52,18 @@ export function TravelRequestCard({ request, showProposalButton = true }: Travel
     }
   };
 
-  const initials = request.traveler?.full_name
-    ?.split(' ')
+  const travelerName = getRenterDisplayName({
+    fullName: request.traveler?.full_name,
+    email: request.traveler?.email,
+    userId: request.traveler?.id ?? request.traveler_id,
+  });
+  const initials = travelerName
+    .replace(/^(Renter|Owner|User)\s+/, '')
+    .replace(/^#/, '')
+    .split(/\s+/)
     .map((n) => n[0])
+    .filter(Boolean)
+    .slice(0, 2)
     .join('')
     .toUpperCase() || '?';
 

--- a/src/hooks/owner/__tests__/useOwnerBidActivity.test.ts
+++ b/src/hooks/owner/__tests__/useOwnerBidActivity.test.ts
@@ -138,7 +138,8 @@ describe('useOwnerBidActivity', () => {
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
     expect(result.current.data![0].property_name).toBe('Unknown');
-    expect(result.current.data![0].traveler_initial).toBe('?');
+    // When bidder has no name/email/id, fallback is the role label "Renter" → initial "R"
+    expect(result.current.data![0].traveler_initial).toBe('R');
   });
 
   it('returns empty array when no bids', async () => {

--- a/src/hooks/owner/useOwnerBidActivity.ts
+++ b/src/hooks/owner/useOwnerBidActivity.ts
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { supabase } from '@/lib/supabase';
 import { useAuth } from '@/contexts/AuthContext';
+import { getRenterDisplayName } from '@/lib/displayName';
 import type { BidEvent } from '@/types/ownerDashboard';
 
 function mapBidStatus(status: string): BidEvent['event_type'] {
@@ -21,9 +22,9 @@ export function useOwnerBidActivity() {
       const { data, error } = await supabase
         .from('listing_bids')
         .select(`
-          id, listing_id, bid_amount, status, created_at,
+          id, listing_id, bidder_id, bid_amount, status, created_at,
           listing:listings!inner(owner_id, property:properties!inner(resort_name)),
-          bidder:profiles!listing_bids_bidder_id_fkey(full_name)
+          bidder:profiles!listing_bids_bidder_id_fkey(id, full_name, email)
         `)
         .eq('listing.owner_id', user!.id)
         .order('created_at', { ascending: false })
@@ -33,15 +34,26 @@ export function useOwnerBidActivity() {
       if (!data) return [];
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      return data.map((bid: any) => ({
-        id: bid.id,
-        listing_id: bid.listing_id,
-        property_name: bid.listing?.property?.resort_name || 'Unknown',
-        event_type: mapBidStatus(bid.status),
-        amount: bid.bid_amount,
-        traveler_initial: bid.bidder?.full_name?.[0]?.toUpperCase() || '?',
-        created_at: bid.created_at,
-      }));
+      return data.map((bid: any) => {
+        const name = getRenterDisplayName({
+          fullName: bid.bidder?.full_name,
+          email: bid.bidder?.email,
+          userId: bid.bidder?.id ?? bid.bidder_id,
+        });
+        return {
+          id: bid.id,
+          listing_id: bid.listing_id,
+          property_name: bid.listing?.property?.resort_name || 'Unknown',
+          event_type: mapBidStatus(bid.status),
+          amount: bid.bid_amount,
+          traveler_initial: name
+            .replace(/^(Renter|Owner|User)\s+/, '')
+            .replace(/^#/, '')
+            .charAt(0)
+            .toUpperCase() || '?',
+          created_at: bid.created_at,
+        };
+      });
     },
     enabled: !!user?.id,
     staleTime: 2 * 60 * 1000,

--- a/src/lib/displayName.test.ts
+++ b/src/lib/displayName.test.ts
@@ -1,0 +1,85 @@
+// @p0
+import { describe, it, expect } from "vitest";
+import {
+  getDisplayName,
+  getRenterDisplayName,
+  getOwnerDisplayName,
+} from "./displayName";
+
+describe("getDisplayName", () => {
+  it("returns fullName when set", () => {
+    expect(getDisplayName({ fullName: "Jane Doe" })).toBe("Jane Doe");
+  });
+
+  it("trims whitespace-only fullName and falls through", () => {
+    expect(
+      getDisplayName({ fullName: "   ", email: "jane.doe@example.com", role: "Renter" }),
+    ).toBe("Renter Jane D.");
+  });
+
+  it("builds name + last initial from email local-part with dot", () => {
+    expect(
+      getDisplayName({ email: "jane.doe@example.com", role: "Renter" }),
+    ).toBe("Renter Jane D.");
+  });
+
+  it("handles underscore-separated email local-part", () => {
+    expect(
+      getDisplayName({ email: "jane_smith@example.com", role: "Owner" }),
+    ).toBe("Owner Jane S.");
+  });
+
+  it("capitalizes single-token email local-part", () => {
+    expect(
+      getDisplayName({ email: "jane@example.com", role: "Renter" }),
+    ).toBe("Renter Jane");
+  });
+
+  it("falls back to user id tail when email is missing", () => {
+    expect(
+      getDisplayName({ userId: "abc12345-dead-beef-cafe-000000000001", role: "Renter" }),
+    ).toBe("Renter #abc123");
+  });
+
+  it("strips dashes before slicing id", () => {
+    expect(
+      getDisplayName({ userId: "a1-b2-c3-d4-e5", role: "Renter" }),
+    ).toBe("Renter #a1b2c3");
+  });
+
+  it("returns role alone when nothing else is available", () => {
+    expect(getDisplayName({ role: "Renter" })).toBe("Renter");
+  });
+
+  it("defaults role to User when not provided", () => {
+    expect(getDisplayName({ userId: "abc123" })).toBe("User #abc123");
+  });
+
+  it("getRenterDisplayName delegates with Renter role", () => {
+    expect(
+      getRenterDisplayName({ email: "pat.kim@example.com" }),
+    ).toBe("Renter Pat K.");
+  });
+
+  it("getOwnerDisplayName delegates with Owner role", () => {
+    expect(
+      getOwnerDisplayName({ fullName: null, userId: "xxxxxxxxxxxx" }),
+    ).toBe("Owner #xxxxxx");
+  });
+
+  it("prefers fullName even when email + id also set", () => {
+    expect(
+      getDisplayName({
+        fullName: "Sam Rivera",
+        email: "sam@example.com",
+        userId: "abc",
+      }),
+    ).toBe("Sam Rivera");
+  });
+
+  it("handles email with no local-part tokens (e.g. '@x.com')", () => {
+    expect(
+      getDisplayName({ email: "@example.com", userId: "abc123def", role: "Renter" }),
+    ).toBe("Renter #abc123");
+  });
+});

--- a/src/lib/displayName.ts
+++ b/src/lib/displayName.ts
@@ -1,0 +1,75 @@
+/**
+ * Display-name utilities for user-facing labels when a profile's
+ * `full_name` is missing. Used across bid/offer and messaging surfaces
+ * so we never show a literal "Anonymous" or an empty string.
+ *
+ * Priority:
+ *  1. If `full_name` is set and non-empty → return it
+ *  2. Else if email is available → "Renter J.D." (first + last initials)
+ *     or "Renter j***@example.com" as a safer alternative
+ *  3. Else if user id is available → "Renter #a1b2c3"
+ *  4. Else → the provided `role` prefix alone (e.g. "Renter")
+ */
+
+export type RoleLabel = "Renter" | "Owner" | "User";
+
+interface DisplayNameInput {
+  fullName?: string | null;
+  email?: string | null;
+  userId?: string | null;
+  role?: RoleLabel;
+}
+
+/**
+ * Build a human-readable display name with a role prefix when the profile
+ * does not have `full_name` populated.
+ */
+export function getDisplayName({
+  fullName,
+  email,
+  userId,
+  role = "User",
+}: DisplayNameInput): string {
+  const trimmed = fullName?.trim();
+  if (trimmed) return trimmed;
+
+  // Try to construct initials from an email local-part like "jane.doe@x.com"
+  // → "Jane D." · "j.doe" → "J. D." · single-name → capitalized first word
+  if (email && email.includes("@")) {
+    const local = email.split("@")[0] ?? "";
+    const tokens = local
+      .split(/[._\-+]/)
+      .map((t) => t.trim())
+      .filter(Boolean);
+
+    if (tokens.length >= 2) {
+      const first = capitalize(tokens[0]);
+      const lastInitial = (tokens[tokens.length - 1][0] ?? "").toUpperCase();
+      return `${role} ${first} ${lastInitial}.`;
+    }
+    if (tokens.length === 1 && tokens[0]) {
+      return `${role} ${capitalize(tokens[0])}`;
+    }
+  }
+
+  if (userId) {
+    const tail = userId.replace(/-/g, "").slice(0, 6);
+    if (tail) return `${role} #${tail}`;
+  }
+
+  return role;
+}
+
+/**
+ * Convenience helpers — avoids passing `role` at every call site.
+ */
+export const getRenterDisplayName = (input: Omit<DisplayNameInput, "role">) =>
+  getDisplayName({ ...input, role: "Renter" });
+
+export const getOwnerDisplayName = (input: Omit<DisplayNameInput, "role">) =>
+  getDisplayName({ ...input, role: "Owner" });
+
+function capitalize(word: string): string {
+  if (!word) return "";
+  return word[0].toUpperCase() + word.slice(1).toLowerCase();
+}

--- a/src/lib/formatDateSafe.test.ts
+++ b/src/lib/formatDateSafe.test.ts
@@ -1,0 +1,34 @@
+// @p0
+import { describe, it, expect } from "vitest";
+import { formatDateSafe } from "./formatDateSafe";
+
+describe("formatDateSafe", () => {
+  it("formats a valid ISO string", () => {
+    // Use explicit local-midnight parsing to avoid TZ shift on date-only inputs.
+    expect(formatDateSafe("2026-04-15T12:00:00", "yyyy-MM-dd")).toBe("2026-04-15");
+  });
+
+  it("formats a Date instance", () => {
+    expect(formatDateSafe(new Date(2026, 3, 15, 12, 0, 0), "yyyy")).toBe("2026");
+  });
+
+  it("returns fallback for null", () => {
+    expect(formatDateSafe(null, "MMM d")).toBe("—");
+  });
+
+  it("returns fallback for undefined", () => {
+    expect(formatDateSafe(undefined, "MMM d")).toBe("—");
+  });
+
+  it("returns fallback for empty string", () => {
+    expect(formatDateSafe("", "MMM d")).toBe("—");
+  });
+
+  it("returns fallback for an unparseable string (does not throw)", () => {
+    expect(formatDateSafe("not-a-date", "MMM d")).toBe("—");
+  });
+
+  it("uses a custom fallback when provided", () => {
+    expect(formatDateSafe(null, "MMM d", "Dates TBD")).toBe("Dates TBD");
+  });
+});

--- a/src/lib/formatDateSafe.ts
+++ b/src/lib/formatDateSafe.ts
@@ -1,0 +1,21 @@
+import { format, isValid } from "date-fns";
+
+/**
+ * Safely format a date-like input. If the value is null/undefined, empty,
+ * or fails to parse into a valid Date, returns the provided fallback
+ * (default: `"—"`) instead of throwing.
+ *
+ * Use this anywhere a database column may be null or a relation may be
+ * missing (e.g., a bid whose parent listing has no dates set yet, a
+ * proposal with an unset `valid_until`).
+ */
+export function formatDateSafe(
+  value: string | Date | null | undefined,
+  pattern: string,
+  fallback = "—",
+): string {
+  if (!value) return fallback;
+  const date = value instanceof Date ? value : new Date(value);
+  if (!isValid(date)) return fallback;
+  return format(date, pattern);
+}

--- a/src/pages/MyBidsDashboard.tsx
+++ b/src/pages/MyBidsDashboard.tsx
@@ -49,6 +49,7 @@ import {
   ThumbsDown,
 } from 'lucide-react';
 import { format, formatDistanceToNow } from 'date-fns';
+import { formatDateSafe } from '@/lib/formatDateSafe';
 import type { TravelRequest, TravelProposalWithDetails } from '@/types/bidding';
 
 const STATUS_COLORS = {
@@ -160,8 +161,14 @@ const MyBidsDashboard = ({ embedded }: { embedded?: boolean }) => {
                             <div className="flex flex-wrap items-center gap-2 sm:gap-4 mt-2 text-sm">
                               <span className="flex items-center gap-1">
                                 <Calendar className="h-3 w-3" />
-                                {format(new Date(bid.listing?.check_in_date || ''), 'MMM d')} -
-                                {format(new Date(bid.listing?.check_out_date || ''), 'MMM d, yyyy')}
+                                {bid.listing?.check_in_date && bid.listing?.check_out_date ? (
+                                  <>
+                                    {formatDateSafe(bid.listing.check_in_date, 'MMM d')} -{' '}
+                                    {formatDateSafe(bid.listing.check_out_date, 'MMM d, yyyy')}
+                                  </>
+                                ) : (
+                                  <span className="text-muted-foreground">Dates TBD</span>
+                                )}
                               </span>
                             </div>
                           </div>
@@ -332,8 +339,8 @@ const MyBidsDashboard = ({ embedded }: { embedded?: boolean }) => {
                             <div className="flex flex-wrap items-center gap-2 sm:gap-4 mt-2 text-sm text-muted-foreground">
                               <span className="flex items-center gap-1">
                                 <Calendar className="h-3 w-3" />
-                                {format(new Date(request.check_in_date), 'MMM d')} -
-                                {format(new Date(request.check_out_date), 'MMM d, yyyy')}
+                                {formatDateSafe(request.check_in_date, 'MMM d')} -{' '}
+                                {formatDateSafe(request.check_out_date, 'MMM d, yyyy')}
                               </span>
                               <span>{request.guest_count} guests</span>
                               <span>{request.bedrooms_needed} BR</span>
@@ -437,10 +444,10 @@ function ProposalsDialog({ request, open, onOpenChange }: ProposalsDialogProps) 
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-w-[95vw] sm:max-w-2xl max-h-[80vh] overflow-y-auto">
         <DialogHeader>
-          <DialogTitle>Proposals for {request.destination_location}</DialogTitle>
+          <DialogTitle>Offers for {request.destination_location}</DialogTitle>
           <DialogDescription>
-            {format(new Date(request.check_in_date), 'MMM d')} - 
-            {format(new Date(request.check_out_date), 'MMM d, yyyy')}
+            {formatDateSafe(request.check_in_date, 'MMM d')} -{' '}
+            {formatDateSafe(request.check_out_date, 'MMM d, yyyy')}
           </DialogDescription>
         </DialogHeader>
 
@@ -485,12 +492,12 @@ function ProposalsDialog({ request, open, onOpenChange }: ProposalsDialogProps) 
                       )}
                     </div>
                     <div className="text-right">
-                      <p className="text-sm text-muted-foreground">Proposed price</p>
+                      <p className="text-sm text-muted-foreground">Offer price</p>
                       <p className="text-2xl font-bold text-primary">
                         ${proposal.proposed_price.toLocaleString()}
                       </p>
                       <p className="text-xs text-muted-foreground mt-1">
-                        Valid until {format(new Date(proposal.valid_until), 'MMM d')}
+                        Valid until {formatDateSafe(proposal.valid_until, 'MMM d')}
                       </p>
                     </div>
                   </div>


### PR DESCRIPTION
## Summary
Two pre-launch marketplace bug fixes shipped together.

### #354 — Renter \`/my-trips?tab=offers\` crash
Root cause (Sentry-confirmed at MyBidsDashboard.tsx:163): \`format(new Date(bid.listing?.check_in_date || ''))\` throws on Invalid Date when a bid's parent listing has no dates. New \`formatDateSafe\` util returns \`'—'\` (or caller fallback) instead of throwing. Renders \"Dates TBD\" placeholder when the listing date pair is entirely missing.

### #353 — Owner sees bidder as \"Anonymous\"
Root cause: bidder profile has \`full_name = NULL\`. New \`getRenterDisplayName\` util builds a readable fallback from email local-part (e.g. \"Renter Jane D.\") or user id tail (e.g. \"Renter #abc123\"). Applied to BidsManagerDialog, TravelRequestCard, and the owner dashboard activity feed.

### Small bonus
Two stray Session-47-era strings caught in the same file: \"Proposals for X\" dialog title and \"Proposed price\" label → \"Offers for X\" / \"Offer price\" per the Session 52 terminology lock.

## Test plan
- [x] \`npm run test\` — 1066 tests passing (+20 new)
- [x] \`npx tsc --noEmit\` — clean
- [x] \`npm run build\` — clean
- [ ] Visual QA: log in as renter with a bid on a deleted/dateless listing → \`/my-trips?tab=offers\` no longer crashes
- [ ] Visual QA: log in as owner → review bids on a listing → names render as \"Renter Jane D.\" style, never \"Anonymous\"

Closes #353, #354

🤖 Generated with [Claude Code](https://claude.com/claude-code)