### PR TITLE
feat(api): WS3 — MDM resort API with delta sync, brand filter, external ID lookup

### DIFF
--- a/docs/api/public-api.yaml
+++ b/docs/api/public-api.yaml
@@ -242,13 +242,51 @@ paths:
     get:
       operationId: listResorts
       tags: [Destinations]
-      summary: Browse resort directory
+      summary: Browse MDM-enriched resort directory
       description: |
-        Paginated resort listing with unit types.
+        Paginated resort directory with full MDM-enriched records including
+        location coordinates, data quality scores, policies, amenities,
+        attraction tags, and nested unit types with OTA-standard fields.
+
+        By default, only active resorts are returned. Use `include_inactive=true`
+        to include deprecated resorts.
+
+        Supports delta sync via `updated_since` for efficient polling.
       security:
         - ApiKeyAuth: []
         - BearerAuth: []
       parameters:
+        - name: brand
+          in: query
+          schema:
+            type: string
+            enum:
+              - hilton_grand_vacations
+              - marriott_vacation_club
+              - disney_vacation_club
+              - wyndham_destinations
+              - hyatt_residence_club
+              - bluegreen_vacations
+              - holiday_inn_club
+              - worldmark
+              - other
+          description: Filter by vacation club brand (OTA ChainCode equivalent)
+        - name: updated_since
+          in: query
+          schema:
+            type: string
+            format: date-time
+          description: |
+            Return only resorts updated after this ISO 8601 timestamp.
+            Use for delta sync — store the `updated_at` from your last sync
+            and pass it here on subsequent calls.
+          example: "2026-01-01T00:00:00Z"
+        - name: include_inactive
+          in: query
+          schema:
+            type: boolean
+            default: false
+          description: Include inactive/deprecated resorts (default false)
         - name: page
           in: query
           schema:
@@ -262,11 +300,60 @@ paths:
             maximum: 50
       responses:
         '200':
-          description: Resort list
+          description: Resort list with full MDM-enriched records
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ResortsResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+  /v1/resorts/by-external-id:
+    get:
+      operationId: getResortByExternalId
+      tags: [Destinations]
+      summary: Look up a RAV resort by partner system ID
+      description: |
+        Maps an external system's resort identifier to the RAV golden record.
+        Use this to integrate partner resort IDs (e.g. XPD, OTA aggregator codes)
+        without maintaining a local cross-reference table.
+      security:
+        - ApiKeyAuth: []
+        - BearerAuth: []
+      parameters:
+        - name: system
+          in: query
+          required: true
+          schema:
+            type: string
+          description: Partner system name (e.g. 'xpd', 'expedia')
+          example: "xpd"
+        - name: id
+          in: query
+          required: true
+          schema:
+            type: string
+          description: The partner's resort ID
+          example: "XPD-12345"
+      responses:
+        '200':
+          description: Matching resort record
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SingleResortResponse'
+        '400':
+          description: Missing system or id parameter
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: No resort found for this external ID
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '401':
           $ref: '#/components/responses/Unauthorized'
 
@@ -466,10 +553,99 @@ components:
         api_version:
           type: string
 
-    ResortsResponse:
+    ResortObject:
       type: object
       properties:
-        data:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+          description: "OTA: HotelName"
+        brand:
+          type: string
+          description: "OTA: ChainCode"
+        description:
+          type: string
+          description: "OTA: HotelDescriptiveText"
+        is_active:
+          type: boolean
+        location:
+          type: object
+          properties:
+            address:
+              type: string
+              description: "OTA: AddressLine"
+            city:
+              type: string
+              description: "OTA: CityName"
+            state:
+              type: string
+              description: "OTA: StateProv (ISO 3166-2 subdivision)"
+            country:
+              type: string
+              description: "OTA: CountryName (ISO 3166-1 alpha-2)"
+            postal_code:
+              type: string
+              description: "OTA: PostalCode"
+            latitude:
+              type: number
+              format: double
+              description: "OTA: Latitude (WGS 84)"
+            longitude:
+              type: number
+              format: double
+              description: "OTA: Longitude (WGS 84)"
+        amenities:
+          type: array
+          items:
+            type: string
+          description: "OTA: HotelAmenity"
+        attraction_tags:
+          type: array
+          items:
+            type: string
+        policies:
+          type: object
+          properties:
+            check_in:
+              type: string
+              description: "OTA: CheckInTime (24h format)"
+            check_out:
+              type: string
+              description: "OTA: CheckOutTime (24h format)"
+            pets:
+              type: string
+              description: "OTA: PetPolicy"
+            parking:
+              type: string
+              description: "OTA: ParkingPolicy"
+        nearby_airports:
+          type: array
+          items:
+            type: string
+        guest_rating:
+          type: number
+          description: Guest satisfaction rating (0-5)
+        data_quality_score:
+          type: number
+          description: Data completeness score (0-100)
+        updated_at:
+          type: string
+          format: date-time
+        rating:
+          type: number
+          description: "Backward compat alias for guest_rating"
+          deprecated: true
+        city:
+          type: string
+          description: "Backward compat — use location.city instead"
+          deprecated: true
+        state:
+          type: string
+          description: "Backward compat — use location.state instead"
+          deprecated: true
+        unit_types:
           type: array
           items:
             type: object
@@ -479,27 +655,49 @@ components:
                 format: uuid
               name:
                 type: string
-              brand:
-                type: string
-              rating:
+                description: "OTA: RoomType"
+              bedrooms:
+                type: integer
+                description: "OTA: Bedrooms"
+              bathrooms:
                 type: number
-              city:
+              max_occupancy:
+                type: integer
+                description: "OTA: MaxOccupancy"
+              square_footage:
+                type: integer
+                description: "OTA: Size"
+              kitchen_type:
                 type: string
-              state:
-                type: string
-              unit_types:
+                description: "OTA: KitchenType"
+              amenities:
                 type: array
                 items:
-                  type: object
-                  properties:
-                    name:
-                      type: string
-                    bedrooms:
-                      type: integer
-                    max_occupancy:
-                      type: integer
+                  type: string
+              min_stay_nights:
+                type: integer
+                description: "OTA: MinimumStay"
+              smoking_policy:
+                type: string
+                description: "OTA: SmokingPolicy"
+
+    ResortsResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/ResortObject'
         meta:
           $ref: '#/components/schemas/PaginationMeta'
+        api_version:
+          type: string
+
+    SingleResortResponse:
+      type: object
+      properties:
+        data:
+          $ref: '#/components/schemas/ResortObject'
         api_version:
           type: string
 

--- a/docs/features/mdm-resort-data/normalisation-log.md
+++ b/docs/features/mdm-resort-data/normalisation-log.md
@@ -1,20 +1,20 @@
 ---
-last_updated: "2026-04-16T02:25:57"
-change_ref: "799fb78"
+last_updated: "2026-04-16T03:21:09"
+change_ref: "da92789"
 change_type: "manual-edit"
 status: "active"
 ---
 
 # Normalisation Log
 
-> Generated: 2026-04-16T02:21:48.088Z
-> Mode: DRY-RUN
+> Generated: 2026-04-16T03:06:52.366Z
+> Mode: APPLIED
 
 ## Summary
 
-- 439 field changes identified (dry-run)
-- 0 records with null data_source would be patched
-- 117 quality scores computed (dry-run)
+- 439 field changes applied
+- 0 records with null data_source patched
+- 117 quality scores written
 
 ## Changes
 

--- a/public/api/public-api.yaml
+++ b/public/api/public-api.yaml
@@ -242,13 +242,51 @@ paths:
     get:
       operationId: listResorts
       tags: [Destinations]
-      summary: Browse resort directory
+      summary: Browse MDM-enriched resort directory
       description: |
-        Paginated resort listing with unit types.
+        Paginated resort directory with full MDM-enriched records including
+        location coordinates, data quality scores, policies, amenities,
+        attraction tags, and nested unit types with OTA-standard fields.
+
+        By default, only active resorts are returned. Use `include_inactive=true`
+        to include deprecated resorts.
+
+        Supports delta sync via `updated_since` for efficient polling.
       security:
         - ApiKeyAuth: []
         - BearerAuth: []
       parameters:
+        - name: brand
+          in: query
+          schema:
+            type: string
+            enum:
+              - hilton_grand_vacations
+              - marriott_vacation_club
+              - disney_vacation_club
+              - wyndham_destinations
+              - hyatt_residence_club
+              - bluegreen_vacations
+              - holiday_inn_club
+              - worldmark
+              - other
+          description: Filter by vacation club brand (OTA ChainCode equivalent)
+        - name: updated_since
+          in: query
+          schema:
+            type: string
+            format: date-time
+          description: |
+            Return only resorts updated after this ISO 8601 timestamp.
+            Use for delta sync — store the `updated_at` from your last sync
+            and pass it here on subsequent calls.
+          example: "2026-01-01T00:00:00Z"
+        - name: include_inactive
+          in: query
+          schema:
+            type: boolean
+            default: false
+          description: Include inactive/deprecated resorts (default false)
         - name: page
           in: query
           schema:
@@ -262,11 +300,60 @@ paths:
             maximum: 50
       responses:
         '200':
-          description: Resort list
+          description: Resort list with full MDM-enriched records
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ResortsResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+  /v1/resorts/by-external-id:
+    get:
+      operationId: getResortByExternalId
+      tags: [Destinations]
+      summary: Look up a RAV resort by partner system ID
+      description: |
+        Maps an external system's resort identifier to the RAV golden record.
+        Use this to integrate partner resort IDs (e.g. XPD, OTA aggregator codes)
+        without maintaining a local cross-reference table.
+      security:
+        - ApiKeyAuth: []
+        - BearerAuth: []
+      parameters:
+        - name: system
+          in: query
+          required: true
+          schema:
+            type: string
+          description: Partner system name (e.g. 'xpd', 'expedia')
+          example: "xpd"
+        - name: id
+          in: query
+          required: true
+          schema:
+            type: string
+          description: The partner's resort ID
+          example: "XPD-12345"
+      responses:
+        '200':
+          description: Matching resort record
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SingleResortResponse'
+        '400':
+          description: Missing system or id parameter
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: No resort found for this external ID
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '401':
           $ref: '#/components/responses/Unauthorized'
 
@@ -466,10 +553,99 @@ components:
         api_version:
           type: string
 
-    ResortsResponse:
+    ResortObject:
       type: object
       properties:
-        data:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+          description: "OTA: HotelName"
+        brand:
+          type: string
+          description: "OTA: ChainCode"
+        description:
+          type: string
+          description: "OTA: HotelDescriptiveText"
+        is_active:
+          type: boolean
+        location:
+          type: object
+          properties:
+            address:
+              type: string
+              description: "OTA: AddressLine"
+            city:
+              type: string
+              description: "OTA: CityName"
+            state:
+              type: string
+              description: "OTA: StateProv (ISO 3166-2 subdivision)"
+            country:
+              type: string
+              description: "OTA: CountryName (ISO 3166-1 alpha-2)"
+            postal_code:
+              type: string
+              description: "OTA: PostalCode"
+            latitude:
+              type: number
+              format: double
+              description: "OTA: Latitude (WGS 84)"
+            longitude:
+              type: number
+              format: double
+              description: "OTA: Longitude (WGS 84)"
+        amenities:
+          type: array
+          items:
+            type: string
+          description: "OTA: HotelAmenity"
+        attraction_tags:
+          type: array
+          items:
+            type: string
+        policies:
+          type: object
+          properties:
+            check_in:
+              type: string
+              description: "OTA: CheckInTime (24h format)"
+            check_out:
+              type: string
+              description: "OTA: CheckOutTime (24h format)"
+            pets:
+              type: string
+              description: "OTA: PetPolicy"
+            parking:
+              type: string
+              description: "OTA: ParkingPolicy"
+        nearby_airports:
+          type: array
+          items:
+            type: string
+        guest_rating:
+          type: number
+          description: Guest satisfaction rating (0-5)
+        data_quality_score:
+          type: number
+          description: Data completeness score (0-100)
+        updated_at:
+          type: string
+          format: date-time
+        rating:
+          type: number
+          description: "Backward compat alias for guest_rating"
+          deprecated: true
+        city:
+          type: string
+          description: "Backward compat — use location.city instead"
+          deprecated: true
+        state:
+          type: string
+          description: "Backward compat — use location.state instead"
+          deprecated: true
+        unit_types:
           type: array
           items:
             type: object
@@ -479,27 +655,49 @@ components:
                 format: uuid
               name:
                 type: string
-              brand:
-                type: string
-              rating:
+                description: "OTA: RoomType"
+              bedrooms:
+                type: integer
+                description: "OTA: Bedrooms"
+              bathrooms:
                 type: number
-              city:
+              max_occupancy:
+                type: integer
+                description: "OTA: MaxOccupancy"
+              square_footage:
+                type: integer
+                description: "OTA: Size"
+              kitchen_type:
                 type: string
-              state:
-                type: string
-              unit_types:
+                description: "OTA: KitchenType"
+              amenities:
                 type: array
                 items:
-                  type: object
-                  properties:
-                    name:
-                      type: string
-                    bedrooms:
-                      type: integer
-                    max_occupancy:
-                      type: integer
+                  type: string
+              min_stay_nights:
+                type: integer
+                description: "OTA: MinimumStay"
+              smoking_policy:
+                type: string
+                description: "OTA: SmokingPolicy"
+
+    ResortsResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/ResortObject'
         meta:
           $ref: '#/components/schemas/PaginationMeta'
+        api_version:
+          type: string
+
+    SingleResortResponse:
+      type: object
+      properties:
+        data:
+          $ref: '#/components/schemas/ResortObject'
         api_version:
           type: string
 

--- a/supabase/functions/api-gateway/index.ts
+++ b/supabase/functions/api-gateway/index.ts
@@ -43,6 +43,11 @@ const routes: Record<string, RouteConfig> = {
     scope: "listings:read",
     handler: handleResorts,
   },
+  "GET /v1/resorts/by-external-id": {
+    method: "GET",
+    scope: "listings:read",
+    handler: handleResortByExternalId,
+  },
 };
 
 // ─── Main handler ───────────────────────────────────────────────────────────
@@ -180,6 +185,15 @@ function matchRoute(
   const exactKey = `${method} ${normalizedPath}`;
   if (routes[exactKey]) {
     return { handler: routes[exactKey].handler, scope: routes[exactKey].scope, matchedPath: normalizedPath };
+  }
+
+  // Try sub-path exact matches (e.g. /v1/resorts/by-external-id)
+  // These must be checked before parameterized matches
+  for (const [key, config] of Object.entries(routes)) {
+    const [routeMethod, routePath] = key.split(" ", 2);
+    if (routeMethod === method && routePath === normalizedPath) {
+      return { handler: config.handler, scope: config.scope, matchedPath: normalizedPath };
+    }
   }
 
   // Try parameterized match: /v1/listings/:id
@@ -418,8 +432,73 @@ async function handleDestinations(
   });
 }
 
+// ── Resort response transform (shared by /v1/resorts and /v1/resorts/by-external-id)
+
+// deno-lint-ignore no-explicit-any
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function transformResort(r: any) {
+  return {
+    id: r.id,
+    name: r.resort_name,                        // OTA: HotelName
+    brand: r.brand,                              // OTA: ChainCode
+    description: r.description,                  // OTA: HotelDescriptiveText
+    is_active: r.is_active,
+    location: {
+      address: r.location?.full_address || null, // OTA: AddressLine
+      city: r.location?.city,                    // OTA: CityName
+      state: r.location?.state,                  // OTA: StateProv
+      country: r.location?.country,              // OTA: CountryName (ISO 3166-1 alpha-2)
+      postal_code: r.postal_code,                // OTA: PostalCode
+      latitude: r.latitude,                      // OTA: Latitude
+      longitude: r.longitude,                    // OTA: Longitude
+    },
+    amenities: r.resort_amenities || [],          // OTA: HotelAmenity
+    attraction_tags: r.attraction_tags || [],
+    policies: {
+      check_in: r.policies?.check_in || null,    // OTA: CheckInTime
+      check_out: r.policies?.check_out || null,  // OTA: CheckOutTime
+      pets: r.policies?.pets || null,            // OTA: PetPolicy
+      parking: r.policies?.parking || null,      // OTA: ParkingPolicy
+    },
+    nearby_airports: r.nearby_airports || [],
+    guest_rating: r.guest_rating,
+    data_quality_score: r.data_quality_score,
+    updated_at: r.updated_at,
+    // Backward compat: keep flat fields old clients may depend on
+    rating: r.guest_rating,
+    city: r.location?.city,
+    state: r.location?.state,
+    country: r.location?.country,
+    // Unit types
+    unit_types: (r.resort_unit_types || []).map((ut: Record<string, unknown>) => ({
+      id: ut.id,
+      name: ut.unit_type_name,                   // OTA: RoomType
+      bedrooms: ut.bedrooms,                     // OTA: Bedrooms
+      bathrooms: ut.bathrooms,
+      max_occupancy: ut.max_occupancy,           // OTA: MaxOccupancy
+      square_footage: ut.square_footage,         // OTA: Size
+      kitchen_type: ut.kitchen_type,             // OTA: KitchenType
+      amenities: ut.unit_amenities || [],
+      min_stay_nights: ut.min_stay_nights,       // OTA: MinimumStay
+      smoking_policy: ut.smoking_policy,         // OTA: SmokingPolicy
+    })),
+  };
+}
+
+const RESORT_SELECT = `
+  id, resort_name, brand, description, location,
+  latitude, longitude, postal_code,
+  resort_amenities, attraction_tags, policies, nearby_airports,
+  guest_rating, data_quality_score, is_active, updated_at,
+  resort_unit_types (
+    id, unit_type_name, bedrooms, bathrooms, max_occupancy,
+    square_footage, kitchen_type, unit_amenities, min_stay_nights, smoking_policy
+  )
+`;
+
 /**
- * GET /v1/resorts — Resort directory with pagination
+ * GET /v1/resorts — Resort directory with full MDM-enriched records
+ * Supports: ?brand=, ?updated_since=, ?include_inactive=true, pagination
  */
 async function handleResorts(
   _req: Request,
@@ -427,41 +506,78 @@ async function handleResorts(
   url: URL
 ): Promise<Response> {
   const { page, perPage, offset } = parsePagination(url);
+  const brand = url.searchParams.get("brand");
+  const updatedSince = url.searchParams.get("updated_since");
+  const includeInactive = url.searchParams.get("include_inactive") === "true";
 
-  const { data, error, count } = await supabase
+  let query = supabase
     .from("resorts")
-    .select(`
-      id,
-      name,
-      brand,
-      rating,
-      amenities,
-      address,
-      city,
-      state,
-      country,
-      unit_types (
-        id,
-        name,
-        bedrooms,
-        bathrooms,
-        max_occupancy,
-        square_footage
-      )
-    `, { count: "exact" })
-    .order("name")
-    .range(offset, offset + perPage - 1);
+    .select(RESORT_SELECT, { count: "exact" });
+
+  if (!includeInactive) query = query.eq("is_active", true);
+  if (brand) query = query.eq("brand", brand);
+  if (updatedSince) query = query.gte("updated_at", updatedSince);
+
+  query = query.order("resort_name").range(offset, offset + perPage - 1);
+
+  const { data, error, count } = await query;
 
   if (error) {
     console.error("[API-GATEWAY] Resorts query error:", error);
     return apiError("query_error", error.message, 500);
   }
 
+  const transformed = (data || []).map(transformResort);
   const totalCount = count ?? 0;
-  return apiSuccess(data, {
+  return apiSuccess(transformed, {
     page,
     per_page: perPage,
     total_count: totalCount,
     total_pages: Math.ceil(totalCount / perPage),
   });
+}
+
+/**
+ * GET /v1/resorts/by-external-id?system=xpd&id=XPD-12345
+ * Maps an external partner resort ID to the RAV golden record.
+ */
+async function handleResortByExternalId(
+  _req: Request,
+  supabase: ReturnType<typeof createClient>,
+  url: URL
+): Promise<Response> {
+  const system = url.searchParams.get("system");
+  const externalId = url.searchParams.get("id");
+
+  if (!system || !externalId) {
+    return apiError("invalid_request", "Both 'system' and 'id' query parameters are required.", 400);
+  }
+
+  const { data: mapping, error: mapErr } = await supabase
+    .from("resort_external_ids")
+    .select("resort_id")
+    .eq("system_name", system)
+    .eq("external_id", externalId)
+    .maybeSingle();
+
+  if (mapErr) {
+    console.error("[API-GATEWAY] External ID lookup error:", mapErr);
+    return apiError("query_error", mapErr.message, 500);
+  }
+
+  if (!mapping) {
+    return apiError("not_found", `No resort found for ${system}:${externalId}`, 404);
+  }
+
+  const { data: resort, error: rErr } = await supabase
+    .from("resorts")
+    .select(RESORT_SELECT)
+    .eq("id", mapping.resort_id)
+    .single();
+
+  if (rErr || !resort) {
+    return apiError("not_found", "Resort record not found", 404);
+  }
+
+  return apiSuccess(transformResort(resort));
 }


### PR DESCRIPTION
## Summary
Final workstream (WS3) of the MDM resort data initiative. Extends the public resort API with full MDM-enriched records and partner-friendly features.

### What changed (api-gateway edge function)
- **GET /v1/resorts** — now returns full MDM record: description, lat/lng, postal_code, amenities, attraction_tags, policies, guest_rating, data_quality_score, is_active, updated_at + nested unit types with min_stay_nights, smoking_policy, kitchen_type
- **New filter: ?brand=** — filter by vacation club brand enum
- **New filter: ?updated_since=** — ISO 8601 timestamp for delta sync
- **New filter: ?include_inactive=** — defaults false (active-only by default)
- **New endpoint: GET /v1/resorts/by-external-id?system=xpd&id=XPD-12345** — maps partner IDs to RAV golden records via resort_external_ids table
- Backward compat: flat `rating`, `city`, `state` fields preserved (marked deprecated in spec)

### OpenAPI spec (public-api.yaml)
- New `ResortObject` + `SingleResortResponse` schemas with OTA field cross-references
- 3 new query params documented
- New `/v1/resorts/by-external-id` path with full parameter + response docs
- Both `docs/api/` and `public/api/` copies kept identical

### MDM workstream complete
| WS | What | PR |
|---|---|---|
| WS1 | Schema hardening (9 columns + external_ids table + quality function) | #362 |
| WS2 | Data quality audit + description gen + normalisation (applied to DEV) | #363 |
| WS3 | API enhancement (this PR) | — |

## Test plan
- [x] 1090 tests passing
- [x] Build clean
- [ ] Deploy api-gateway edge function to DEV
- [ ] Test: `curl /v1/resorts?brand=hilton_grand_vacations` — returns only HGV resorts
- [ ] Test: `curl /v1/resorts?updated_since=2020-01-01` — returns all records
- [ ] Test: `curl /v1/resorts` — verify is_active, data_quality_score, latitude present in response
- [ ] Test: `curl /v1/resorts/by-external-id?system=xpd&id=unknown` — returns 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)