### PR TITLE
docs: bring Session 54 state current across hub, testing-status, roadmap

### DIFF
--- a/docs/PRIORITY-ROADMAP.md
+++ b/docs/PRIORITY-ROADMAP.md
@@ -1,7 +1,7 @@
 ---
-last_updated: "2026-04-16T04:05:13"
-change_ref: "7cba187"
-change_type: "session-50"
+last_updated: "2026-04-20T02:55:17"
+change_ref: "f82a427"
+change_type: "session-54"
 status: "active"
 ---
 # PRIORITY ROADMAP — Rent-A-Vacation
@@ -9,6 +9,17 @@ status: "active"
 > **Purpose:** Single source of truth for what to work on next. Updated every session that includes a prioritization discussion.
 > **Rule:** Start every working session by reading this file + `gh issue list --state open`. This file captures the WHY and ORDER; GitHub Issues captures the WHAT and STATUS.
 > **Excluded permanently:** #127 (LLC/EIN), #63 (Accounting — blocked on #127), #65 (Tax Filing — blocked on #127), #80 (Legal — needs LLC)
+
+---
+
+## Changelog since last tier assignment (Sessions 50–54)
+
+- **Session 50-53 shipped:** Event unification (#338, #339), MDM WS1/WS2/WS3 (DEC-032), Brand/terminology lock (DEC-031), Site-wide UI polish, 5 tier-gated features (#278-#282 — all Tier C items now **DONE**), Sentry guide, API docs audit.
+- **Session 54 shipped:** Stripe Tax env-flag gate (`STRIPE_TAX_ENABLED`), edge function JWT config hardening, migration 057 catch-up to DEV + PROD, MDM script CI fix, and 3 QA-surfaced bug fixes (offers-tab crash, owner bid notification, owner booking notification).
+- **New follow-up issues opened in Session 54:**
+  - **#370** — Platform synthetic uptime monitoring (DEC-033 — Checkly SaaS). Post-launch, not Tier A.
+  - **#371** — Add edge function test harness (CLAUDE.md Tests-With-Features follow-up). Needs tier assignment.
+- **QA audit items surfaced from testing (need issues + tier assignment):** terminology sync, listing verification UX, cancel listing flow, "Open for bidding" indicator, MyTrips post-booking detail view, Track 1 vs Track 2 user mental model.
 
 ---
 
@@ -28,17 +39,17 @@ These require decisions, walkthroughs, or external dependencies before coding.
 | #257 | Resort data compliance audit | Legal review of seed data sources. |
 | #322 | RAV Wishes proposal enforcement | Deferred until 30+ days of real proposal data. Post-beta. |
 
-### Tier C: Tier Feature Differentiation (Bundle as Sprint)
+### Tier C: Tier Feature Differentiation — ✅ COMPLETED IN SESSION 53 (PR #367)
 
-These define what paid tiers actually GET. Can be built as a focused sprint.
+All 5 items shipped. Migration 057. Shared `tierGating.ts` utility with 26 tests.
 
-| Issue | Title |
-|-------|-------|
-| #278 | Early access to new listings (Traveler Plus) |
-| #279 | Exclusive deals for Premium travelers |
-| #280 | Priority listing placement for Owner Pro |
-| #281 | Concierge support for Premium travelers |
-| #282 | Dedicated account manager for Owner Business |
+| Issue | Title | Status |
+|-------|-------|--------|
+| #278 | Early access to new listings (Traveler Plus) | ✅ Done |
+| #279 | Exclusive deals for Premium travelers | ✅ Done |
+| #280 | Priority listing placement for Owner Pro | ✅ Done |
+| #281 | Concierge support for Premium travelers | ✅ Done |
+| #282 | Dedicated account manager for Owner Business | ✅ Done |
 
 ### Tier D: Marketing & Social (Non-Code, Human-Driven)
 

--- a/docs/PROJECT-HUB.md
+++ b/docs/PROJECT-HUB.md
@@ -1,6 +1,6 @@
 ---
-last_updated: "2026-04-19T16:25:58"
-change_ref: "d22b799"
+last_updated: "2026-04-20T02:55:17"
+change_ref: "f82a427"
 change_type: "session-39-docs-update"
 status: "active"
 ---
@@ -93,16 +93,16 @@ gh issue create --repo rent-a-vacation/rav-website --title "..." --label "..." -
 - Edge functions require `--no-verify-jwt` deployment flag
 
 ### Platform Status
-- **1125+ automated tests** (133 test files, all passing), 0 type errors, 0 lint errors, build clean
+- **1133 automated tests** (133 test files, all passing), 0 type errors, 0 lint errors, build clean
 - **P0 tests:** 97 critical-path tests tagged `@p0` + 4 subscription P0s — run with `npm run test:p0`
 - **CI reporting:** GitHub native via dorny/test-reporter (JUnit XML) — PR annotations on every run (Qase removed Mar 2026)
 - **Migrations created:** 001-057 (all deployed to DEV and PROD) + 3 date-based MDM migrations
-- **Edge functions:** 34 total (27 deployed to PROD + 4 subscription functions on DEV + 3 SMS functions pending LLC/EIN). `create-booking-checkout` deployed to both DEV and PROD with `--no-verify-jwt` (Session 54).
+- **Edge functions:** 34 total (27 deployed to PROD + 4 subscription functions on DEV + 3 SMS functions pending LLC/EIN). `create-booking-checkout` + `verify-booking-payment` deployed to both DEV and PROD with `--no-verify-jwt` (Session 54).
 - **Stripe Subscription:** Sandbox configured — 4 products, webhook (11 events), Customer Portal. Subscription epic #263 CLOSED (all 9 stories complete)
 - **Stripe Tax:** env-gated via `STRIPE_TAX_ENABLED` (Session 54). Unset on both DEV + PROD → `automatic_tax` disabled → bookings work without tax collection. Flip to `"true"` on PROD only after live Stripe Tax fully activated post-#127.
 - **PROD platform:** locked (Staff Only Mode enabled)
 - **Supabase CLI:** currently linked to DEV
-- **dev and main:** dev ahead by 3 commits — PR #372 open (Stripe Tax gate + CI fix)
+- **dev and main:** in sync — PRs #372 + #373 merged (Session 54)
 - **GitHub Project:** RAV Roadmap — 202 issues, all with Status/Category/Sub-Category/Type populated. Auto-add workflow enabled. PRs excluded.
 
 ### Session Handoff (Sessions 25-54)
@@ -114,10 +114,16 @@ gh issue create --repo rent-a-vacation/rav-website --title "..." --label "..." -
 - **Deployed:** `create-booking-checkout` to both DEV and PROD with `--no-verify-jwt`. Migration 057 (tier features — Session 53 gap) caught up on both DEV and PROD.
 - **Cleanup:** Deleted 4 stale `pending` bookings on DEV from today's failed Stripe attempts (preserved the 10 seed-data pending bookings from 2026-04-05).
 - **DEC-033 (Platform Monitoring):** Chose Checkly (SaaS free tier) for synthetic uptime monitoring — see Key Decisions Log. Tracked as post-launch issue #370.
+- **QA scenario testing (S-01 to S-05) — 3 bugs fixed (PR #373):**
+  - **S-05 offers-tab crash** — `/my-trips?tab=offers` threw "Invalid time value" on `bid.created_at` + `request.proposals_deadline`. Regression of #354 (which only patched check-in/out dates). Added `formatDistanceToNowSafe` helper and applied at both crash sites.
+  - **S-05 bid notification missing** — `useCreateBid` inserted directly to `listing_bids` and never invoked `notification-dispatcher`. Added dispatch targeting listing owner with `type_key: new_bid_received` (non-blocking).
+  - **S-04 booking notification missing** — `verify-booking-payment` sent legacy email but never invoked `notification-dispatcher`. Added `booking_confirmed` dispatch after booking status flip (email unchanged).
+  - Also added `[functions.verify-booking-payment] verify_jwt = false` to `config.toml` to preempt the same gateway 401 regression.
+- **S-05 "Anonymous" bidder display** — investigated; source not found in code (`BidsManagerDialog` uses `getRenterDisplayName` correctly). Likely stale browser cache — hard-refresh + retest required to confirm.
 - **Follow-up issues:** #371 (edge function test harness — shipped Stripe fix without tests; flagged per CLAUDE.md Tests-With-Features). #370 (Checkly monitoring implementation).
 - **Docs:** LAUNCH-READINESS.md documents `STRIPE_TAX_ENABLED` under Payments check 7b with explicit activation criteria. Blocked Items row updated for #127.
 
-**End state:** PR #372 open with 3 commits (Stripe Tax gate + JWT config + CI fix). Migration 057 deployed to DEV + PROD. `create-booking-checkout` redeployed to both environments. Supabase CLI relinked to DEV.
+**End state:** PR #372 + #373 merged to main. All Session 54 code deployed to DEV + PROD: `create-booking-checkout`, `verify-booking-payment`, migration 057. Supabase CLI relinked to DEV. Dev and main in sync. Tests: 1133 passing (133 files), 0 type errors, build clean. QA tester to re-run S-02 / S-04 / S-05 on dev to confirm fixes.
 
 **Session 53 — Tier Features, API Review, Sentry Guide (Apr 17-18, 2026):**
 - **5 tier-gated features (#278-#282):** Early Access for Plus travelers (48h window on new listings), Exclusive Deals for Premium (admin-toggled `is_exclusive_deal`), Priority Listing Placement for Pro/Business owners (sort boost + Featured badge), Concierge Support for Premium (request system + admin tab), Dedicated Account Manager for Business owners (admin assignment + dashboard card). Migration 057. Shared `tierGating.ts` utility (6 functions, 26 tests). PR #367 merged.

--- a/docs/testing/TESTING-STATUS.md
+++ b/docs/testing/TESTING-STATUS.md
@@ -1,13 +1,13 @@
 ---
-last_updated: "2026-04-05T15:57:17"
-change_ref: "800bcfa"
-change_type: "session-39-docs-update"
+last_updated: "2026-04-20T02:55:17"
+change_ref: "f82a427"
+change_type: "session-54"
 status: "active"
 ---
 # Testing Status
 
 > Current state of the RAV test suite. Updated each session.
-> **Last Updated:** March 13, 2026 (Session 39)
+> **Last Updated:** April 19, 2026 (Session 54)
 
 ---
 
@@ -15,15 +15,16 @@ status: "active"
 
 | Metric | Value |
 |--------|-------|
-| **Total tests** | 848 |
-| **Test files** | 108 |
-| **P0 critical-path tests** | 97 (tagged `@p0`) |
+| **Total tests** | 1133 |
+| **Test files** | 133 |
+| **P0 critical-path tests** | 97 (tagged `@p0`) + 4 subscription P0s |
 | **E2E smoke tests** | 3 (Playwright) |
-| **Local run time** | ~65s |
+| **Local run time** | ~2.5 min (full), ~2s (P0 only) |
 | **CI run time** | <3 min |
 | **TypeScript errors** | 0 |
 | **Lint errors** | 0 |
 | **Build** | Clean |
+| **QA manual scenarios** | 30 total — S-01 through S-05 in progress (Apr 19). 3 bugs fixed via PR #373, retest pending |
 
 ## Coverage Thresholds (enforced in CI)
 


### PR DESCRIPTION
## Summary

Doc refresh to match the actual end-of-Session-54 state. No code changes.

| File | Changes |
|------|---------|
| `docs/PROJECT-HUB.md` | Session 54 entry now includes PR #373 bugs (offers crash, owner bid/booking notifications). End-state corrected from "PR #372 open" to "PRs #372+#373 merged". Platform Status test count 1125→1133. Dev/main line corrected from "ahead by 3 commits" to "in sync". |
| `docs/testing/TESTING-STATUS.md` | 848→1133 tests, 108→133 files, run times refreshed, QA manual scenarios row added, Session 39→54 timestamp. |
| `docs/PRIORITY-ROADMAP.md` | New Session 50–54 changelog block. Tier C (#278-#282) marked ✅ Done (shipped Session 53). New follow-up issues #370 + #371 noted. QA audit items listed for tier assignment. |

## Not in this PR (intentional)

- `docs/COMPLETED-PHASES.md` — recent sessions (51-54) are still in PROJECT-HUB's Session Handoff. That's by design; COMPLETED-PHASES is an archive that receives older session entries after they age out of the hub.

## Test plan

- [x] Doc-only change, no tests required
- [ ] CI docs audit check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)