### PR TITLE
feat(my-trips): surface booking details — fees, cancellation policy, confirmation, countdown (#379)

### DIFF
--- a/src/lib/renterDashboard.test.ts
+++ b/src/lib/renterDashboard.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { computeRenterOverview, getCheckInCountdown } from './renterDashboard';
+import { computeRenterOverview, getCheckInCountdown, isImminentCheckIn } from './renterDashboard';
 
 describe('computeRenterOverview', () => {
   beforeEach(() => {
@@ -79,5 +79,36 @@ describe('getCheckInCountdown', () => {
 
   it('returns "Already checked in" for past dates', () => {
     expect(getCheckInCountdown('2026-03-01')).toBe('Already checked in');
+  });
+});
+
+describe('isImminentCheckIn', () => {
+  it('is imminent for "Today!"', () => {
+    expect(isImminentCheckIn('Today!')).toBe(true);
+  });
+
+  it('is imminent for "Tomorrow"', () => {
+    expect(isImminentCheckIn('Tomorrow')).toBe(true);
+  });
+
+  it('is imminent for "3 days"', () => {
+    expect(isImminentCheckIn('3 days')).toBe(true);
+  });
+
+  it('is imminent at boundary "7 days"', () => {
+    expect(isImminentCheckIn('7 days')).toBe(true);
+  });
+
+  it('is not imminent for "2 weeks"', () => {
+    expect(isImminentCheckIn('2 weeks')).toBe(false);
+  });
+
+  it('is not imminent for "Already checked in"', () => {
+    expect(isImminentCheckIn('Already checked in')).toBe(false);
+  });
+
+  it('is not imminent for unexpected text', () => {
+    expect(isImminentCheckIn('')).toBe(false);
+    expect(isImminentCheckIn('soon')).toBe(false);
   });
 });

--- a/src/lib/renterDashboard.ts
+++ b/src/lib/renterDashboard.ts
@@ -74,3 +74,18 @@ export function getCheckInCountdown(checkInDate: string): string {
 
   return `${days} days`;
 }
+
+/**
+ * Is a check-in countdown text considered imminent (<= 7 days away)?
+ * Used for elevating visual priority on the booking card.
+ */
+export function isImminentCheckIn(countdownText: string): boolean {
+  if (countdownText === 'Today!' || countdownText === 'Tomorrow') return true;
+  // "N days" where N is a small integer (getCheckInCountdown returns "N days" only when N < 7)
+  const daysMatch = /^(\d+) days$/.exec(countdownText);
+  if (daysMatch) {
+    const n = parseInt(daysMatch[1], 10);
+    return n <= 7;
+  }
+  return false;
+}

--- a/src/pages/MyBookings.tsx
+++ b/src/pages/MyBookings.tsx
@@ -14,12 +14,14 @@ import { Badge } from "@/components/ui/badge";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Button } from "@/components/ui/button";
-import { Calendar, MapPin, Users, DollarSign, Ban, ExternalLink, AlertTriangle, MessageCircle, CheckCircle, Clock, RefreshCw, Star, ChevronDown } from "lucide-react";
+import { Calendar, MapPin, Users, DollarSign, Ban, ExternalLink, AlertTriangle, MessageCircle, CheckCircle, Clock, RefreshCw, Star, ChevronDown, Plane, KeyRound } from "lucide-react";
 import { format } from "date-fns";
 import type { Booking, BookingStatus, Listing, Property } from "@/types/database";
 import { computeBookingTimeline } from "@/lib/bookingTimeline";
 import { BookingTimeline } from "@/components/booking/BookingTimeline";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
+import { CancellationPolicyDetail } from "@/components/CancellationPolicyDetail";
+import { getCheckInCountdown, isImminentCheckIn } from "@/lib/renterDashboard";
 
 interface DisputeInfo {
   id: string;
@@ -32,9 +34,16 @@ interface DisputeInfo {
   resolved_at: string | null;
 }
 
+interface BookingConfirmationInfo {
+  resort_confirmation_number: string | null;
+  owner_confirmation_status: string | null;
+  owner_confirmation_deadline: string | null;
+}
+
 interface BookingWithListing extends Booking {
   listing: Listing & { property: Property };
   disputes?: DisputeInfo[];
+  booking_confirmations?: BookingConfirmationInfo[];
 }
 
 const DISPUTE_STATUS_CONFIG: Record<string, { label: string; color: string; icon: React.ReactNode }> = {
@@ -96,6 +105,11 @@ const MyBookings = ({ embedded }: { embedded?: boolean }) => {
             refund_amount,
             created_at,
             resolved_at
+          ),
+          booking_confirmations(
+            resort_confirmation_number,
+            owner_confirmation_status,
+            owner_confirmation_deadline
           )
         `)
         .eq("renter_id", user.id)
@@ -166,6 +180,16 @@ const MyBookings = ({ embedded }: { embedded?: boolean }) => {
   const renderBookingCard = (booking: BookingWithListing) => {
     const listing = booking.listing;
     const property = listing?.property;
+    const confirmation = booking.booking_confirmations?.[0];
+
+    // Countdown only shown for upcoming bookings (confirmed/pending, check-in still in future)
+    const checkInDateStr = listing?.check_in_date;
+    const showCountdown =
+      checkInDateStr &&
+      (booking.status === "confirmed" || booking.status === "pending") &&
+      new Date(checkInDateStr + "T00:00:00") >= new Date();
+    const countdownText = showCountdown ? getCheckInCountdown(checkInDateStr!) : null;
+    const isImminent = countdownText ? isImminentCheckIn(countdownText) : false;
 
     return (
       <Card key={booking.id} className="overflow-hidden">
@@ -182,11 +206,20 @@ const MyBookings = ({ embedded }: { embedded?: boolean }) => {
                 </CardDescription>
               )}
             </div>
-            <Badge
-              className={`${STATUS_COLORS[booking.status]} shrink-0`}
-            >
-              {STATUS_LABELS[booking.status]}
-            </Badge>
+            <div className="flex flex-col items-end gap-1.5 shrink-0">
+              <Badge className={STATUS_COLORS[booking.status]}>
+                {STATUS_LABELS[booking.status]}
+              </Badge>
+              {countdownText && (
+                <Badge
+                  variant="outline"
+                  className={`gap-1 ${isImminent ? "border-primary text-primary bg-primary/5" : "text-muted-foreground"}`}
+                >
+                  <Plane className="h-3 w-3" />
+                  {countdownText}
+                </Badge>
+              )}
+            </div>
           </div>
         </CardHeader>
 
@@ -270,14 +303,14 @@ const MyBookings = ({ embedded }: { embedded?: boolean }) => {
             </div>
           )}
 
-          {/* Expandable Full Timeline */}
+          {/* Expandable Booking Details — timeline + fees + cancellation policy */}
           {listing && (
             <Collapsible>
               <CollapsibleTrigger className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors">
                 <ChevronDown className="h-3 w-3" />
-                Timeline details
+                Booking details
               </CollapsibleTrigger>
-              <CollapsibleContent className="pt-2">
+              <CollapsibleContent className="pt-3 space-y-4">
                 <BookingTimeline
                   steps={computeBookingTimeline({
                     status: booking.status,
@@ -287,6 +320,52 @@ const MyBookings = ({ embedded }: { embedded?: boolean }) => {
                     hasReview: reviewedBookingIds.has(booking.id),
                   })}
                 />
+
+                {/* Fee breakdown */}
+                <div className="border-t pt-3">
+                  <h4 className="text-sm font-medium mb-2">Payment breakdown</h4>
+                  <div className="space-y-1 text-sm">
+                    {booking.base_amount != null && (
+                      <div className="flex justify-between text-muted-foreground">
+                        <span>Base rate</span>
+                        <span>${booking.base_amount.toLocaleString()}</span>
+                      </div>
+                    )}
+                    {booking.service_fee != null && booking.service_fee > 0 && (
+                      <div className="flex justify-between text-muted-foreground">
+                        <span>Service fee</span>
+                        <span>${booking.service_fee.toLocaleString()}</span>
+                      </div>
+                    )}
+                    {booking.cleaning_fee != null && booking.cleaning_fee > 0 && (
+                      <div className="flex justify-between text-muted-foreground">
+                        <span>Cleaning fee</span>
+                        <span>${booking.cleaning_fee.toLocaleString()}</span>
+                      </div>
+                    )}
+                    {booking.tax_amount != null && booking.tax_amount > 0 && (
+                      <div className="flex justify-between text-muted-foreground">
+                        <span>Tax</span>
+                        <span>${booking.tax_amount.toLocaleString()}</span>
+                      </div>
+                    )}
+                    <div className="flex justify-between pt-1 border-t font-medium">
+                      <span>Total</span>
+                      <span>${booking.total_amount.toLocaleString()}</span>
+                    </div>
+                  </div>
+                </div>
+
+                {/* Cancellation policy */}
+                {listing.cancellation_policy && (
+                  <div className="border-t pt-3">
+                    <CancellationPolicyDetail
+                      policy={listing.cancellation_policy}
+                      checkInDate={listing.check_in_date}
+                      compact
+                    />
+                  </div>
+                )}
               </CollapsibleContent>
             </Collapsible>
           )}
@@ -307,11 +386,22 @@ const MyBookings = ({ embedded }: { embedded?: boolean }) => {
             </div>
           </div>
 
-          {/* Booking Reference */}
-          <div className="flex items-center justify-between pt-3 border-t">
-            <span className="text-xs text-muted-foreground">
-              Ref: <span className="font-mono font-semibold tracking-wider">{booking.id.slice(0, 8).toUpperCase()}</span>
-            </span>
+          {/* Booking Reference + Resort Confirmation */}
+          <div className="flex items-center justify-between pt-3 border-t gap-2 flex-wrap">
+            <div className="flex items-center gap-3 flex-wrap text-xs text-muted-foreground">
+              <span>
+                Ref: <span className="font-mono font-semibold tracking-wider">{booking.id.slice(0, 8).toUpperCase()}</span>
+              </span>
+              {confirmation?.resort_confirmation_number && (
+                <span className="flex items-center gap-1">
+                  <KeyRound className="h-3 w-3" />
+                  Resort:{" "}
+                  <span className="font-mono font-semibold tracking-wider">
+                    {confirmation.resort_confirmation_number}
+                  </span>
+                </span>
+              )}
+            </div>
 
             <div className="flex items-center gap-2">
               {listing && (

--- a/src/pages/UserGuide.tsx
+++ b/src/pages/UserGuide.tsx
@@ -1947,7 +1947,7 @@ const UserGuide = () => {
                 <div className="space-y-4">
                   {[
                     { tab: "Overview", desc: "Quick stats — upcoming trips, active offers, saved searches. Check-in countdown shows days until your next trip." },
-                    { tab: "Bookings", desc: "All your bookings with status, timeline visualization, review buttons, and cancellation options." },
+                    { tab: "Bookings", desc: "All your bookings. Each card shows a check-in countdown badge for upcoming trips, the full payment breakdown (base rate, service fee, cleaning fee, tax, total), cancellation policy with refund windows, and the resort confirmation number once the owner provides it. Expand \"Booking details\" for the full timeline + payment + policy view." },
                     { tab: "Offers", desc: "Track all your active bids and offers. See which are pending, accepted, or expired." },
                     { tab: "Favorites", desc: "Properties you've saved, plus your saved searches with price drop alerts." },
                   ].map((item, i) => (


### PR DESCRIPTION
## Summary

Closes audit #5 (issue [#379](https://github.com/rent-a-vacation/rav-website/issues/379)) — the first Phase A work item from Session 55 planning. Tester feedback from S-04 was that after booking + payment, renters couldn't see any details beyond a reference number. This PR surfaces the missing details using existing components wherever possible (rooted in simplicity principle).

## Changes

**`src/pages/MyBookings.tsx`** — each booking card now shows:
- Check-in countdown badge next to status (highlighted when trip is within 7 days via \`isImminentCheckIn\`)
- Resort confirmation number next to booking reference once owner provides it (joined from \`booking_confirmations\`)
- Expandable **Booking details** section with:
  - Full timeline (already present)
  - Itemized payment breakdown (base, service, cleaning, tax, total) — all fields already fetched, now shown
  - Cancellation policy with deadlines — reuses existing \`<CancellationPolicyDetail compact />\`

**`src/lib/renterDashboard.ts`** — new \`isImminentCheckIn(countdownText)\` helper. Keeps presentation logic out of the component and makes it unit-testable.

**`src/lib/renterDashboard.test.ts`** — 7 new tests for boundary conditions (Today!, Tomorrow, 7 days edge, "2 weeks" not imminent, past dates, empty/unexpected text).

**`src/pages/UserGuide.tsx`** — renter dashboard \"Bookings\" tab description updated to reflect the new details view.

## Rooted in simplicity

- Default card stays lean — all the new detail is behind the single \"Booking details\" collapsible, folded by default.
- Check-in countdown uses visual emphasis only when imminent (< 7 days) — otherwise stays muted.
- Reuses \`CancellationPolicyDetail\` instead of inventing a new component.
- Fee breakdown layout matches the pattern in PropertyDetail checkout summary.

## Test plan

- [x] \`npx vitest run src/lib/renterDashboard.test.ts\` — 15/15 passing (7 new)
- [x] \`npx tsc --noEmit\` — clean
- [x] Pre-commit hook eslint + vitest-related-run — clean
- [ ] Manual retest by tester: S-04 Run flow end-to-end. Card should show countdown for an upcoming booking, fee breakdown inside \"Booking details\", resort confirmation number next to Ref:

## Follows the /sdlc Phase 6 checklist

- [x] USER-GUIDE updated
- [ ] PROJECT-HUB Session 55 entry — to be added at end of session
- [ ] TESTING-STATUS test count bump (1133 → 1140) — end of session
- [ ] LAUNCH-READINESS — no new env flags introduced, no change needed

## Related
- Closes: first two items of #379
- Follow-up: overflow menu for mobile + receipt PDF link deferred (separate issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)