### PR TITLE
feat(ux): Path 3 hybrid dashboard naming + mobile nav fix (#375)

### DIFF
--- a/docs/brand-assets/BRAND-LOCK.md
+++ b/docs/brand-assets/BRAND-LOCK.md
@@ -1,6 +1,6 @@
 ---
-last_updated: "2026-04-15T04:06:53"
-change_ref: "5fb0c20"
+last_updated: "2026-04-20T04:52:26"
+change_ref: "824263c"
 change_type: "session-52-terminology-lock"
 status: "active"
 ---
@@ -349,29 +349,35 @@ Every named feature follows one of three naming patterns. When adding a new feat
 
 **"Offer" replaces both "Bid" (old UI) and "Proposal" (old UI).** In the database, the two mechanics are still stored in separate tables (`listing_bids` vs `travel_proposals`) because they point at different parents — but end users see a single noun: "Offer."
 
-### Navigation & Page Titles
+### Navigation & Page Titles — Path 3 Hybrid (Session 55)
 
-| Location | Nav Label | Page Title | Link |
-|----------|-----------|------------|------|
-| Header nav (everyone) | **Marketplace** | Marketplace — Listings & Wishes | /marketplace |
-| Header nav (everyone) | **Browse Rentals** | Vacation Rentals | /rentals |
-| Header nav (owner) | **My Rentals** | My Rentals | /owner-dashboard |
-| Header nav (renter) | **My Trips** | My Trips | /my-trips |
-| Header nav (admin) | **RAV Ops** | RAV Ops — Operations | /admin |
-| Header nav (executive) | **RAV Insights** | RAV Insights — Business Intelligence | /executive-dashboard |
-| Header nav (tools) | **Free Tools** | RAV Tools | /tools |
-| Header nav (owner CTA) | **List Your Property** | List Your Property | /list-property |
-| Tab label — listings (inside Marketplace) | **Listings** | — | /marketplace (default for renter/anon) |
-| Tab label — wishes (inside Marketplace) | **Wishes** | — | /marketplace?tab=wishes (default for owner) |
+**Pattern:** keep the short brand name as the dominant H1 + CTA label, add a small-caps **role-descriptive eyebrow** above it so users instantly understand what they're looking at.
+
+| Location | Nav Label | Page Eyebrow (small caps) | Page H1 | Link |
+|----------|-----------|---------------------------|---------|------|
+| Header nav (everyone) | **Marketplace** | — | Marketplace — Listings & Wishes | /marketplace |
+| Header nav (everyone) | **Browse Rentals** | — | Vacation Rentals | /rentals |
+| Header nav (owner) | **My Rentals** | Property Owner Dashboard | My Rentals | /owner-dashboard |
+| Header nav (renter) | **My Trips** | Traveler Dashboard | My Trips | /my-trips |
+| Header nav (admin) | **RAV Ops** | RAV Admin Dashboard (or RAV Staff Dashboard — dynamic by role) | RAV Ops | /admin |
+| Header nav (executive) | **RAV Insights** | Executive Dashboard — Business Intelligence | RAV Insights | /executive-dashboard |
+| Header nav (tools) | **Free Tools** | — | RAV Tools | /tools |
+| Header nav (owner CTA) | **List Your Property** | — | List Your Property | /list-property |
+| Tab label — listings (inside Marketplace) | **Listings** | — | — | /marketplace (default for renter/anon) |
+| Tab label — wishes (inside Marketplace) | **Wishes** | — | — | /marketplace?tab=wishes (default for owner) |
+
+**Rationale:** brand names like "My Rentals" / "My Trips" / "RAV Ops" remain the short, scannable CTAs in the header nav — preserving DEC-031. The descriptive eyebrow ("Property Owner Dashboard") tells a first-time user what the page represents in role terms — so the mapping between brand name and function is visually guided.
 
 ### User dropdown (role-aware "My Activity")
 
 | Renter sees | Owner sees |
 |---|---|
-| My Trips | My Listings |
+| My Trips | My Rentals |
 | My Offers | Offers I Sent |
 | My Wishes | Offers on My Listings |
 | Account Settings | Account Settings |
+
+**Note:** Owner dropdown previously showed "My Listings" as its top item; this was an inconsistency with the nav label "My Rentals" and was corrected in Session 55. Sub-tab labels inside the dashboard (e.g., the "My Listings" tab within My Rentals) remain as sub-labels — they name a tab, not the dashboard.
 
 ### CTA Buttons (plain language — no RAV prefix on transactional CTAs)
 

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -464,7 +464,7 @@ const Header = () => {
                   className={`py-2.5 text-sm font-medium transition-colors ${isActive("/owner-dashboard") ? "text-foreground" : "text-muted-foreground"}`}
                   onClick={() => setIsMenuOpen(false)}
                 >
-                  My Listings
+                  My Rentals
                 </Link>
                 <Link
                   to="/owner-dashboard?tab=offers-sent"

--- a/src/pages/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard.tsx
@@ -164,6 +164,9 @@ const AdminDashboard = () => {
                 <ArrowLeft className="h-5 w-5" />
               </Button>
               <div>
+                <div className="text-[10px] sm:text-xs font-medium tracking-widest uppercase text-muted-foreground mb-0.5">
+                  {isRavAdmin() ? "RAV Admin Dashboard" : "RAV Staff Dashboard"}
+                </div>
                 <div className="flex items-center gap-2">
                   <h1 className="font-display text-xl sm:text-2xl font-bold tracking-tight">RAV Ops</h1>
                   <ShieldCheck className="h-5 w-5 text-primary" />

--- a/src/pages/ExecutiveDashboard.tsx
+++ b/src/pages/ExecutiveDashboard.tsx
@@ -15,7 +15,7 @@ import Footer from '@/components/Footer';
 import { usePageMeta } from '@/hooks/usePageMeta';
 
 const ExecutiveDashboard = () => {
-  usePageMeta('RAV Insights', 'Executive dashboard for Rent-A-Vacation marketplace operations and business intelligence.');
+  usePageMeta('RAV Insights — Business Intelligence', 'Executive dashboard for Rent-A-Vacation marketplace operations and business intelligence.');
 
   const { user, isRavTeam, isLoading } = useAuth();
   const [settingsOpen, setSettingsOpen] = useState(false);
@@ -47,6 +47,9 @@ const ExecutiveDashboard = () => {
           {/* Page header */}
           <div className="flex items-start justify-between mb-8 md:mb-10 gap-6">
             <div>
+              <div className="text-xs font-medium tracking-widest uppercase text-slate-400 mb-1.5">
+                Executive Dashboard — Business Intelligence
+              </div>
               <h1 className="font-display text-2xl md:text-3xl font-bold tracking-tight text-white">RAV Insights</h1>
               <p className="text-sm text-slate-400 mt-2 max-w-2xl">
                 Boardroom-grade intelligence. Real-time marketplace performance, proprietary metrics like Liquidity Score and Bid Spread Index,

--- a/src/pages/OwnerDashboard.tsx
+++ b/src/pages/OwnerDashboard.tsx
@@ -315,6 +315,9 @@ const OwnerDashboard = () => {
                 <ArrowLeft className="h-5 w-5" />
               </Button>
               <div>
+                <div className="text-[10px] sm:text-xs font-medium tracking-widest uppercase text-muted-foreground mb-0.5">
+                  Property Owner Dashboard
+                </div>
                 <h1 className="font-display text-xl sm:text-2xl font-bold tracking-tight">My Rentals</h1>
                 <p className="text-sm text-muted-foreground">
                   Manage listings, bookings, earnings, and more.

--- a/src/pages/RenterDashboard.tsx
+++ b/src/pages/RenterDashboard.tsx
@@ -117,6 +117,9 @@ const RenterDashboard = () => {
       <div className="pt-20 md:pt-24 pb-12">
         <div className="container mx-auto px-4">
           <div className="mb-8 md:mb-10">
+            <div className="text-xs font-medium tracking-widest uppercase text-muted-foreground mb-1.5">
+              Traveler Dashboard
+            </div>
             <h1 className="font-display text-3xl md:text-4xl font-bold text-foreground tracking-tight">
               My Trips
             </h1>


### PR DESCRIPTION
## Summary

Closes audit #1 (issue [#375](https://github.com/rent-a-vacation/rav-website/issues/375)). Implements **Path 3 hybrid** terminology per user direction:

- Keep brand-compliant nav CTAs (My Trips, My Rentals, RAV Ops, RAV Insights) — short, scannable, honors DEC-031
- Add a small-caps **role-descriptive eyebrow** above each dashboard H1 — so users see the brand-to-function mapping at a glance

## Changes

**Component fixes:**
- `Header.tsx:467` — mobile nav \"My Listings\" → \"My Rentals\" (the top inconsistency from audit; desktop already said \"My Rentals\")

**Dashboard eyebrows (descriptive labels above brand H1):**
- `OwnerDashboard.tsx` — \"Property Owner Dashboard\" above \"My Rentals\"
- `RenterDashboard.tsx` — \"Traveler Dashboard\" above \"My Trips\"
- `AdminDashboard.tsx` — dynamic: \"RAV Admin Dashboard\" (for `rav_admin`) or \"RAV Staff Dashboard\" (for `rav_staff`) above \"RAV Ops\"
- `ExecutiveDashboard.tsx` — \"Executive Dashboard — Business Intelligence\" above \"RAV Insights\"; also updates `usePageMeta` title so browser tab shows subtitle

**Docs:**
- `BRAND-LOCK.md` Section 9 — Nav & Page Titles table expanded with an Eyebrow column + rationale + user-dropdown clarification

## Sub-tab labels NOT changed

Sub-tab labels inside dashboards (e.g., the \"My Listings\" tab inside the My Rentals dashboard) remain unchanged — those name a **tab**, not the dashboard itself.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run src/components/Header.test.tsx` — 9 tests pass
- [x] Pre-commit hook — clean
- [ ] Manual verification: each dashboard renders eyebrow + H1; mobile nav shows \"My Rentals\" for owners

## /sdlc Phase 6 checklist
- [x] BRAND-LOCK.md updated with new terminology guidance
- [x] All 4 dashboard page H1s consistent with new pattern
- [ ] USER-GUIDE — no changes needed (labels reference the role/functional name which is now explicit)
- [ ] PROJECT-HUB Session 55 entry — end of session

## Related
- Closes #375
- Sibling: #381 (role-relevant landing-view ordering) — separate issue, will tackle next

🤖 Generated with [Claude Code](https://claude.com/claude-code)