### PR TITLE
feat(flow) Phase 1/5 of #380: listing_type enum + source tracking (DEC-034)

### DIFF
--- a/src/hooks/useBidding.ts
+++ b/src/hooks/useBidding.ts
@@ -558,6 +558,7 @@ export function useUpdateProposalStatus() {
             status: 'active',
             notes: `Auto-created from accepted travel request proposal`,
             cancellation_policy: 'moderate',
+            source_type: 'wish_matched',
           } as never)
           .select()
           .single();

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -306,6 +306,7 @@ export type Database = {
           rav_commission: number
           renter_id: string
           service_fee: number | null
+          source_type: Database["public"]["Enums"]["listing_source_type"]
           special_requests: string | null
           status: Database["public"]["Enums"]["booking_status"]
           stripe_tax_calculation_id: string | null
@@ -314,6 +315,7 @@ export type Database = {
           tax_jurisdiction: string | null
           tax_rate: number | null
           total_amount: number
+          travel_proposal_id: string | null
           updated_at: string
         }
         Insert: {
@@ -333,6 +335,7 @@ export type Database = {
           rav_commission: number
           renter_id: string
           service_fee?: number | null
+          source_type?: Database["public"]["Enums"]["listing_source_type"]
           special_requests?: string | null
           status?: Database["public"]["Enums"]["booking_status"]
           stripe_tax_calculation_id?: string | null
@@ -341,6 +344,7 @@ export type Database = {
           tax_jurisdiction?: string | null
           tax_rate?: number | null
           total_amount: number
+          travel_proposal_id?: string | null
           updated_at?: string
         }
         Update: {
@@ -360,6 +364,7 @@ export type Database = {
           rav_commission?: number
           renter_id?: string
           service_fee?: number | null
+          source_type?: Database["public"]["Enums"]["listing_source_type"]
           special_requests?: string | null
           status?: Database["public"]["Enums"]["booking_status"]
           stripe_tax_calculation_id?: string | null
@@ -368,6 +373,7 @@ export type Database = {
           tax_jurisdiction?: string | null
           tax_rate?: number | null
           total_amount?: number
+          travel_proposal_id?: string | null
           updated_at?: string
         }
         Relationships: [
@@ -746,6 +752,7 @@ export type Database = {
           rav_markup: number
           reserve_price: number | null
           resort_fee: number | null
+          source_type: Database["public"]["Enums"]["listing_source_type"]
           status: Database["public"]["Enums"]["listing_status"]
           updated_at: string
         }
@@ -771,6 +778,7 @@ export type Database = {
           rav_markup?: number
           reserve_price?: number | null
           resort_fee?: number | null
+          source_type?: Database["public"]["Enums"]["listing_source_type"]
           status?: Database["public"]["Enums"]["listing_status"]
           updated_at?: string
         }
@@ -796,6 +804,7 @@ export type Database = {
           rav_markup?: number
           reserve_price?: number | null
           resort_fee?: number | null
+          source_type?: Database["public"]["Enums"]["listing_source_type"]
           status?: Database["public"]["Enums"]["listing_status"]
           updated_at?: string
         }
@@ -2247,6 +2256,7 @@ export type Database = {
         | "released"
         | "refunded"
         | "disputed"
+      listing_source_type: "pre_booked" | "wish_matched"
       listing_status:
         | "draft"
         | "pending_approval"
@@ -2321,6 +2331,7 @@ export type Database = {
 
 export type AppRole = Database['public']['Enums']['app_role'];
 export type ListingStatus = Database['public']['Enums']['listing_status'];
+export type ListingSourceType = Database['public']['Enums']['listing_source_type'];
 export type BookingStatus = Database['public']['Enums']['booking_status'];
 export type PayoutStatus = Database['public']['Enums']['payout_status'];
 export type AgreementStatus = Database['public']['Enums']['agreement_status'];

--- a/supabase/migrations/058_marketplace_flow_distinction.sql
+++ b/supabase/migrations/058_marketplace_flow_distinction.sql
@@ -1,0 +1,85 @@
+-- Migration 058: Marketplace Flow Distinction (Pre-Booked Stay vs Wish-Matched Stay)
+-- DEC-034 — explicit model for the two flows
+--
+-- Flow 1 (pre_booked): owner has the resort reservation already. Listing goes
+--   live after RAV staff verifies proof. Booking confirmed instantly on payment.
+-- Flow 2 (wish_matched): listing auto-created from an accepted travel_proposal.
+--   Owner has a deadline to confirm the resort reservation post-acceptance;
+--   RAV staff verifies that confirmation before booking is truly active.
+
+-- ============================================================
+-- 1. source_type enum + columns
+-- ============================================================
+DO $$ BEGIN
+  CREATE TYPE public.listing_source_type AS ENUM ('pre_booked', 'wish_matched');
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+ALTER TABLE listings
+  ADD COLUMN IF NOT EXISTS source_type listing_source_type NOT NULL DEFAULT 'pre_booked';
+
+ALTER TABLE bookings
+  ADD COLUMN IF NOT EXISTS source_type listing_source_type NOT NULL DEFAULT 'pre_booked',
+  ADD COLUMN IF NOT EXISTS travel_proposal_id UUID REFERENCES travel_proposals(id) ON DELETE SET NULL;
+
+-- Index for admin queue + reporting queries
+CREATE INDEX IF NOT EXISTS idx_listings_source_type ON listings(source_type);
+CREATE INDEX IF NOT EXISTS idx_bookings_source_type ON bookings(source_type);
+CREATE INDEX IF NOT EXISTS idx_bookings_travel_proposal_id ON bookings(travel_proposal_id)
+  WHERE travel_proposal_id IS NOT NULL;
+
+-- ============================================================
+-- 2. Backfill existing auto-created wish-matched listings
+-- ============================================================
+-- Any listing whose notes field marks it as auto-created from a travel proposal
+-- should be flagged as wish_matched for historical accuracy. The check is narrow
+-- (matches the exact phrase used by useBidding.ts:559) so we don't mis-classify
+-- genuine pre-booked listings.
+UPDATE listings
+SET source_type = 'wish_matched'
+WHERE source_type = 'pre_booked'
+  AND notes = 'Auto-created from accepted travel request proposal';
+
+-- Link historical wish-matched bookings back to their originating proposals
+-- (best-effort: joins on listing_id since that's the only bridge we have for
+-- rows created before travel_proposal_id existed).
+UPDATE bookings b
+SET
+  source_type = 'wish_matched',
+  travel_proposal_id = tp.id
+FROM travel_proposals tp
+WHERE tp.listing_id = b.listing_id
+  AND tp.status = 'accepted'
+  AND b.source_type = 'pre_booked';
+
+-- ============================================================
+-- 3. Note on owner_confirmation_status
+-- ============================================================
+-- Flow 1 (pre_booked) bookings skip the owner-confirmation countdown entirely.
+-- In Phase 2 (edge function branching), verify-booking-payment will set
+-- booking.status = 'confirmed' directly and either (a) skip creating a
+-- booking_confirmations row, or (b) create one with owner_confirmation_status
+-- already set to 'owner_confirmed' and owner_confirmed_at set to now().
+-- Either approach avoids adding a new enum value (ALTER TYPE ADD VALUE
+-- cannot run inside a migration's implicit transaction).
+
+-- ============================================================
+-- 4. Helper RPC: is_wish_matched_booking
+-- ============================================================
+-- Convenience for the admin queue + reports. Returns true if a booking
+-- originated from an accepted travel proposal.
+CREATE OR REPLACE FUNCTION is_wish_matched_booking(p_booking_id UUID)
+RETURNS BOOLEAN
+LANGUAGE sql
+STABLE
+AS $$
+  SELECT source_type = 'wish_matched'
+  FROM bookings
+  WHERE id = p_booking_id;
+$$;
+
+COMMENT ON TYPE listing_source_type IS 'DEC-034: pre_booked = owner had resort reservation at list time; wish_matched = listing auto-created from accepted travel_proposal';
+COMMENT ON COLUMN listings.source_type IS 'How this listing came to be. pre_booked (owner-initiated with reservation) or wish_matched (auto-created from accepted travel proposal).';
+COMMENT ON COLUMN bookings.source_type IS 'Which marketplace flow produced this booking. Determines whether owner-confirmation countdown applies.';
+COMMENT ON COLUMN bookings.travel_proposal_id IS 'FK to travel_proposals for wish_matched bookings; NULL for pre_booked.';


### PR DESCRIPTION
## Summary

Phase 1 of 5 for [#380](https://github.com/rent-a-vacation/rav-website/issues/380) — Marketplace Flow Distinction (Pre-Booked Stay vs Wish-Matched Stay). Pure data-model groundwork. **No user-visible behavior change in this PR** — Phase 2 will branch the edge function to actually use the new flag.

## What this PR does

### Migration 058 (deployed to DEV, PROD after merge)
- New enum \`listing_source_type\`: \`pre_booked\` | \`wish_matched\`
- \`listings.source_type\` (default \`pre_booked\`)
- \`bookings.source_type\` (default \`pre_booked\`) + \`travel_proposal_id\` FK
- Backfills: auto-created listings from accepted travel proposals → \`wish_matched\`; joined bookings → \`wish_matched\` + link to the originating proposal
- Indexes for admin queue / reporting queries
- Helper \`is_wish_matched_booking(uuid)\` RPC

### Frontend
- \`useBidding.ts\` proposal-accept auto-create now stamps the new listing with \`source_type='wish_matched'\`
- \`src/types/database.ts\` — targeted additions only (didn't regen — would wipe 57 hand-curated exports, type-hardening is deferred per MEMORY.md)

## What this PR does NOT do (later phases)
- **Phase 2** — \`verify-booking-payment\` branches per source_type (pre_booked auto-confirms, wish_matched keeps countdown)
- **Phase 3** — UI type + status badges; \`OwnerConfirmationTimer\` hidden for pre_booked
- **Phase 4** — Admin wish-matched verification queue + 3 new notifications
- **Phase 5** — USER-GUIDE / FAQ / ARCHITECTURE / QA-PLAYBOOK docs updates

## Test plan
- [x] \`npx tsc --noEmit\` — clean
- [x] \`npx vitest run src/hooks/useBidding.test.ts src/lib/compareListings.test.ts\` — 33 tests pass
- [x] \`npx supabase db push --linked\` to DEV — applied
- [ ] After merge: \`npx supabase db push --linked\` to PROD

## Release note
Data-model only. Zero risk — new columns default to \`pre_booked\` which matches today's uniform behavior. Phase 2 is what actually introduces the flow distinction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)