### PR TITLE
feat(flow) Phase 2/5 of #380: verify-booking-payment branches per source_type

### DIFF
--- a/supabase/functions/create-booking-checkout/index.ts
+++ b/supabase/functions/create-booking-checkout/index.ts
@@ -68,11 +68,28 @@ serve(async (req) => {
     if (listingError || !listing) {
       throw new Error("Listing not found or not available");
     }
-    logStep("Listing fetched", { 
-      listingId: listing.id, 
+    logStep("Listing fetched", {
+      listingId: listing.id,
       price: listing.final_price,
-      property: listing.property?.resort_name 
+      property: listing.property?.resort_name,
+      sourceType: listing.source_type,
     });
+
+    // DEC-034: Inherit source_type from listing; for wish_matched bookings
+    // also link back to the originating travel_proposal so the admin queue
+    // + reporting can reconcile the full flow.
+    const listingSourceType: "pre_booked" | "wish_matched" =
+      listing.source_type === "wish_matched" ? "wish_matched" : "pre_booked";
+    let travelProposalId: string | null = null;
+    if (listingSourceType === "wish_matched") {
+      const { data: proposal } = await supabaseClient
+        .from("travel_proposals")
+        .select("id")
+        .eq("listing_id", listing.id)
+        .eq("status", "accepted")
+        .maybeSingle();
+      travelProposalId = proposal?.id ?? null;
+    }
 
     // Determine commission rate:
     // 1. Check per-owner agreement override
@@ -156,6 +173,8 @@ serve(async (req) => {
         owner_payout: ownerPayout,
         guest_count: guestCount || 1,
         special_requests: specialRequests || null,
+        source_type: listingSourceType,
+        travel_proposal_id: travelProposalId,
       })
       .select()
       .single();

--- a/supabase/functions/verify-booking-payment/index.ts
+++ b/supabase/functions/verify-booking-payment/index.ts
@@ -198,25 +198,50 @@ serve(async (req) => {
         logStep("Using default owner confirmation window", { minutes: ownerConfirmationWindowMinutes });
       }
 
-      // Calculate owner confirmation deadline
-      const ownerConfirmationDeadline = new Date();
-      ownerConfirmationDeadline.setMinutes(ownerConfirmationDeadline.getMinutes() + ownerConfirmationWindowMinutes);
+      // DEC-034: branch the owner-confirmation flow per listing source_type.
+      //   pre_booked   -> owner already has the resort reservation; skip the
+      //                   countdown, mark owner_confirmed immediately. The
+      //                   renter sees a Confirmed booking right away.
+      //   wish_matched -> owner has to go confirm at the resort; keep the
+      //                   existing deadline + reminder flow.
+      const sourceType: "pre_booked" | "wish_matched" =
+        booking.source_type === "wish_matched" ? "wish_matched" : "pre_booked";
+      logStep("Source type determined", { sourceType });
 
-      // Create booking_confirmations record with 48-hour deadline (escrow) + owner confirmation
       const confirmationDeadline = getConfirmationDeadline();
+      const ownerConfirmationDeadline = new Date();
+      ownerConfirmationDeadline.setMinutes(
+        ownerConfirmationDeadline.getMinutes() + ownerConfirmationWindowMinutes,
+      );
+
+      const confirmationInsertBody = sourceType === "pre_booked"
+        ? {
+            booking_id: bookingId,
+            listing_id: booking.listing_id,
+            owner_id: booking.listing?.owner_id,
+            confirmation_deadline: confirmationDeadline,
+            escrow_status: "pending_confirmation",
+            escrow_amount: booking.total_amount,
+            owner_confirmation_status: "owner_confirmed",
+            owner_confirmed_at: new Date().toISOString(),
+            owner_confirmation_deadline: null,
+            extensions_used: 0,
+          }
+        : {
+            booking_id: bookingId,
+            listing_id: booking.listing_id,
+            owner_id: booking.listing?.owner_id,
+            confirmation_deadline: confirmationDeadline,
+            escrow_status: "pending_confirmation",
+            escrow_amount: booking.total_amount,
+            owner_confirmation_status: "pending_owner",
+            owner_confirmation_deadline: ownerConfirmationDeadline.toISOString(),
+            extensions_used: 0,
+          };
+
       const { data: bookingConfirmation, error: confirmationError } = await supabaseClient
         .from("booking_confirmations")
-        .insert({
-          booking_id: bookingId,
-          listing_id: booking.listing_id,
-          owner_id: booking.listing?.owner_id,
-          confirmation_deadline: confirmationDeadline,
-          escrow_status: "pending_confirmation",
-          escrow_amount: booking.total_amount,
-          owner_confirmation_status: "pending_owner",
-          owner_confirmation_deadline: ownerConfirmationDeadline.toISOString(),
-          extensions_used: 0,
-        })
+        .insert(confirmationInsertBody)
         .select()
         .single();
 
@@ -273,23 +298,29 @@ serve(async (req) => {
           logStep("Warning: Failed to dispatch in-app notification", { error: String(dispatchError) });
         }
 
-        // Send owner confirmation request notification
-        try {
-          const notificationUrl = `${Deno.env.get("SUPABASE_URL")}/functions/v1/send-booking-confirmation-reminder`;
-          await fetch(notificationUrl, {
-            method: "POST",
-            headers: {
-              "Content-Type": "application/json",
-              "Authorization": `Bearer ${Deno.env.get("SUPABASE_ANON_KEY")}`,
-            },
-            body: JSON.stringify({
-              type: "owner_confirmation_request",
-              bookingConfirmationId: bookingConfirmation.id,
-            }),
-          });
-          logStep("Owner confirmation request notification sent");
-        } catch (emailError) {
-          logStep("Warning: Failed to send owner confirmation request", { error: String(emailError) });
+        // DEC-034: only send the "please confirm at the resort" email for
+        // wish_matched bookings. Pre_booked listings already have the
+        // reservation, so the email would be confusing.
+        if (sourceType === "wish_matched") {
+          try {
+            const notificationUrl = `${Deno.env.get("SUPABASE_URL")}/functions/v1/send-booking-confirmation-reminder`;
+            await fetch(notificationUrl, {
+              method: "POST",
+              headers: {
+                "Content-Type": "application/json",
+                "Authorization": `Bearer ${Deno.env.get("SUPABASE_ANON_KEY")}`,
+              },
+              body: JSON.stringify({
+                type: "owner_confirmation_request",
+                bookingConfirmationId: bookingConfirmation.id,
+              }),
+            });
+            logStep("Owner confirmation request notification sent (wish_matched)");
+          } catch (emailError) {
+            logStep("Warning: Failed to send owner confirmation request", { error: String(emailError) });
+          }
+        } else {
+          logStep("Skipping owner-confirmation email — booking is pre_booked");
         }
       }
 


### PR DESCRIPTION
## Summary

Phase 2 of 5 for [#380](https://github.com/rent-a-vacation/rav-website/issues/380). First **user-visible behavior change** in the flow-distinction rollout. Builds on Phase 1 (PR #385) schema.

## Changes

### `create-booking-checkout`
- Inherits \`source_type\` from the listing when creating the booking row
- For \`wish_matched\` listings, also fetches the originating \`travel_proposal\` and stores \`travel_proposal_id\` on the booking

### `verify-booking-payment`
Branches the owner-confirmation flow per \`booking.source_type\`:

| Source type | Behavior |
|---|---|
| \`pre_booked\` | \`booking_confirmations\` created with \`owner_confirmation_status='owner_confirmed'\`, \`owner_confirmed_at=now()\`, no deadline. **Skips the "please confirm at resort" email** (confusing since owner already has the reservation). Renter sees a Confirmed booking immediately. |
| \`wish_matched\` | Existing behavior preserved — \`pending_owner\` status with countdown, reminder email, owner UI countdown timer |

In-app "new booking" notification still dispatched for both flows.

## Deployment
- [x] \`create-booking-checkout\` deployed to DEV with \`--no-verify-jwt\`
- [x] \`verify-booking-payment\` deployed to DEV with \`--no-verify-jwt\`
- [ ] After merge: both deployed to PROD

## Test plan
- [x] \`npx tsc --noEmit\` — clean
- [x] \`npx vitest run src/hooks/useBidding.test.ts\` — 24 tests pass (Phase 2 is edge-function only; no frontend tests needed)
- [ ] Manual smoke on DEV after merge: traveler books a pre-booked listing → land on /booking-success → MyTrips shows Confirmed (no countdown). Separately: traveler accepts an Offer on a Wish → books → owner sees countdown to confirm. QA scenarios will validate both in Phase 5.

## Upcoming phases
- **Phase 3** — UI type + status badges; OwnerConfirmationTimer hidden for pre_booked
- **Phase 4** — Admin wish-matched verification queue + 3 new notification type_keys
- **Phase 5** — USER-GUIDE / FAQ / ARCHITECTURE / QA-PLAYBOOK

## Follow-up
Edge function test harness for Stripe-touching functions is tracked in #371 — will land these changes' coverage there once that infra exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)