### PR TITLE
feat(flow) Phase 3/5 of #380: ListingTypeBadge + critical search filter fix

### DIFF
--- a/src/components/marketplace/ListingTypeBadge.test.tsx
+++ b/src/components/marketplace/ListingTypeBadge.test.tsx
@@ -1,0 +1,40 @@
+// @p0
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { ListingTypeBadge } from "./ListingTypeBadge";
+
+describe("ListingTypeBadge", () => {
+  it("renders 'Pre-Booked Stay' for pre_booked", () => {
+    render(<ListingTypeBadge type="pre_booked" />);
+    expect(screen.getByText("Pre-Booked Stay")).toBeInTheDocument();
+  });
+
+  it("renders 'Wish-Matched Stay' for wish_matched", () => {
+    render(<ListingTypeBadge type="wish_matched" />);
+    expect(screen.getByText("Wish-Matched Stay")).toBeInTheDocument();
+  });
+
+  it("renders a descriptive tooltip (title attribute) for pre_booked", () => {
+    render(<ListingTypeBadge type="pre_booked" />);
+    const badge = screen.getByText("Pre-Booked Stay").closest("[title]");
+    expect(badge?.getAttribute("title")).toContain("Owner has the resort reservation");
+  });
+
+  it("renders a descriptive tooltip for wish_matched", () => {
+    render(<ListingTypeBadge type="wish_matched" />);
+    const badge = screen.getByText("Wish-Matched Stay").closest("[title]");
+    expect(badge?.getAttribute("title")).toContain("traveler's Wish");
+  });
+
+  it("applies size=sm with smaller text", () => {
+    const { container } = render(<ListingTypeBadge type="pre_booked" size="sm" />);
+    expect(container.querySelector(".text-\\[10px\\]")).toBeInTheDocument();
+  });
+
+  it("accepts additional className", () => {
+    const { container } = render(
+      <ListingTypeBadge type="pre_booked" className="ml-2" />,
+    );
+    expect(container.querySelector(".ml-2")).toBeInTheDocument();
+  });
+});

--- a/src/components/marketplace/ListingTypeBadge.tsx
+++ b/src/components/marketplace/ListingTypeBadge.tsx
@@ -1,0 +1,59 @@
+import { Badge } from "@/components/ui/badge";
+import { CalendarCheck, Sparkles } from "lucide-react";
+import type { ListingSourceType } from "@/types/database";
+
+/**
+ * Visual identifier for the two marketplace flows (DEC-034).
+ * Always renders — even pre_booked (the default) — so the distinction is
+ * part of the mental model users see consistently across the app.
+ */
+interface ListingTypeBadgeProps {
+  type: ListingSourceType;
+  size?: "sm" | "md";
+  className?: string;
+}
+
+const CONFIG: Record<ListingSourceType, {
+  label: string;
+  icon: React.ReactNode;
+  className: string;
+  title: string;
+}> = {
+  pre_booked: {
+    label: "Pre-Booked Stay",
+    icon: <CalendarCheck className="h-3 w-3" />,
+    className:
+      "border-emerald-500/50 bg-emerald-50 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300",
+    title:
+      "Owner has the resort reservation already — this stay is ready to book and confirmed immediately on payment.",
+  },
+  wish_matched: {
+    label: "Wish-Matched Stay",
+    icon: <Sparkles className="h-3 w-3" />,
+    className:
+      "border-amber-500/50 bg-amber-50 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300",
+    title:
+      "This stay matched a traveler's Wish. Owner will confirm the resort reservation after booking is accepted.",
+  },
+};
+
+export function ListingTypeBadge({ type, size = "md", className = "" }: ListingTypeBadgeProps) {
+  const config = CONFIG[type];
+  return (
+    <Badge
+      variant="outline"
+      title={config.title}
+      className={[
+        "gap-1",
+        config.className,
+        size === "sm" ? "text-[10px] px-1.5 py-0.5" : "text-xs",
+        className,
+      ]
+        .filter(Boolean)
+        .join(" ")}
+    >
+      {config.icon}
+      <span>{config.label}</span>
+    </Badge>
+  );
+}

--- a/src/components/owner/OwnerListings.tsx
+++ b/src/components/owner/OwnerListings.tsx
@@ -48,6 +48,7 @@ import { BidsManagerDialog } from "@/components/bidding/BidsManagerDialog";
 import { ActionSuccessCard } from "@/components/ActionSuccessCard";
 import { sendListingSubmittedEmail } from "@/lib/email";
 import { ListingFairValueBadge } from "@/components/fair-value/ListingFairValueBadge";
+import { ListingTypeBadge } from "@/components/marketplace/ListingTypeBadge";
 import { DemandSignal } from "@/components/bidding/DemandSignal";
 import { calculateNights, computeListingPricing } from "@/lib/pricing";
 
@@ -664,7 +665,7 @@ const OwnerListings = () => {
               <CardHeader className="pb-3">
                 <div className="flex items-start justify-between">
                   <div>
-                    <div className="flex items-center gap-2 mb-1">
+                    <div className="flex items-center gap-2 mb-1 flex-wrap">
                       <Badge className={
                         listing.status === 'active' && isPast(new Date(listing.check_out_date))
                           ? 'bg-orange-500'
@@ -674,6 +675,10 @@ const OwnerListings = () => {
                           ? 'Expired'
                           : STATUS_LABELS[listing.status]}
                       </Badge>
+                      <ListingTypeBadge
+                        type={(listing as { source_type?: "pre_booked" | "wish_matched" }).source_type ?? "pre_booked"}
+                        size="sm"
+                      />
                       {/* Bidding Status Badge */}
                       {listing.open_for_bidding && listing.bidding_ends_at && (
                         isPast(new Date(listing.bidding_ends_at)) ? (

--- a/src/hooks/useListings.test.ts
+++ b/src/hooks/useListings.test.ts
@@ -28,20 +28,28 @@ beforeEach(() => {
   resetListingCounter();
 });
 
+// Helper: build a two-eq chain for useActiveListings (status + source_type filters)
+// Returns .eq returning a chainable that itself has .eq -> same chain, then .gte -> terminal
+function buildTwoEqChain(terminal: unknown) {
+  const chain: Record<string, unknown> = { gte: mockGte.mockReturnValue(terminal) };
+  chain.eq = vi.fn().mockReturnValue(chain);
+  return chain;
+}
+
 describe("useActiveListings @p0", () => {
   it("returns active listings on success", async () => {
     const listings = mockListings(3);
 
     mockFrom.mockReturnValue({
       select: mockSelect.mockReturnValue({
-        eq: mockEq.mockReturnValue({
-          gte: mockGte.mockReturnValue({
+        eq: mockEq.mockReturnValue(
+          buildTwoEqChain({
             order: mockOrder.mockResolvedValue({
               data: listings,
               error: null,
             }),
           }),
-        }),
+        ),
       }),
     });
 
@@ -58,14 +66,14 @@ describe("useActiveListings @p0", () => {
   it("returns empty array when no listings exist", async () => {
     mockFrom.mockReturnValue({
       select: mockSelect.mockReturnValue({
-        eq: mockEq.mockReturnValue({
-          gte: mockGte.mockReturnValue({
+        eq: mockEq.mockReturnValue(
+          buildTwoEqChain({
             order: mockOrder.mockResolvedValue({
               data: [],
               error: null,
             }),
           }),
-        }),
+        ),
       }),
     });
 
@@ -80,14 +88,14 @@ describe("useActiveListings @p0", () => {
   it("handles database errors", async () => {
     mockFrom.mockReturnValue({
       select: mockSelect.mockReturnValue({
-        eq: mockEq.mockReturnValue({
-          gte: mockGte.mockReturnValue({
+        eq: mockEq.mockReturnValue(
+          buildTwoEqChain({
             order: mockOrder.mockResolvedValue({
               data: null,
               error: { message: "Database error" },
             }),
           }),
-        }),
+        ),
       }),
     });
 
@@ -135,14 +143,14 @@ describe("useListing", () => {
 
 describe("useActiveListingsCount", () => {
   it("returns count of active listings", async () => {
+    // Two .eq() calls (status, source_type) chained then .gte() resolves
+    const gteTerminal = mockGte.mockResolvedValue({ count: 5, error: null });
+    const countChain: Record<string, unknown> = { gte: gteTerminal };
+    countChain.eq = vi.fn().mockReturnValue(countChain);
+
     mockFrom.mockReturnValue({
       select: mockSelect.mockReturnValue({
-        eq: mockEq.mockReturnValue({
-          gte: mockGte.mockResolvedValue({
-            count: 5,
-            error: null,
-          }),
-        }),
+        eq: mockEq.mockReturnValue(countChain),
       }),
     });
 

--- a/src/hooks/useListings.ts
+++ b/src/hooks/useListings.ts
@@ -67,6 +67,10 @@ export function useActiveListings() {
           )
         `)
         .eq('status', 'active')
+        // DEC-034: wish_matched listings are auto-created for a specific
+        // accepting traveler and should never appear in generic search.
+        // They remain reachable via useListing() for that traveler's checkout.
+        .eq('source_type', 'pre_booked')
         .gte('check_out_date', today)
         .order('created_at', { ascending: false });
 
@@ -113,6 +117,7 @@ export function useActiveListingsCount() {
         .from('listings')
         .select('*', { count: 'exact', head: true })
         .eq('status', 'active')
+        .eq('source_type', 'pre_booked')
         .gte('check_out_date', today);
 
       if (error) throw error;

--- a/src/pages/MyBookings.tsx
+++ b/src/pages/MyBookings.tsx
@@ -22,6 +22,7 @@ import { BookingTimeline } from "@/components/booking/BookingTimeline";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { CancellationPolicyDetail } from "@/components/CancellationPolicyDetail";
 import { getCheckInCountdown, isImminentCheckIn } from "@/lib/renterDashboard";
+import { ListingTypeBadge } from "@/components/marketplace/ListingTypeBadge";
 
 interface DisputeInfo {
   id: string;
@@ -210,6 +211,7 @@ const MyBookings = ({ embedded }: { embedded?: boolean }) => {
               <Badge className={STATUS_COLORS[booking.status]}>
                 {STATUS_LABELS[booking.status]}
               </Badge>
+              <ListingTypeBadge type={booking.source_type ?? "pre_booked"} size="sm" />
               {countdownText && (
                 <Badge
                   variant="outline"

--- a/src/pages/PropertyDetail.tsx
+++ b/src/pages/PropertyDetail.tsx
@@ -31,6 +31,7 @@ import {
   Shield,
 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
+import { ListingTypeBadge } from "@/components/marketplace/ListingTypeBadge";
 import { useListing, useActiveListings } from "@/hooks/useListings";
 import { usePageMeta } from "@/hooks/usePageMeta";
 import { useJsonLd } from "@/hooks/useJsonLd";
@@ -371,8 +372,9 @@ const PropertyDetail = () => {
                 <h1 className="font-display text-3xl md:text-4xl font-bold text-foreground tracking-tight mb-3">
                   {displayName}
                 </h1>
-                {/* Social proof badges */}
+                {/* Social proof + type badges */}
                 <div className="flex flex-wrap items-center gap-2 mb-4">
+                  <ListingTypeBadge type={(listing as { source_type?: "pre_booked" | "wish_matched" })?.source_type ?? "pre_booked"} />
                   {popularityLabel && (
                     <Badge className="bg-orange-500/90 text-white border-0">
                       <Flame className="w-3 h-3 mr-1" />


### PR DESCRIPTION
## Summary

Phase 3 of 5 for [#380](https://github.com/rent-a-vacation/rav-website/issues/380). First **visible UI** phase — users now see the Pre-Booked Stay / Wish-Matched Stay distinction. Builds on Phase 1 schema (#385) and Phase 2 edge function branching (#386).

## Changes

### New component: \`ListingTypeBadge\`
- Renders "Pre-Booked Stay" (emerald) or "Wish-Matched Stay" (amber)
- Descriptive \`title\` tooltip explains each type in user-friendly language
- \`size=\"sm\" | \"md\"\` variants
- 6 new tests, tagged @p0

### Badge applied to three surfaces
| Surface | Why |
|---|---|
| **MyBookings** card | Traveler sees both flow types in their bookings history |
| **PropertyDetail** page | Listing detail needs the origin context |
| **OwnerListings** card | Owner sees both types in their listings |

Not applied to **ListingCard** (search results) because search results are now filtered to pre_booked-only (see below), so the badge would always say the same thing there.

### Critical bug fix surfaced during implementation

\`useActiveListings\` + \`useActiveListingsCount\` previously returned BOTH types in generic search. That meant a wish_matched listing auto-created for Traveler A's accepted Offer could be seen and booked by Traveler B browsing search. Filter now restricts public search to \`source_type='pre_booked'\`; wish_matched listings are still reachable via \`useListing(id)\` for the accepting traveler's checkout.

### OwnerConfirmationTimer

No change needed — Phase 2 sets \`owner_confirmation_status='owner_confirmed'\` for pre_booked bookings, and the parent filter (\`usePendingOwnerConfirmations\`) already filters on \`pending_owner\`, so the countdown naturally hides for Flow 1.

## Test plan
- [x] \`npx vitest run src/hooks/useListings.test.ts src/components/marketplace/ListingTypeBadge.test.tsx\` — 12 tests pass
- [x] \`npx tsc --noEmit\` clean
- [x] useListings tests updated to chain two .eq() calls (status + source_type)
- [ ] Manual smoke on DEV after merge: search shows Pre-Booked Stay badge on PropertyDetail; MyBookings shows type badge per booking; OwnerListings shows type badge per listing

## Upcoming phases
- **Phase 4** — Admin wish-matched verification queue + 3 new notification type_keys
- **Phase 5** — USER-GUIDE / FAQ / ARCHITECTURE / QA-PLAYBOOK docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)