### PR TITLE
feat(flow) Phase 4/5 of #380: wish-matched notifications + admin filter

### DIFF
--- a/src/components/admin/AdminEscrow.tsx
+++ b/src/components/admin/AdminEscrow.tsx
@@ -75,6 +75,7 @@ import type {
 import { AdminEntityLink } from "./AdminEntityLink";
 import { DateRangeFilter } from "./DateRangeFilter";
 import { AgeBadge } from "./AgeBadge";
+import { ListingTypeBadge } from "@/components/marketplace/ListingTypeBadge";
 
 interface EscrowWithDetails extends BookingConfirmation {
   booking: Booking & {
@@ -131,6 +132,7 @@ const AdminEscrow = ({ initialSearch = "", onNavigateToEntity }: { initialSearch
   const [isLoading, setIsLoading] = useState(true);
   const [searchQuery, setSearchQuery] = useState(initialSearch);
   const [statusFilter, setStatusFilter] = useState<string>("all");
+  const [sourceFilter, setSourceFilter] = useState<string>("all");
   const [dateRange, setDateRange] = useState<DateRange | undefined>();
   const [selectedEscrow, setSelectedEscrow] = useState<EscrowWithDetails | null>(null);
   const [isDetailsDialogOpen, setIsDetailsDialogOpen] = useState(false);
@@ -424,12 +426,15 @@ const AdminEscrow = ({ initialSearch = "", onNavigateToEntity }: { initialSearch
 
     const matchesStatus = statusFilter === "all" || e.escrow_status === statusFilter;
 
+    const matchesSource = sourceFilter === "all" ||
+      ((e.booking as Record<string, unknown> | undefined)?.source_type ?? "pre_booked") === sourceFilter;
+
     const matchesDateRange = !dateRange?.from || isWithinInterval(
       new Date(e.created_at),
       { start: startOfDay(dateRange.from), end: endOfDay(dateRange.to || dateRange.from) }
     );
 
-    return matchesSearch && matchesStatus && matchesDateRange;
+    return matchesSearch && matchesStatus && matchesSource && matchesDateRange;
   });
 
   // Stats
@@ -487,6 +492,16 @@ const AdminEscrow = ({ initialSearch = "", onNavigateToEntity }: { initialSearch
               <SelectItem value="released">Released</SelectItem>
               <SelectItem value="refunded">Refunded</SelectItem>
               <SelectItem value="disputed">Disputed</SelectItem>
+            </SelectContent>
+          </Select>
+          <Select value={sourceFilter} onValueChange={setSourceFilter}>
+            <SelectTrigger className="w-40">
+              <SelectValue placeholder="Filter by type" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All Types</SelectItem>
+              <SelectItem value="pre_booked">Pre-Booked Stay</SelectItem>
+              <SelectItem value="wish_matched">Wish-Matched Stay</SelectItem>
             </SelectContent>
           </Select>
           <DateRangeFilter value={dateRange} onChange={setDateRange} />
@@ -651,6 +666,10 @@ const AdminEscrow = ({ initialSearch = "", onNavigateToEntity }: { initialSearch
                             {ESCROW_STATUS_CONFIG[escrow.escrow_status].icon}
                             {ESCROW_STATUS_CONFIG[escrow.escrow_status].label}
                           </Badge>
+                          <ListingTypeBadge
+                            type={((escrow.booking as Record<string, unknown> | undefined)?.source_type as "pre_booked" | "wish_matched") ?? "pre_booked"}
+                            size="sm"
+                          />
                           {escrow.payout_held && (
                             <Badge variant="outline" className="text-orange-600 border-orange-600 w-fit text-xs">
                               <PauseCircle className="h-3 w-3 mr-1" />

--- a/src/hooks/useOwnerConfirmation.ts
+++ b/src/hooks/useOwnerConfirmation.ts
@@ -130,6 +130,42 @@ export function useConfirmBooking() {
         .eq('id', bookingConfirmationId);
 
       if (error) throw error;
+
+      // DEC-034 Phase 4: for wish_matched bookings, dispatch the traveler
+      // notification that their Wish-Matched booking is now confirmed.
+      // Fire-and-forget — the confirmation already succeeded; the dispatch
+      // is a follow-up UX win.
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const { data: conf } = await (supabase as any)
+          .from('booking_confirmations')
+          .select('booking_id, booking:bookings(id, renter_id, source_type, listing_id, listing:listings(property:properties(resort_name)))')
+          .eq('id', bookingConfirmationId)
+          .single();
+
+        const booking = conf?.booking;
+        if (booking?.source_type === 'wish_matched' && booking?.renter_id) {
+          const resortName = booking?.listing?.property?.resort_name;
+          supabase.functions.invoke('notification-dispatcher', {
+            body: {
+              type_key: 'wish_owner_confirmed',
+              user_id: booking.renter_id,
+              payload: {
+                title: 'Wish-Matched booking confirmed',
+                message: resortName
+                  ? `The owner has confirmed your stay at ${resortName}. You're all set.`
+                  : "The owner has confirmed your stay. You're all set.",
+                booking_id: booking.id,
+                listing_id: booking.listing_id,
+              },
+            },
+          }).catch(() => {
+            // Best-effort; confirmation already succeeded
+          });
+        }
+      } catch {
+        // Non-blocking — do not fail the confirmation
+      }
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['owner-confirmation'] });

--- a/supabase/functions/verify-booking-payment/index.ts
+++ b/supabase/functions/verify-booking-payment/index.ts
@@ -319,6 +319,31 @@ serve(async (req) => {
           } catch (emailError) {
             logStep("Warning: Failed to send owner confirmation request", { error: String(emailError) });
           }
+
+          // DEC-034 Phase 4: notify the traveler that their Wish-Matched
+          // booking is waiting on owner confirmation. Gives them visibility
+          // into the window (today they were silent after Offer acceptance).
+          try {
+            const resortName = ((booking.listing as Record<string, unknown>)?.property as Record<string, unknown>)?.resort_name as string | undefined;
+            await supabaseClient.functions.invoke("notification-dispatcher", {
+              body: {
+                type_key: "wish_owner_confirming",
+                user_id: booking.renter_id,
+                payload: {
+                  title: "Owner confirming your booking",
+                  message: resortName
+                    ? `Your Wish-Matched booking at ${resortName} is waiting on the owner's resort confirmation. We'll notify you as soon as they confirm.`
+                    : "Your Wish-Matched booking is waiting on the owner's resort confirmation. We'll notify you as soon as they confirm.",
+                  booking_id: booking.id,
+                  listing_id: booking.listing_id,
+                  deadline: ownerConfirmationDeadline.toISOString(),
+                },
+              },
+            });
+            logStep("Wish-Matched traveler notification dispatched", { renterId: booking.renter_id });
+          } catch (dispatchError) {
+            logStep("Warning: Failed to dispatch wish_owner_confirming", { error: String(dispatchError) });
+          }
         } else {
           logStep("Skipping owner-confirmation email — booking is pre_booked");
         }

--- a/supabase/migrations/059_wish_matched_notifications.sql
+++ b/supabase/migrations/059_wish_matched_notifications.sql
@@ -1,0 +1,38 @@
+-- Migration 059: Notification catalog entries for Wish-Matched Stay lifecycle
+-- DEC-034 Phase 4 — adds three notification type_keys so wish-matched travelers
+-- get visibility into the owner-confirmation process after they accept an Offer.
+
+INSERT INTO public.notification_catalog (
+  type_key, display_name, description, category, opt_out_level,
+  default_in_app, default_email, default_sms,
+  channel_in_app_allowed, channel_email_allowed, channel_sms_allowed,
+  sort_order
+) VALUES
+  (
+    'wish_owner_confirming',
+    'Owner Confirming Your Booking',
+    'Your Wish-Matched booking is awaiting the owner''s resort confirmation. Sent right after payment.',
+    'transactional', 'mandatory',
+    true, true, false,
+    true, true, false,
+    14
+  ),
+  (
+    'wish_owner_confirmed',
+    'Wish-Matched Booking Confirmed',
+    'The owner has confirmed their resort reservation — your stay is locked in.',
+    'transactional', 'mandatory',
+    true, true, false,
+    true, true, false,
+    15
+  ),
+  (
+    'wish_owner_failed_to_confirm',
+    'Wish-Matched Booking Could Not Be Confirmed',
+    'The owner could not confirm the resort reservation in time. Your booking is cancelled and your payment is being refunded.',
+    'transactional', 'mandatory',
+    true, true, false,
+    true, true, false,
+    16
+  )
+ON CONFLICT (type_key) DO NOTHING;


### PR DESCRIPTION
## Summary

Phase 4 of 5 for [#380](https://github.com/rent-a-vacation/rav-website/issues/380). Closes the traveler-visibility gap for wish-matched bookings — after accepting an Offer, the traveler now gets proactive notifications as the owner works through the resort-confirmation step.

## Changes

### Migration 059 — 3 new notification catalog entries
- \`wish_owner_confirming\` — dispatched after payment verification; tells traveler their Wish-Matched booking is waiting on owner's resort confirmation
- \`wish_owner_confirmed\` — dispatched when owner marks the booking confirmed
- \`wish_owner_failed_to_confirm\` — placeholder for future timeout-handling cron (no dispatch yet)

All three are \`mandatory\` (transactional) and support in-app + email.

### Edge function
- \`verify-booking-payment\`: after the wish_matched email goes out, also dispatches \`wish_owner_confirming\` to the renter via \`notification-dispatcher\`, with the owner confirmation deadline in the payload

### Frontend
- \`useConfirmBooking\` hook: after a confirmation succeeds, if the booking is wish_matched, dispatches \`wish_owner_confirmed\` (fire-and-forget; doesn't fail the confirmation if dispatch hiccups)
- \`AdminEscrow\`:
  - New **Filter by type** select: All Types / Pre-Booked Stay / Wish-Matched Stay
  - Inline \`ListingTypeBadge\` below the Escrow Status badge in each row, so staff can spot and triage Wish-Matched bookings at a glance without filtering

## Intentionally deferred (not needed for Phase 4 user-value)

- **AdminWishMatchedVerifications stand-alone tab** — the filter + badge already surfaces Wish-Matched bookings in AdminEscrow; a dedicated tab would duplicate views without adding new capability
- **confirm-wish-booking dedicated edge function** — existing \`booking_confirmations\` flow with \`resort_confirmation_number\` already supports the step; no net-new endpoint needed
- **\`wish_owner_failed_to_confirm\` dispatch** — requires a timeout cron (no such cron exists for owner-confirmation timeouts today); parked for a separate issue

## Test plan
- [x] \`npx tsc --noEmit\` clean
- [x] \`npx vitest run src/hooks/useBidding.test.ts src/components/marketplace/ListingTypeBadge.test.tsx\` — 30 tests pass
- [x] Migration 059 applied to DEV
- [x] \`verify-booking-payment\` redeployed to DEV with \`--no-verify-jwt\`
- [ ] After merge: migration + edge function redeploy to PROD

## Upcoming
- **Phase 5** — USER-GUIDE / FAQ / ARCHITECTURE flow manifests / BRAND-LOCK §9 / QA-PLAYBOOK S-##a/S-##b split

🤖 Generated with [Claude Code](https://claude.com/claude-code)