### PR TITLE
docs(roadmap): refresh tiers and revision history through Session 56

### DIFF
--- a/docs/PRIORITY-ROADMAP.md
+++ b/docs/PRIORITY-ROADMAP.md
@@ -1,7 +1,7 @@
 ---
-last_updated: "2026-04-20T02:55:17"
-change_ref: "f82a427"
-change_type: "session-54"
+last_updated: "2026-04-20T13:54:34"
+change_ref: "24ac5f1"
+change_type: "session-56"
 status: "active"
 ---
 # PRIORITY ROADMAP — Rent-A-Vacation
@@ -12,22 +12,41 @@ status: "active"
 
 ---
 
-## Changelog since last tier assignment (Sessions 50–54)
+## Changelog since last tier assignment (Sessions 50–56)
 
 - **Session 50-53 shipped:** Event unification (#338, #339), MDM WS1/WS2/WS3 (DEC-032), Brand/terminology lock (DEC-031), Site-wide UI polish, 5 tier-gated features (#278-#282 — all Tier C items now **DONE**), Sentry guide, API docs audit.
-- **Session 54 shipped:** Stripe Tax env-flag gate (`STRIPE_TAX_ENABLED`), edge function JWT config hardening, migration 057 catch-up to DEV + PROD, MDM script CI fix, and 3 QA-surfaced bug fixes (offers-tab crash, owner bid notification, owner booking notification).
-- **New follow-up issues opened in Session 54:**
-  - **#370** — Platform synthetic uptime monitoring (DEC-033 — Checkly SaaS). Post-launch, not Tier A.
-  - **#371** — Add edge function test harness (CLAUDE.md Tests-With-Features follow-up). Needs tier assignment.
-- **QA audit items surfaced from testing (need issues + tier assignment):** terminology sync, listing verification UX, cancel listing flow, "Open for bidding" indicator, MyTrips post-booking detail view, Track 1 vs Track 2 user mental model.
+- **Session 54 shipped:** Stripe Tax env-flag gate (`STRIPE_TAX_ENABLED`), edge function JWT config hardening, migration 057 catch-up to DEV + PROD, MDM script CI fix, and 3 QA-surfaced bug fixes (offers-tab crash, owner bid notification, owner booking notification). PRs #372-#374.
+- **Session 55 shipped:** QA audit response (S-01..S-05 read; 7 new issues opened — #375-#381); Phase A UX wins: **#379 MyTrips booking detail view** (fee breakdown, cancellation policy, resort confirmation, check-in countdown — PR #382) and **#375 Path 3 hybrid dashboard naming** (role-descriptive eyebrows above brand H1, mobile nav fix — PR #383); `/sdlc` Phase 6 doc-update checklist expanded. PRs #382-#384.
+- **Session 56 shipped — DEC-034 Marketplace Flow Distinction end-to-end (#380 CLOSED):** 5 incremental PRs (#385-#389). Schema: `listing_source_type` enum + `source_type` column on listings/bookings + `travel_proposal_id` FK (Migration 058). Edge functions branch per source_type: Pre-Booked auto-confirms; Wish-Matched keeps countdown. `ListingTypeBadge` visual system applied to MyBookings, PropertyDetail, OwnerListings, AdminEscrow. **Critical search-filter bug fixed** (wish-matched listings no longer leak to unrelated travelers). 3 new notification types: `wish_owner_confirming`, `wish_owner_confirmed`, `wish_owner_failed_to_confirm` (Migration 059). AdminEscrow filter by type + badge per row. `/sdlc` Phase 6 checklist promoted to root `CLAUDE.md` (PR #390) so doc-sync applies to every session regardless of entry point.
+
+### Issues closed in Sessions 55-56
+- ✅ **#375** — Dashboard terminology alignment (Session 55, PR #383)
+- ✅ **#379** — MyTrips booking detail view (Session 55, PR #382)
+- ✅ **#380** — Marketplace Flow Distinction / DEC-034 (Session 56, PRs #385-#389)
+
+### New follow-up issues still open (need work or tier assignment)
+- **#370** — Platform synthetic uptime monitoring (DEC-033 — Checkly SaaS). Post-launch → Tier E.
+- **#371** — Edge function test harness (CLAUDE.md Tests-With-Features follow-up). Tier B (needs scope decision).
+- **#376** — Pre-Booked listing verification proof workflow (unblocked by DEC-034). **Ready for Tier A.**
+- **#377** — Cancel-listing cascade (bids + bookings + escrow + notifications). Standalone. **Ready for Tier A.**
+- **#378** — "Open for Bidding" indicator across all surfaces (unblocked by DEC-034). **Ready for Tier A.**
+- **#381** — Role-relevant landing-view ordering. **Ready for Tier A.**
 
 ---
 
-## Current Priority Tiers (as of April 13, 2026 — Session 49)
+## Current Priority Tiers (as of April 20, 2026 — Session 56)
 
 ### Tier A: Build Next (High Impact, Code-Ready)
 
-**Tier A is EMPTY** — all items completed in Session 49. Promote from Tier B/C as needed.
+All unblocked follow-ups from Sessions 54-56 QA audit work. Pick in any order; they're independent.
+
+| Issue | Title | Est. | Why now |
+|-------|-------|------|---------|
+| **#376** | Pre-Booked listing verification (resort reservation proof) | 1-2d | Unblocked by DEC-034 — proof-collection UX only meaningful after the flow distinction exists (which it now does). New schema fields + admin verify dialog + email templates. |
+| **#378** | "Open for Bidding" indicator everywhere (create-time toggle + consistent badge) | 3-4h | Unblocked by DEC-034 — integrates with the ListingTypeBadge visual system. |
+| **#381** | Role-relevant landing-view ordering | 6-8h | Surface most-time-sensitive items on each dashboard's Overview tab per "rooted in simplicity" principle. |
+| **#377** | Cancel-listing cascade (bulk bid rejection + booking cancellation + notifications) | 1d | Standalone, coordinates with DEC-034 wish-matched handling. New edge function + atomic cascade. |
+| **#371** | Edge function test harness | 1-2d (needs scoping) | Tech-debt follow-up from Tests-With-Features shortfalls. Enables future edge-fn work to be properly tested. |
 
 ### Tier B: Pre-Launch Important (Needs Human Input)
 
@@ -79,6 +98,7 @@ Park these until after launch or until specific triggers.
 | #107 | Blog / content marketing | After launch, for SEO |
 | #225 | Slack workspace for partners | After first partner |
 | #226-228 | Sentry enhancements (3 issues) | Post-launch monitoring needs |
+| #370 | Checkly synthetic uptime monitoring (DEC-033) | Post-launch — complements Sentry, covers critical-path health |
 | #224 | One-Time Events support | Future — after event search ships |
 | #165 | Owner Volume Discount | Needs decision — post-launch |
 | #166 | Membership tier value prop | Needs decision — post-launch |
@@ -104,6 +124,9 @@ These unblock when the LLC is formed. Not code-dependent.
 
 | Date | Session | Changes |
 |------|---------|---------|
+| Apr 20, 2026 | 56 | **DEC-034 Marketplace Flow Distinction SHIPPED end-to-end (#380 CLOSED)** via 5 incremental PRs (#385-#389). Migrations 058 + 059. `listing_source_type` enum + `ListingTypeBadge` everywhere. Critical search-filter fix. 3 new notification types. `/sdlc` doc-update checklist promoted to root `CLAUDE.md` (PR #390) so it applies to every session. 1146 tests. Issues unblocked: #376, #378, #381. |
+| Apr 20, 2026 | 55 | QA audit response: read S-01..S-05 from scenario spreadsheet, opened 7 new issues (#375-#381) with full findings. Shipped Phase A UX wins: #379 MyTrips booking detail (PR #382), #375 Path 3 hybrid dashboard naming (PR #383). Expanded `/sdlc` Phase 6 into 13-item doc-update checklist. 1140 tests. DEC-035 (dashboard naming) logged. |
+| Apr 18-19, 2026 | 54 | Stripe Tax env-flag gate (`STRIPE_TAX_ENABLED`) fixes dev + PROD checkout blocker. Edge function JWT regression fixed via `config.toml` + `--no-verify-jwt`. Migration 057 deployed. MDM script CI fix. 3 bug fixes surfaced by QA testing (offers crash, owner bid/booking notifications). PRs #372-#374. Opened #370, #371. DEC-033 (Checkly monitoring). 1133 tests. |
 | Apr 15-16, 2026 | 52 | Terminology lock (Listing/Wish/Offer, DEC-031). UI polish (30 pages). Bug fixes #353+#354. MDM Resort Data complete (DEC-032): WS1 schema hardening, WS2 data quality + normalisation + descriptions, WS3 API enhancement. All deployed to DEV + PROD. Brand docs scrubbed. 1090 tests. PRs #352-#365. |
 | Apr 14, 2026 | 51 | #349 UI polish audit completed. New `Section` + `SectionHeader` layout primitives. Tightened vertical rhythm, headings, and section demarcation across Homepage, PropertyDetail, Rentals, BiddingMarketplace, OwnerDashboard, MyBookings, ListProperty. Build clean, P0 tests passing. |
 | Apr 14, 2026 | 50 | #338 + #339 completed. Events unified into DB (migration 055) + multi-year generator RPC (migration 056). Admin Templates tab + Add/Edit Instance dialogs + "Generate {next year}" button. `useCuratedEvents` hook. docs-audit CI permissions fix. ARCHITECTURE + COMPLETED-PHASES refreshed. PRs #350, #351. 1046 tests. |


### PR DESCRIPTION
## Summary

PRIORITY-ROADMAP was stale — header still said "Session 49" and Tier A claimed empty. With Sessions 54-56 having shipped 11 PRs and closed 3 issues, the next session bootstrap (via \`/sdlc status\`) would have miscalled the current state.

## Changes

- **Header:** "as of April 13 — Session 49" → "as of April 20 — Session 56"
- **Tier A populated** with 5 ready-to-work follow-ups: #376, #378, #381, #377, #371 (all unblocked by DEC-034 or standalone)
- **Changelog** extended to cover Sessions 54, 55, 56 — including the #380 Marketplace Flow Distinction epic (5 PRs: #385-#389)
- **Issues closed section** added: #375, #379, #380
- **Tier E** added #370 (Checkly monitoring, post-launch)
- **Revision History** extended with Session 54, 55, 56 entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)