### PR TITLE
feat(support-agent): Phase 22 C1 + C4 — support context + 5 agent tools (#405, #408)

### DIFF
--- a/docs/PRIORITY-ROADMAP.md
+++ b/docs/PRIORITY-ROADMAP.md
@@ -1,7 +1,7 @@
 ---
-last_updated: "2026-04-21T23:23:19"
-change_ref: "3905aa8"
-change_type: "session-57"
+last_updated: "2026-04-22T23:47:09"
+change_ref: "c820f23"
+change_type: "session-58"
 status: "active"
 ---
 # PRIORITY ROADMAP — Rent-A-Vacation
@@ -37,19 +37,19 @@ status: "active"
 
 ---
 
-## Current Priority Tiers (as of April 20, 2026 — Session 57)
+## Current Priority Tiers (as of April 22, 2026 — Session 58)
 
 ### Tier A: Build Next (High Impact, Code-Ready)
 
-All unblocked follow-ups from Sessions 54-57. Pick in any order; they're independent.
+All unblocked follow-ups from Sessions 54-58. Pick in any order; they're independent.
 
 | Issue | Title | Est. | Why now |
 |-------|-------|------|---------|
-| **#405** | Phase 22 C1: `context: 'support'` branch in text-chat edge fn | 4-6h | **Phase 22 next step.** Add support context to `supabase/functions/text-chat/` with auth check + support system prompt + tool-use schema. Pairs tightly with #408 (C4 — 5 agent tools). Do together. |
-| **#408** | Phase 22 C4: 5 agent tools (lookup_booking, check_refund_status, check_dispute_status, open_dispute, query_support_docs) | 1d | **Pair with #405.** All RLS-enforced, auth-scoped. Each has unit tests (happy + auth fail). `query_support_docs` queries the `support_docs` table (shipped in PR #420). Unit tests mandatory per CLAUDE.md Tests-With-Features. |
-| **#406** | Phase 22 C2: Route-based context detection in `useTextChat` | 4-6h | Depends on #405. Auto-switch support vs discovery by route. Suggested prompts swap per context. |
+| **#406** | Phase 22 C2: Route-based context detection in `useTextChat` | 4-6h | Unblocked by Session 58 (#405 + #408 shipped). Auto-switch support vs discovery by route. Suggested prompts swap per context. Small frontend-only PR. |
 | **#407** | Phase 22 C3: Intent classifier + "Switched to Support" chip | 4-6h | Depends on #406. Fallback for ambiguous routes. Keyword classifier + model fallback. Chip UI + session override. |
-| **#409** | Phase 22 C5: Agent-opened disputes with `source: 'ravio_support'` tag | 4h | Depends on #408. Migration adds `source` enum to disputes table. AdminDisputes UI shows badge. |
+| **#409** | Phase 22 C5: Agent-opened disputes with `source: 'ravio_support'` tag | 4h | Unblocked by Session 58. Migration adds `source` enum to disputes table; `open_dispute` tool updated to set it; AdminDisputes UI shows badge + filter. |
+| **#410** | Phase 22 D1: Support conversation logging | 6-8h | Unblocked by Session 58. Extend `conversations` table so support turns are captured for metrics + replay. |
+| **#411** | Phase 22 D2: Admin "Support Interactions" tab + metrics | 1d | Depends on #410. Deflection rate, escalation rate, SLA. |
 | **#376** | Pre-Booked listing verification (resort reservation proof) | 1-2d | Unblocked by DEC-034 — proof-collection UX only meaningful after the flow distinction exists (which it now does). New schema fields + admin verify dialog + email templates. |
 | **#378** | "Open for Bidding" indicator everywhere (create-time toggle + consistent badge) | 3-4h | Unblocked by DEC-034 — integrates with the ListingTypeBadge visual system. |
 | **#381** | Role-relevant landing-view ordering | 6-8h | Surface most-time-sensitive items on each dashboard's Overview tab per "rooted in simplicity" principle. |
@@ -57,7 +57,7 @@ All unblocked follow-ups from Sessions 54-57. Pick in any order; they're indepen
 | **#371** | Edge function test harness | 1-2d (needs scoping) | Tech-debt follow-up from Tests-With-Features shortfalls. Enables future edge-fn work to be properly tested. |
 | **#393** | PLATFORM-INVENTORY.md — one-page mental model of everything built | 2-3h | Session 56 meta-ask: a single doc cataloging product + platform + dev-tooling + governance layers so the user can explain what they've built to investors, new collaborators, and future sessions. |
 
-> **Phase 22 epic (#395)** — Tracks A, B, E complete in Session 57 (#396-#404, #412-#417 all CLOSED). Track C (#405-#409) + Track D (#410, #411) remain — all code work. Best next-session start: #405 + #408 together.
+> **Phase 22 epic (#395)** — Tracks A, B, E complete in Session 57; C1 + C4 (#405 + #408) shipped in Session 58. Remaining: #406, #407, #409 (Track C finale) + #410, #411 (Track D observability). Recommended next: #406 (small frontend-only) or #409 (completes the escalation loop end-to-end).
 
 ### Tier B: Pre-Launch Important (Needs Human Input)
 
@@ -136,6 +136,7 @@ These unblock when the LLC is formed. Not code-dependent.
 
 | Date | Session | Changes |
 |------|---------|---------|
+| Apr 22, 2026 | 58 | **Phase 22 C1 + C4 SHIPPED (#405 + #408).** `text-chat` edge fn gains `context:'support'` branch + 5 agent tools (lookup_booking, check_refund_status, check_dispute_status, open_dispute, query_support_docs). `check_refund_status` uses DB-first with live Stripe reconcile; fails closed. 20 new unit tests. Phase 22 now 77% complete (17 of 22). Remaining Tier A: #406, #407, #409, #410, #411. |
 | Apr 21, 2026 | 57 | **Phase 22 SHIPPED Tracks A + B + E (15 of 22 tickets, 8 PRs #418-#425).** Full documentation infrastructure end-to-end on DEV: 22 markdown files in `docs/support/`, migration 060 (support_docs), `ingest-support-docs` edge fn + GitHub Action, `docs-sync-check` extension, 6 legal-blocked drafts at status:draft pending #80. Issues closed: #396-#404, #412-#417. Remaining: Track C (#405-#409 RAVIO agent code) + Track D (#410, #411 observability) — next session. PROD deploys held per CLAUDE.md. |
 | Apr 20, 2026 | 57 (planning) | Phase 22 Customer Support Foundation SCOPED. Milestone #37 + epic #395 + 22 child issues #396-#417. DEC-036 logged: reject CrewAI, extend RAVIO text chat with `context: 'support'` + tool use; voice stays discovery-only. 20 support docs planned. Markdown canonical → Supabase `support_docs` sync. PR #418. |
 | Apr 20, 2026 | 56 | **DEC-034 Marketplace Flow Distinction SHIPPED end-to-end (#380 CLOSED)** via 5 incremental PRs (#385-#389). Migrations 058 + 059. `listing_source_type` enum + `ListingTypeBadge` everywhere. Critical search-filter fix. 3 new notification types. `/sdlc` doc-update checklist promoted to root `CLAUDE.md` (PR #390) so it applies to every session. 1146 tests. Issues unblocked: #376, #378, #381. |

--- a/docs/PRIORITY-ROADMAP.md
+++ b/docs/PRIORITY-ROADMAP.md
@@ -1,7 +1,7 @@
 ---
-last_updated: "2026-04-20T15:49:43"
-change_ref: "0df1dd8"
-change_type: "session-56"
+last_updated: "2026-04-21T11:05:47"
+change_ref: "469ee98"
+change_type: "session-57"
 status: "active"
 ---
 # PRIORITY ROADMAP — Rent-A-Vacation
@@ -12,7 +12,10 @@ status: "active"
 
 ---
 
-## Changelog since last tier assignment (Sessions 50–56)
+## Changelog since last tier assignment (Sessions 50–57)
+
+- **Session 57 scoped (planning-only, no code):** Phase 22 Customer Support Foundation milestone (#37) + epic #395 + 22 child issues #396-#417 created. DEC-036 logged: extend RAVIO text chat with `context: 'support'` + tool use (reject CrewAI; voice stays discovery-only). Gap analysis added 7 docs beyond original brief's 13 → 20 total support docs. Markdown canonical in `docs/support/` → synced to Supabase `support_docs` table. Escalation reuses existing `AdminDisputes` (no parallel admin surface). B5 public-policy drafts (#404) blocked by #80; all other tracks unblocked.
+
 
 - **Session 50-53 shipped:** Event unification (#338, #339), MDM WS1/WS2/WS3 (DEC-032), Brand/terminology lock (DEC-031), Site-wide UI polish, 5 tier-gated features (#278-#282 — all Tier C items now **DONE**), Sentry guide, API docs audit.
 - **Session 54 shipped:** Stripe Tax env-flag gate (`STRIPE_TAX_ENABLED`), edge function JWT config hardening, migration 057 catch-up to DEV + PROD, MDM script CI fix, and 3 QA-surfaced bug fixes (offers-tab crash, owner bid notification, owner booking notification). PRs #372-#374.
@@ -34,20 +37,24 @@ status: "active"
 
 ---
 
-## Current Priority Tiers (as of April 20, 2026 — Session 56)
+## Current Priority Tiers (as of April 20, 2026 — Session 57)
 
 ### Tier A: Build Next (High Impact, Code-Ready)
 
-All unblocked follow-ups from Sessions 54-56 QA audit work. Pick in any order; they're independent.
+All unblocked follow-ups from Sessions 54-57. Pick in any order; they're independent.
 
 | Issue | Title | Est. | Why now |
 |-------|-------|------|---------|
+| **#400** | Phase 22 B1: Gap analysis — 20 support docs × authoritative source mapping | 2-3h | **Gates all Phase 22 content tracks.** Deliverable is `docs/support/GAP-ANALYSIS.md` — table mapping each of 20 target docs to {derive from code, extract from FAQ/UserGuide, write new, legal-blocked}. Prevents drift and scope creep downstream. |
+| **#396** | Phase 22 A1: `docs/support/` folder + frontmatter schema + exemplar doc | 4-6h | **Foundational for Phase 22.** Independent of content — establishes the shared schema + body structure every one of the 20 docs will follow. Also unblocks A2 (migration) + A3 (ingest edge fn). |
 | **#376** | Pre-Booked listing verification (resort reservation proof) | 1-2d | Unblocked by DEC-034 — proof-collection UX only meaningful after the flow distinction exists (which it now does). New schema fields + admin verify dialog + email templates. |
 | **#378** | "Open for Bidding" indicator everywhere (create-time toggle + consistent badge) | 3-4h | Unblocked by DEC-034 — integrates with the ListingTypeBadge visual system. |
 | **#381** | Role-relevant landing-view ordering | 6-8h | Surface most-time-sensitive items on each dashboard's Overview tab per "rooted in simplicity" principle. |
 | **#377** | Cancel-listing cascade (bulk bid rejection + booking cancellation + notifications) | 1d | Standalone, coordinates with DEC-034 wish-matched handling. New edge function + atomic cascade. |
 | **#371** | Edge function test harness | 1-2d (needs scoping) | Tech-debt follow-up from Tests-With-Features shortfalls. Enables future edge-fn work to be properly tested. |
 | **#393** | PLATFORM-INVENTORY.md — one-page mental model of everything built | 2-3h | Session 56 meta-ask: a single doc cataloging product + platform + dev-tooling + governance layers so the user can explain what they've built to investors, new collaborators, and future sessions. |
+
+> **Phase 22 epic (#395)** umbrella for 22 child issues #396-#417 — pick entry points #400 or #396 from this tier. Remaining tracks (A2-A4, B2-B4, C1-C5, D1-D2, E1-E6) unlock as their dependencies ship; see epic body for the full DAG. B5 (#404) is legal-blocked — see Tier B.
 
 ### Tier B: Pre-Launch Important (Needs Human Input)
 
@@ -58,6 +65,7 @@ These require decisions, walkthroughs, or external dependencies before coding.
 | #187 | Pre-launch manual verification | Needs systematic walkthrough. Partially done. |
 | #257 | Resort data compliance audit | Legal review of seed data sources. |
 | #322 | RAV Wishes proposal enforcement | Deferred until 30+ days of real proposal data. Post-beta. |
+| **#404** | Phase 22 B5: Legal-blocked public policy docs (privacy, booking-terms, payment-policy, trust-safety, insurance-liability, subscription-terms) | Blocked by #80 (legal consult — timeshare lawyer). 6 drafts production-ready, held with `status: 'draft'` pending lawyer sign-off. Not blocking launch of the support agent itself. |
 
 ### Tier C: Tier Feature Differentiation — ✅ COMPLETED IN SESSION 53 (PR #367)
 
@@ -125,6 +133,7 @@ These unblock when the LLC is formed. Not code-dependent.
 
 | Date | Session | Changes |
 |------|---------|---------|
+| Apr 20, 2026 | 57 | **Phase 22 Customer Support Foundation SCOPED (planning-only; no code shipped).** Milestone #37 + epic #395 + 22 child issues #396-#417. DEC-036 logged: reject CrewAI, extend RAVIO text chat with `context: 'support'` + tool use; voice stays discovery-only. 20 support docs (13 from brief + 7 gap adds: privacy, trust-safety, insurance-liability, subscription-terms, account-security, emergency-safety, support-sla). Markdown canonical → Supabase `support_docs` sync. Escalation reuses `AdminDisputes`. B5 (#404) → blocked by #80. Tier A entry points: #400 (B1 gap analysis) + #396 (A1 schema). |
 | Apr 20, 2026 | 56 | **DEC-034 Marketplace Flow Distinction SHIPPED end-to-end (#380 CLOSED)** via 5 incremental PRs (#385-#389). Migrations 058 + 059. `listing_source_type` enum + `ListingTypeBadge` everywhere. Critical search-filter fix. 3 new notification types. `/sdlc` doc-update checklist promoted to root `CLAUDE.md` (PR #390) so it applies to every session. 1146 tests. Issues unblocked: #376, #378, #381. |
 | Apr 20, 2026 | 55 | QA audit response: read S-01..S-05 from scenario spreadsheet, opened 7 new issues (#375-#381) with full findings. Shipped Phase A UX wins: #379 MyTrips booking detail (PR #382), #375 Path 3 hybrid dashboard naming (PR #383). Expanded `/sdlc` Phase 6 into 13-item doc-update checklist. 1140 tests. DEC-035 (dashboard naming) logged. |
 | Apr 18-19, 2026 | 54 | Stripe Tax env-flag gate (`STRIPE_TAX_ENABLED`) fixes dev + PROD checkout blocker. Edge function JWT regression fixed via `config.toml` + `--no-verify-jwt`. Migration 057 deployed. MDM script CI fix. 3 bug fixes surfaced by QA testing (offers crash, owner bid/booking notifications). PRs #372-#374. Opened #370, #371. DEC-033 (Checkly monitoring). 1133 tests. |

--- a/docs/PROJECT-HUB.md
+++ b/docs/PROJECT-HUB.md
@@ -1,7 +1,7 @@
 ---
-last_updated: "2026-04-20T12:58:39"
-change_ref: "0a2ec90"
-change_type: "session-39-docs-update"
+last_updated: "2026-04-21T11:05:47"
+change_ref: "469ee98"
+change_type: "session-57"
 status: "active"
 ---
 # PROJECT HUB - Rent-A-Vacation
@@ -9,7 +9,7 @@ status: "active"
 > **Architectural decisions, session context, and agent instructions**
 > **Task tracking has moved to [GitHub Issues & Milestones](https://github.com/rent-a-vacation/rav-website/issues)**
 > **Project board: [RAV Roadmap](https://github.com/orgs/rent-a-vacation/projects/1)**
-> **Last Updated:** March 10, 2026 (Session 38: #173, #174)
+> **Last Updated:** April 20, 2026 (Session 57: DEC-036, Phase 22 epic scoped)
 > **Repository:** https://github.com/rent-a-vacation/rav-website
 > **App Version:** v0.9.0 (build version visible in footer)
 
@@ -106,7 +106,24 @@ gh issue create --repo rent-a-vacation/rav-website --title "..." --label "..." -
 - **dev and main:** in sync — Session 55–56 PRs #382, #383, #384, #385, #386, #387, #388, #389 merged
 - **GitHub Project:** RAV Roadmap — 202 issues, all with Status/Category/Sub-Category/Type populated. Auto-add workflow enabled. PRs excluded.
 
-### Session Handoff (Sessions 25-56)
+### Session Handoff (Sessions 25-57)
+
+**Session 57 — Phase 22 Customer Support Foundation scoped, DEC-036 logged (Apr 20, 2026):**
+- **Milestone #37 + Epic #395 + 22 child issues #396-#417 created.** Planning-only session; no code shipped.
+- **User brief reviewed** (`customer-support-crew-ai.md`): 3-agent CrewAI team + 13 support docs + support widget. Recommended **rejecting CrewAI** and extending existing RAVIO text chat (`supabase/functions/text-chat/index.ts`) with a `context: 'support'` branch + tool use (5 functions: `lookup_booking`, `check_refund_status`, `check_dispute_status`, `open_dispute`, `query_support_docs`). See DEC-036.
+- **VAPI voice stays discovery-only** — quota-metered, poor at auth-gated support queries. No voice-support build.
+- **Gap analysis vs brief:** added 7 docs beyond the original 13 (privacy, trust-safety, insurance-liability, subscription-terms — legal-blocked; account-security, emergency-safety, support-sla — not blocked). Total: **20 support docs** in `docs/support/{policies,faqs,processes}/`.
+- **Docs storage: markdown canonical → Supabase `support_docs` index (one-way sync).** Git diff audit trail for legal review; DB is a build-time cache for fast agent retrieval. GitHub Action on push to main invokes `ingest-support-docs` edge fn.
+- **RAVIO UI: route-based context detection + intent classifier fallback + "Switched to Support" chip.** No explicit user toggle — matches memory rule [Rooted in Simplicity].
+- **Escalation:** agent-opened disputes land in existing `AdminDisputes` with `source: 'ravio_support'` tag — no parallel admin dashboard. Reuses migration 041 + `ReportIssueDialog` infrastructure.
+- **Legal blocker narrowed:** only 6 public-facing policy drafts (#404) blocked by #80. Internal workflow + FAQs are not blocked.
+- **22 issues across 5 tracks:** A infrastructure (4), B content (5), C RAVIO extension (5), D observability (2), E architecture diagrams (6, incl. `CS-OVERVIEW.md` VC-ready one-pager).
+- **Ready-to-start entry points:** #400 (B1 gap analysis, 2-3h, gates content tracks) + #396 (A1 folder + frontmatter schema, independent of content).
+- **Script preserved:** `scripts/create-phase22-issues.sh` (idempotent — skips titles already present in milestone).
+
+**End state:** Phase 22 milestone scoped with full epic + 22 child issues. `docs/support/` not yet created (part of #396). No DB migrations. No code changes. Memory saved: `phase22_customer_support_architecture.md`.
+
+---
 
 **Session 56 — DEC-034 shipped: Pre-Booked Stay / Wish-Matched Stay end-to-end (Apr 20, 2026):**
 - **#380 implemented in 5 incremental PRs** — schema + edge-function branching + UI badges + notifications + docs. Zero big-bang; each phase shipped to DEV + PROD independently.
@@ -817,6 +834,33 @@ Three workstreams shipped plus Phase 21 DoD cleanup. All backed by GitHub issues
 - #190 — Webhook delivery to partners (event notifications)
 - #191 — Chat endpoint (`/v1/chat`) via gateway
 - #192 — SDK packages for partners (npm, Python)
+
+---
+
+### DEC-036: RAVIO Support Architecture — Extend Text Chat, Not CrewAI; Voice Stays Discovery-Only
+**Date:** April 20, 2026 (Session 57)
+**Decision:** Build v1 customer support by extending the existing RAVIO text-chat edge function with a `context: 'support'` branch + Claude tool use. **Do not adopt CrewAI or any multi-agent orchestration framework.** VAPI voice remains discovery-only and is not extended into support.
+
+**Rationale:**
+1. **Shape of the problem.** Customer support is single-threaded — classify intent → fetch context → answer or escalate. CrewAI shines for collaborative multi-agent pipelines (researcher → writer → editor), which is not this shape. Added orchestration overhead with no payoff.
+2. **Reuse the existing stack.** `supabase/functions/text-chat/index.ts` already handles SSE streaming, rate limiting, multi-context system prompts, and auth. Adding a `'support'` context is ~10% of the cost of standing up a parallel CrewAI surface.
+3. **Voice is wrong for support.** VAPI is quota-metered (Free 5/day → Premium unlimited). Support queries burn quota and are poor fits for voice (auth-gated account lookups, evidence upload, screens showing charges). Keep voice as a premium discovery feature.
+4. **Escalation reuses existing dispute infrastructure** (migration 041, `ReportIssueDialog`, `AdminDisputes`). Agent's `open_dispute` tool creates a dispute row with `source: 'ravio_support'` so admins can distinguish agent-opened disputes.
+
+**UI pattern:**
+- **Route-based context detection** — no explicit toggle. Support contexts on `/my-trips`, `/my-bookings`, `/account`, `/owner-dashboard`, `/settings/*`; discovery on `/rentals`, `/property/*`, `/tools/*`, `/destinations/*`; ambiguous routes fall through to intent classifier.
+- **"Switched to Support — [back]" chip** for escape hatch when the classifier switches lanes against the user's will.
+- Matches memory rule [Rooted in Simplicity] — anticipate user flow, don't ask.
+
+**Docs storage model:** Markdown canonical in `docs/support/`, indexed to Supabase `support_docs` table via a GitHub-Action-triggered `ingest-support-docs` edge function. Git is source of truth (PR-reviewable, lawyer-friendly, diffable); DB is a runtime cache for fast agent retrieval. Shared frontmatter schema across 20 docs (policies / FAQs / processes), extending the existing frontmatter convention (`last_updated`, `change_ref`, `change_type`, `status`) with `title`, `doc_type`, `audience[]`, `version`, `legal_review_required`, `reviewed_by`, `reviewed_date`, `tags[]`.
+
+**Agent tool surface (5 functions, all auth-scoped):** `lookup_booking`, `check_refund_status`, `check_dispute_status`, `open_dispute`, `query_support_docs`. RLS enforced; sensitive fields never echoed.
+
+**Future expansion path:** If we ever need genuinely collaborative multi-agent workflows (e.g., complex dispute arbitration with a neutral compliance reviewer), revisit then. This foundation does not preclude that — agent + tool use is a strict subset of what a multi-agent framework needs.
+
+**Status:** Scoped in epic #395 (milestone #37, Phase 22: Customer Support Foundation). 22 child issues #396-#417 across 5 tracks. B5 public-policy drafts (#404) blocked by #80 (legal consult); all other tracks unblocked.
+
+**Supersedes:** DEC-020 (Text Chat Agent — Two-Tier Conversational Model) is retained for discovery; DEC-036 adds the support tier as a parallel `context` inside the same edge function.
 
 ---
 

--- a/docs/PROJECT-HUB.md
+++ b/docs/PROJECT-HUB.md
@@ -1,7 +1,7 @@
 ---
-last_updated: "2026-04-21T23:23:19"
-change_ref: "3905aa8"
-change_type: "session-57"
+last_updated: "2026-04-22T23:47:09"
+change_ref: "c820f23"
+change_type: "session-58"
 status: "active"
 ---
 # PROJECT HUB - Rent-A-Vacation
@@ -93,20 +93,35 @@ gh issue create --repo rent-a-vacation/rav-website --title "..." --label "..." -
 - Edge functions require `--no-verify-jwt` deployment flag
 
 ### Platform Status
-- **1146 automated tests** (134 test files, all passing), 0 type errors, 0 lint errors, build clean
-- **P0 tests:** 97 critical-path tests tagged `@p0` + 4 subscription P0s + 6 ListingTypeBadge P0s — run with `npm run test:p0`
+- **1166 automated tests** (135 test files, all passing), 0 type errors, 0 lint errors, build clean
+- **P0 tests:** 97 critical-path tests tagged `@p0` + 4 subscription P0s + 6 ListingTypeBadge P0s + 1 support-tool P0 — run with `npm run test:p0`
 - **CI reporting:** GitHub native via dorny/test-reporter (JUnit XML) — PR annotations on every run (Qase removed Mar 2026)
 - **Migrations created:** 001-060 (001-059 deployed to DEV + PROD; 060 deployed to DEV only — PROD held per CLAUDE.md) + 3 date-based MDM migrations
-- **Edge functions:** 35 total (27 deployed to PROD + 4 subscription functions on DEV + 3 SMS functions pending LLC/EIN + `ingest-support-docs` deployed to DEV only). `create-booking-checkout` + `verify-booking-payment` deployed to both DEV and PROD with `--no-verify-jwt` (Session 54–56).
+- **Edge functions:** 35 total (27 deployed to PROD + 4 subscription functions on DEV + 3 SMS functions pending LLC/EIN + `ingest-support-docs` deployed to DEV only). `text-chat` gains a `context: 'support'` branch with 5 agent tools (Session 58, Phase 22 C1 + C4).
 - **Stripe Subscription:** Sandbox configured — 4 products, webhook (11 events), Customer Portal. Subscription epic #263 CLOSED (all 9 stories complete)
 - **Stripe Tax:** env-gated via `STRIPE_TAX_ENABLED` (Session 54). Unset on both DEV + PROD → `automatic_tax` disabled → bookings work without tax collection. Flip to `"true"` on PROD only after live Stripe Tax fully activated post-#127.
 - **Marketplace flow distinction (DEC-034):** `listings.source_type` + `bookings.source_type` + `bookings.travel_proposal_id` live. Pre-Booked Stay = instant confirm; Wish-Matched Stay = owner-confirmation required. Implemented via #380 Phases 1–5 (PRs #385–#389).
 - **PROD platform:** locked (Staff Only Mode enabled)
 - **Supabase CLI:** currently linked to DEV
-- **dev and main:** in sync — Session 57 PRs #418, #419, #420, #421, #422, #423, #424, #425 merged (Phase 22 Tracks A, B, E complete)
+- **dev and main:** in sync at Session 57 end; Session 58 PR for Phase 22 C1 + C4 (#405 + #408) open at time of writing
 - **GitHub Project:** RAV Roadmap — 202 issues, all with Status/Category/Sub-Category/Type populated. Auto-add workflow enabled. PRs excluded.
 
-### Session Handoff (Sessions 25-57)
+### Session Handoff (Sessions 25-58)
+
+**Session 58 — Phase 22 Track C: RAVIO support agent wired up (#405 + #408, Apr 22, 2026):**
+- **Paired PR for C1 (#405) + C4 (#408).** `supabase/functions/text-chat/index.ts` gains a `context: 'support'` branch with a dedicated empathetic system prompt. All 5 agent tools implemented as pure-logic handlers in a new `support-tools.ts` module and wired into the edge function's tool-call loop.
+- **5 tools:** `lookup_booking` (booking_id or own-email lookup, RLS-scoped), `check_refund_status` (**DB-first with live Stripe reconcile** when the DB has a refund_reference but no processed timestamp; fails closed with a note on Stripe errors), `check_dispute_status`, `open_dispute` (validates 13 categories + min description length; enforces reporter_id via RLS), `query_support_docs` (keyword tsvector search against the `support_docs` table, status='active' only).
+- **Tool call loop generalised:** the edge function now iterates ALL tool_calls (parallel), dispatches by name (`search_properties` for rentals / any of the 5 support tools / graceful fallback for unknown), and feeds all results back in one follow-up streaming call. Rentals behaviour preserved.
+- **RLS enforcement via user-scoped client.** A second Supabase client is built with `Authorization: Bearer <jwt>` on every request, so `auth.uid()` resolves correctly inside Postgres policies. Never uses service-role for tool queries.
+- **Sensitive-field redaction:** safe column projections defined in `support-tools.ts` — tools never return `payment_intent_id`, `stripe_transfer_id`, payout details, or admin-internal fields.
+- **20 new unit tests** in `support-tools.test.ts` — 5 tools × happy path + auth/RLS failure + domain-rule rejection, plus registry/dispatcher coverage. Vitest `include` extended to `supabase/functions/**/*.test.ts`. Pattern mirrors `_shared/rate-limit.ts` — pure-logic module with a minimal structural Supabase interface so tests run under Vitest without Deno.
+- **Scope boundaries held:** #406 (route-based detection in `useTextChat`), #407 (intent classifier + chip), #409 (`source: 'ravio_support'` enum on disputes) deliberately deferred to their own PRs. This PR is edge-fn + tests only; no frontend changes, no new migrations.
+- **New feedback memory captured:** "CS and UX as business differentiators" — user direction that when picking between cheap and robust implementations for support surfaces, bias toward the robust one even at latency/complexity cost. Drove the choice of DB+Stripe fallback over DB-only for `check_refund_status`.
+- **Tests:** 1146 → 1166 (+20). 134 → 135 files. 0 type errors, build clean (1m 5s).
+
+**End state:** Phase 22 at 17 of 22 tickets (77%). Remaining: #406, #407, #409 (Track C), #410, #411 (Track D). Next session should start with either #406 (frontend route detection — small, independent) or #409 (disputes.source enum + AdminDisputes filter — unblocks CS telemetry). PROD deploy of `text-chat` still held per CLAUDE.md — gets the support prompt + 5 tools on next deploy. `STRIPE_SECRET_KEY` env var is already set on both DEV and PROD (webhook + cancellation fns use it), so the live-Stripe reconcile path is ready on first deploy.
+
+---
 
 **Session 57 — Phase 22 Customer Support Foundation: 15 of 22 tickets SHIPPED across 8 PRs (Apr 20-21, 2026):**
 - **Tracks A, B, E complete.** Tracks C + D (code work) deferred to next session. 68% of Phase 22 complete.

--- a/docs/testing/TESTING-STATUS.md
+++ b/docs/testing/TESTING-STATUS.md
@@ -1,13 +1,13 @@
 ---
-last_updated: "2026-04-20T12:58:39"
-change_ref: "0a2ec90"
-change_type: "session-54"
+last_updated: "2026-04-22T23:47:09"
+change_ref: "c820f23"
+change_type: "session-58"
 status: "active"
 ---
 # Testing Status
 
 > Current state of the RAV test suite. Updated each session.
-> **Last Updated:** April 20, 2026 (Session 56)
+> **Last Updated:** April 22, 2026 (Session 58)
 
 ---
 
@@ -15,9 +15,9 @@ status: "active"
 
 | Metric | Value |
 |--------|-------|
-| **Total tests** | 1146 |
-| **Test files** | 134 |
-| **P0 critical-path tests** | 97 (tagged `@p0`) + 4 subscription P0s |
+| **Total tests** | 1166 |
+| **Test files** | 135 |
+| **P0 critical-path tests** | 97 (tagged `@p0`) + 4 subscription P0s + 1 support-tool P0 |
 | **E2E smoke tests** | 3 (Playwright) |
 | **Local run time** | ~2.5 min (full), ~2s (P0 only) |
 | **CI run time** | <3 min |

--- a/scripts/create-phase22-issues.sh
+++ b/scripts/create-phase22-issues.sh
@@ -1,0 +1,486 @@
+#!/bin/bash
+# Creates 22 child issues for Phase 22: Customer Support Foundation (epic #395)
+# Idempotent: skips if title already exists in epic milestone
+set -e
+
+REPO="rent-a-vacation/rav-website"
+EPIC=395
+MILESTONE="Phase 22: Customer Support Foundation"
+
+create_issue() {
+  local title="$1"
+  local labels="$2"
+  local body="$3"
+
+  # Skip if same title already exists open in this milestone
+  local existing
+  existing=$(gh issue list --repo "$REPO" --milestone "$MILESTONE" --search "\"$title\" in:title" --json number,title --jq ".[] | select(.title == \"$title\") | .number")
+  if [ -n "$existing" ]; then
+    echo "SKIP: #$existing already exists: $title"
+    return
+  fi
+
+  local url
+  url=$(gh issue create --repo "$REPO" --title "$title" --label "$labels" --milestone "$MILESTONE" --body "$body")
+  echo "CREATED: $url — $title"
+}
+
+# ============================================================================
+# TRACK A — Infrastructure (4)
+# ============================================================================
+
+create_issue \
+  "A1: docs/support/ folder + frontmatter schema + exemplar doc" \
+  "docs,platform,pre-launch" \
+  "$(cat <<'EOF'
+## Goal
+Establish `docs/support/` as the home for 20 policy/FAQ/process/guide documents. Define the shared frontmatter schema + body structure every support doc must follow. Ship one exemplar doc demonstrating the pattern.
+
+## Acceptance criteria
+- [ ] `docs/support/{policies,faqs,processes,guides,diagrams}/` created
+- [ ] `docs/support/README.md` documents frontmatter schema + body structure
+- [ ] Frontmatter extends existing (`last_updated`, `change_ref`, `change_type`, `status`) with: `title`, `doc_type`, `audience[]`, `version`, `legal_review_required`, `reviewed_by`, `reviewed_date`, `tags[]`
+- [ ] Body sections standardized: Summary / Details / Examples / Related
+- [ ] One exemplar doc in `policies/` fully populated per schema (suggest: `cancellation-policy.md`)
+
+Parent: #395
+EOF
+)"
+
+create_issue \
+  "A2: Migration — support_docs table + RLS" \
+  "platform,database,pre-launch" \
+  "$(cat <<'EOF'
+## Goal
+DB schema to index `docs/support/` content for fast agent retrieval. Markdown stays canonical in git; this is a build-time cache.
+
+## Acceptance criteria
+- [ ] New migration: `support_docs` table
+- [ ] Columns: `id`, `slug`, `doc_type`, `audience text[]`, `version`, `frontmatter jsonb`, `sections jsonb`, `search_tsv tsvector`, `embedding vector` (if pgvector available, else defer)
+- [ ] Indexes on `slug` (unique), `doc_type`, `search_tsv` (GIN)
+- [ ] RLS: readable by authenticated users; write restricted to `service_role`
+- [ ] Deployed to DEV after PR merge; PROD deploy gated on epic completion
+
+Depends on: A1
+Parent: #395
+EOF
+)"
+
+create_issue \
+  "A3: Ingest edge function + GitHub Action for docs/support/ sync" \
+  "platform,edge-function,pre-launch" \
+  "$(cat <<'EOF'
+## Goal
+One-way sync from `docs/support/*.md` → `support_docs` table. Triggered on push to `main`.
+
+## Acceptance criteria
+- [ ] `supabase/functions/ingest-support-docs/index.ts` parses frontmatter + section headers
+- [ ] Upserts rows by `slug`; deletes rows whose source file was removed
+- [ ] `.github/workflows/sync-support-docs.yml` invokes on push to `main` affecting `docs/support/**`
+- [ ] Handles both DEV and PROD via env (default: PROD on main)
+- [ ] Idempotent — re-running produces same DB state
+- [ ] Test: tamper with an exemplar doc, push, verify DB updated within 2 minutes
+
+Depends on: A1, A2
+Parent: #395
+EOF
+)"
+
+create_issue \
+  "A4: Extend docs-sync-check.ts for docs/support/" \
+  "docs,platform" \
+  "$(cat <<'EOF'
+## Goal
+Prevent staleness + schema violations in support docs via the existing CI check.
+
+## Acceptance criteria
+- [ ] `scripts/docs-sync-check.ts` validates every `docs/support/**/*.md` has required frontmatter fields
+- [ ] Flags docs with `legal_review_required: true` where `last_updated > 90 days`
+- [ ] Flags docs with `status: 'active'` + `legal_review_required: true` where `reviewed_date` is null
+- [ ] Wired into `npm run docs:sync-check` and existing `docs-audit.yml` CI workflow
+
+Depends on: A1
+Parent: #395
+EOF
+)"
+
+# ============================================================================
+# TRACK B — Content (5)
+# ============================================================================
+
+create_issue \
+  "B1: Gap analysis — 20 support docs × authoritative source mapping" \
+  "docs,pre-launch" \
+  "$(cat <<'EOF'
+## Goal
+Before writing any doc, map each of 20 target docs to: **{derive from code, extract from FAQ/UserGuide, write new, legal-blocked}**. Prevents drift and scope creep.
+
+## Deliverable
+`docs/support/GAP-ANALYSIS.md` — table with 20 rows × columns:
+- `doc_slug`
+- `source_type` (derive | extract | write-new | legal-blocked)
+- `authoritative_ref` (file path or existing doc/page)
+- `legal_review_required` (bool)
+- `owner` (who will author)
+- `target_folder` (policies | faqs | processes)
+
+## Acceptance criteria
+- [ ] All 20 docs listed with source type + authoritative reference
+- [ ] Identifies which `FAQ.tsx` / `UserGuide.tsx` sections feed which FAQ doc
+- [ ] Identifies which `src/flows/` manifest or `src/lib/*.ts` file feeds which process doc
+- [ ] Reviewed before B2-B5 begin
+
+Parent: #395
+EOF
+)"
+
+create_issue \
+  "B2: Derive 4 process/policy docs from code" \
+  "docs,pre-launch" \
+  "$(cat <<'EOF'
+## Goal
+Author 4 docs derived from authoritative code sources — not hand-written prose that drifts.
+
+## Docs
+1. `policies/cancellation-policy.md` — from `src/lib/cancellationPolicy.ts` (4 policy tiers, deadlines, refund % per tier, examples)
+2. `policies/refund-policy.md` — Stripe refund flow + `process-cancellation` edge function + dispute refund paths
+3. `processes/booking-workflow.md` — from `src/flows/traveler-lifecycle.ts`
+4. `processes/bidding-process.md` — from `src/flows/owner-lifecycle.ts` + `listing_bids` schema
+
+## Acceptance criteria
+- [ ] All 4 docs in place following schema from A1
+- [ ] Each doc cites its authoritative source (path + commit SHA) in `change_ref`
+- [ ] No duplication of rules from code — narrative only; rules linked
+
+Depends on: A1, B1
+Parent: #395
+EOF
+)"
+
+create_issue \
+  "B3: Consolidate 5 FAQ docs from FAQ.tsx + UserGuide.tsx" \
+  "docs,pre-launch" \
+  "$(cat <<'EOF'
+## Goal
+Extract and consolidate existing FAQ.tsx and UserGuide.tsx content into 5 markdown FAQs for agent retrieval. On-page UX stays untouched.
+
+## Docs
+1. `faqs/booking-faq.md`
+2. `faqs/billing-faq.md` — includes owner tax / 1099-K section
+3. `faqs/property-owner-faq.md`
+4. `faqs/traveler-faq.md`
+5. `faqs/general-platform-faq.md` — includes voice search fair use + referral program sections
+
+## Acceptance criteria
+- [ ] All 5 docs follow schema from A1
+- [ ] `UserGuide.tsx` and `FAQ.tsx` remain the UX surface — no content removal
+- [ ] Clear rule: FAQ.tsx updates trigger a PR task to update the corresponding markdown (or the opposite — TBD in B1)
+
+Depends on: A1, B1
+Parent: #395
+EOF
+)"
+
+create_issue \
+  "B4: Author 5 internal workflow docs (new content)" \
+  "docs,pre-launch" \
+  "$(cat <<'EOF'
+## Goal
+Write 5 internal-workflow docs not blocked by legal review.
+
+## Docs
+1. `processes/customer-support-escalation.md` — when agent escalates, to whom, via what channel
+2. `processes/dispute-resolution.md` — internal dispute workflow (categories, evidence, admin review, refund path). NOT public T&Cs
+3. `processes/emergency-safety-escalation.md` — separate routing for safety-critical (property unsafe, harassment, medical) — distinct SLA from billing
+4. `processes/support-sla.md` — response time commitments + tier differentiation
+5. `faqs/account-security-faq.md` — password reset, 2FA, account recovery, session issues
+
+## Acceptance criteria
+- [ ] All 5 docs follow schema from A1
+- [ ] Emergency-safety escalation explicitly routes outside normal dispute queue
+- [ ] Account-security-faq is user-facing and non-legal
+
+Depends on: A1
+Parent: #395
+EOF
+)"
+
+create_issue \
+  "B5: Legal-blocked public policy docs (6 drafts pending lawyer review)" \
+  "docs,pre-launch,blocked,legal-compliance,needs-decision" \
+  "$(cat <<'EOF'
+## Goal
+Draft 6 public-facing policy docs. All drafts completed and held with `status: 'draft'` + `legal_review_required: true` pending lawyer consult.
+
+## Docs
+1. `policies/privacy-policy.md` — legal requirement (CCPA/GDPR handling)
+2. `policies/booking-terms.md` — public T&Cs for bookings
+3. `policies/payment-policy.md` — fees, processing, billing terms
+4. `policies/trust-safety-policy.md` — marketplace non-discrimination, harassment, prohibited behavior
+5. `policies/insurance-liability-policy.md` — property damage liability, security deposits, trip insurance
+6. `policies/subscription-terms.md` — tier cancellation/upgrade/downgrade/proration (separate from booking T&Cs)
+
+## Acceptance criteria
+- [ ] All 6 drafts in `docs/support/policies/` with `status: 'draft'`, `reviewed_by: null`, `reviewed_date: null`
+- [ ] Drafts are production-quality; only lawyer sign-off gates publish
+- [ ] Not surfaced to users in UI until `reviewed_date` set and `status: 'active'`
+
+## Blocker
+Blocked by legal consult — see #80
+
+Depends on: A1, #80
+Parent: #395
+EOF
+)"
+
+# ============================================================================
+# TRACK C — RAVIO support extension (5)
+# ============================================================================
+
+create_issue \
+  "C1: Add context:'support' branch to text-chat edge function" \
+  "platform,edge-function,pre-launch" \
+  "$(cat <<'EOF'
+## Goal
+Extend `supabase/functions/text-chat/index.ts` to handle a `'support'` context with dedicated system prompt, auth enforcement, and tool-use schema.
+
+## Acceptance criteria
+- [ ] Accept `context: 'support'` in request payload
+- [ ] Support context requires authenticated user (return 401 otherwise)
+- [ ] Tool-use definitions declared (implementations in C4)
+- [ ] Support system prompt: grounded in `support_docs` table, empathetic tone, explicit escalation rules
+- [ ] Existing contexts (discovery, property-detail, bidding, general) untouched
+- [ ] SSE streaming preserved
+
+Depends on: A3
+Parent: #395
+EOF
+)"
+
+create_issue \
+  "C2: Route-based context detection in useTextChat" \
+  "experience,pre-launch" \
+  "$(cat <<'EOF'
+## Goal
+Auto-switch RAVIO to support context on account/booking/dashboard pages; discovery elsewhere. No explicit toggle UI.
+
+## Acceptance criteria
+- [ ] `useTextChat` detects current route via `useLocation`
+- [ ] Support contexts: `/my-trips`, `/my-bookings`, `/account`, `/owner-dashboard`, `/settings/*`, `/disputes/*`
+- [ ] Discovery contexts: `/rentals`, `/property/*`, `/tools/*`, `/destinations/*`
+- [ ] General fallback: `/`, `/help`, `/about`, ambiguous routes
+- [ ] Suggested prompts in `TextChatPanel` swap per detected context
+- [ ] Per memory: [Rooted in Simplicity] — anticipate user flow, surface most-relevant-first
+
+Depends on: C1
+Parent: #395
+EOF
+)"
+
+create_issue \
+  "C3: Intent classifier fallback + 'Switched to Support' chip" \
+  "experience,pre-launch" \
+  "$(cat <<'EOF'
+## Goal
+When user opens RAVIO on ambiguous routes (home, help), classify intent from the first message. Show a subtle chip when the classifier switches lanes, with an escape hatch.
+
+## Acceptance criteria
+- [ ] Lightweight intent classifier in edge fn — keyword heuristics first, small model fallback
+- [ ] Returns `classified_context` in first streamed event
+- [ ] Frontend renders chip: "Switched to Support — [back to Discovery]" when classified context differs from route-inferred context
+- [ ] Chip click reverts + persists user override for the session
+- [ ] Classification + user reverts logged for future tuning
+
+Depends on: C1, C2
+Parent: #395
+EOF
+)"
+
+create_issue \
+  "C4: Agent tool use — 5 function calls" \
+  "platform,edge-function,pre-launch" \
+  "$(cat <<'EOF'
+## Goal
+Implement the function-calling tools the support agent invokes.
+
+## Tools
+1. `lookup_booking(booking_id | email)` — returns booking + listing + payment state (auth-scoped)
+2. `check_refund_status(booking_id)` — cancellation_request + Stripe refund state
+3. `check_dispute_status(booking_id)` — dispute record state
+4. `open_dispute(booking_id, category, description)` — creates dispute row, returns id
+5. `query_support_docs(query, doc_type?)` — keyword + (if available) vector lookup in `support_docs`
+
+## Acceptance criteria
+- [ ] Each tool enforces RLS / auth context of calling user
+- [ ] Each tool has unit tests (happy path + auth failure)
+- [ ] Tool errors returned as structured JSON the agent can reason about
+- [ ] Agent does not receive or echo sensitive fields (full card numbers, etc)
+
+Depends on: A3, C1
+Parent: #395
+EOF
+)"
+
+create_issue \
+  "C5: Agent-opened disputes flow to AdminDisputes (source tagging)" \
+  "platform,pre-launch" \
+  "$(cat <<'EOF'
+## Goal
+Disputes opened via `open_dispute` tool use appear in `AdminDisputes` tagged `source: 'ravio_support'` so admins can distinguish from manually-filed disputes.
+
+## Acceptance criteria
+- [ ] `disputes` table migration: add `source` enum column (`user_filed`, `ravio_support`) — default `user_filed`
+- [ ] `AdminDisputes` UI shows source badge on dispute row
+- [ ] Existing manual filing flow unchanged (defaults to `user_filed`)
+- [ ] `ReportIssueDialog` continues to work as today
+
+Depends on: C4
+Parent: #395
+EOF
+)"
+
+# ============================================================================
+# TRACK D — Observability (2)
+# ============================================================================
+
+create_issue \
+  "D1: Support conversation logging (extend conversations table)" \
+  "platform,post-launch" \
+  "$(cat <<'EOF'
+## Goal
+Persist RAVIO support conversations for audit, escalation handoff, and metrics. Target: pre-launch if time; can slip.
+
+## Acceptance criteria
+- [ ] `conversations` table migration: add `channel` enum (`booking_message`, `listing_inquiry`, `ravio_support`)
+- [ ] Each support turn stored as a message row
+- [ ] Agent tool calls + tool results logged alongside user/assistant messages
+- [ ] RLS: user sees own conversations; admin sees all
+
+Parent: #395
+EOF
+)"
+
+create_issue \
+  "D2: Admin 'Support Interactions' tab + metrics" \
+  "platform,post-launch" \
+  "$(cat <<'EOF'
+## Goal
+Admin observability into agent performance. Target: pre-launch if time; can slip.
+
+## Acceptance criteria
+- [ ] New `AdminDashboard` tab: "Support Interactions"
+- [ ] Transcripts list — filterable by user, date, escalated?
+- [ ] Metrics card: deflection % (resolved without escalation), escalation rate, median response time
+- [ ] Thumb up/down signal collected per conversation (optional button in RAVIO UI)
+
+Depends on: D1
+Parent: #395
+EOF
+)"
+
+# ============================================================================
+# TRACK E — Architecture diagrams (6)
+# ============================================================================
+
+create_issue \
+  "E1: Architecture diagram — system-architecture.md (Mermaid)" \
+  "docs,pre-launch" \
+  "$(cat <<'EOF'
+## Goal
+Full-stack architecture diagram for RAVIO Support — internal technical reference.
+
+## Acceptance criteria
+- [ ] `docs/support/diagrams/system-architecture.md` with Mermaid flowchart
+- [ ] Shows: user → RAVIO UI → `useTextChat` → `text-chat` edge fn → intent classifier → tool use → {Supabase tables, `support_docs`, `AdminDisputes`}
+- [ ] Brief narrative paragraph per major component
+
+Parent: #395
+EOF
+)"
+
+create_issue \
+  "E2: Sequence diagram — discovery query" \
+  "docs,pre-launch" \
+  "$(cat <<'EOF'
+## Goal
+Mermaid sequence diagram for a discovery query (e.g., 'ski resort March').
+
+## Acceptance criteria
+- [ ] `docs/support/diagrams/sequence-discovery-query.md`
+- [ ] Actors: user → RAVIO UI → text-chat edge fn → property search → listings table
+- [ ] Shows SSE streaming + search result card rendering
+- [ ] Confirms voice remains discovery-only (VAPI path shown as parallel)
+
+Parent: #395
+EOF
+)"
+
+create_issue \
+  "E3: Sequence diagram — support query with tool use" \
+  "docs,pre-launch" \
+  "$(cat <<'EOF'
+## Goal
+Mermaid sequence diagram for a support query ('why was I charged $50?').
+
+## Acceptance criteria
+- [ ] `docs/support/diagrams/sequence-support-query.md`
+- [ ] Actors: user → RAVIO → text-chat edge fn → tools (lookup_booking, query_support_docs) → response
+- [ ] Shows auth requirement + tool-use round trip + streamed response
+
+Parent: #395
+EOF
+)"
+
+create_issue \
+  "E4: Sequence diagram — escalation to AdminDisputes" \
+  "docs,pre-launch" \
+  "$(cat <<'EOF'
+## Goal
+Mermaid sequence diagram for escalation from agent to human support.
+
+## Acceptance criteria
+- [ ] `docs/support/diagrams/sequence-escalation.md`
+- [ ] Actors: user → RAVIO → open_dispute tool → disputes table → AdminDisputes → admin notification
+- [ ] Shows agent decision criteria for when to escalate vs self-serve
+
+Parent: #395
+EOF
+)"
+
+create_issue \
+  "E5: Diagram — doc sync pipeline" \
+  "docs,pre-launch" \
+  "$(cat <<'EOF'
+## Goal
+Diagram the markdown → DB sync pipeline, establishing that git is source of truth and DB is a cache.
+
+## Acceptance criteria
+- [ ] `docs/support/diagrams/doc-pipeline.md`
+- [ ] Mermaid flowchart: author edits `.md` → PR merge → GH Action → `ingest-support-docs` → `support_docs` table → agent retrieval
+- [ ] Narrative explaining: 'git is source of truth, DB is cache'
+
+Parent: #395
+EOF
+)"
+
+create_issue \
+  "E6: CS-OVERVIEW.md — VC-ready capability one-pager" \
+  "docs,pre-launch" \
+  "$(cat <<'EOF'
+## Goal
+External-facing one-pager: RAVIO Support capabilities, tech stack at executive level, metrics framework, roadmap. Designed to copy into a pitch deck.
+
+## Acceptance criteria
+- [ ] `docs/support/CS-OVERVIEW.md`
+- [ ] Capability map diagram — what the agent CAN vs CANNOT do
+- [ ] Simplified 3-layer architecture (UI / agent / data) — no internal jargon
+- [ ] Metrics framework (deflection rate, escalation rate, SLA) with placeholder pre-launch values
+- [ ] Roadmap: v1 (pre-launch) → v2 (post-launch: multilingual, voice-support if validated, proactive outreach)
+- [ ] Polished for external share
+
+Parent: #395
+EOF
+)"
+
+echo ""
+echo "Done. Verify with: gh issue list --repo $REPO --milestone \"$MILESTONE\""

--- a/supabase/functions/text-chat/index.ts
+++ b/supabase/functions/text-chat/index.ts
@@ -1,8 +1,17 @@
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
 import { createClient } from "npm:@supabase/supabase-js@2.57.2";
+import Stripe from "npm:stripe@14.21.0";
 import { searchProperties } from "../_shared/property-search.ts";
 import type { SearchParams, SearchResult } from "../_shared/property-search.ts";
 import { checkRateLimit, rateLimitResponse, RATE_LIMITS } from "../_shared/rate-limit.ts";
+import {
+  dispatchSupportTool,
+  isSupportTool,
+  SUPPORT_TOOL_SCHEMAS,
+  type StripeLike,
+  type SupabaseLike,
+  type UserContext,
+} from "./support-tools.ts";
 
 // --- CORS: Same allowlist pattern as voice-search ---
 function isAllowedOrigin(origin: string): boolean {
@@ -106,6 +115,24 @@ Your role as a general platform assistant:
 - Help with navigation — point users to the right pages
 - Answer questions about the platform's trust and safety features
 - Be warm, welcoming, and concise`,
+
+  support: `You are RAVIO, the Rent-A-Vacation customer support agent helping an authenticated user with their account, bookings, refunds, and disputes.
+
+Ground rules:
+- Always be empathetic, clear, and concise. The user is often stressed.
+- Ground policy answers in the support knowledge base — call query_support_docs BEFORE answering questions about cancellation policy, refunds, fees, payouts, or platform rules.
+- For account/booking questions, call lookup_booking to confirm details before answering.
+- For refund questions, call check_refund_status — the tool reconciles our records with Stripe and will tell you the current state and any expected arrival date.
+- Never promise a specific refund amount or arrival date from memory — always cite the value returned by a tool.
+- Never ask for or echo full card numbers, CVV, or passwords. Stripe handles those.
+- Use platform terminology correctly: "Listing", "Wish", "Offer", "Pre-Booked Stay", "Wish-Matched Stay". Say "Rent-A-Vacation" (not "RAV") when talking to users.
+
+Escalation rules:
+- If the user explicitly asks to file a dispute, or if their issue involves damage, no-show, safety, payment failure, or property-not-as-described, offer to open a dispute on their behalf.
+- Only call open_dispute AFTER the user explicitly confirms they want to escalate. Summarize category + description back to them and wait for a "yes" before calling the tool.
+- After opening a dispute, tell the user the dispute ID and that the RAV team has been notified.
+
+If the user asks something outside support scope (finding new properties, pricing strategy), acknowledge and point them back to the search or bidding experience rather than trying to search here.`,
 };
 
 // --- OpenRouter tool definitions ---
@@ -235,11 +262,13 @@ serve(async (req) => {
       );
     }
 
-    // Determine if this context supports search tool
-    const tools = context === "rentals" ? [SEARCH_TOOL] : undefined;
+    // Determine which tools this context exposes to the model
+    let tools: unknown[] | undefined;
+    if (context === "rentals") tools = [SEARCH_TOOL];
+    else if (context === "support") tools = SUPPORT_TOOL_SCHEMAS;
 
     // First OpenRouter call (may trigger tool call)
-    logStep("Calling OpenRouter", { model: OPENROUTER_MODEL, toolsEnabled: !!tools });
+    logStep("Calling OpenRouter", { model: OPENROUTER_MODEL, toolsEnabled: !!tools, context });
     let openRouterResponse = await fetch("https://openrouter.ai/api/v1/chat/completions", {
       method: "POST",
       headers: {
@@ -271,69 +300,130 @@ serve(async (req) => {
     const assistantMessage = result.choices?.[0]?.message;
     let searchResults: SearchResult[] | undefined;
 
-    // Handle tool calls
+    // Handle tool calls — support any number of parallel calls across both
+    // the rentals search tool and the 5 support tools.
     if (assistantMessage?.tool_calls?.length > 0) {
-      const toolCall = assistantMessage.tool_calls[0];
-      if (toolCall.function?.name === "search_properties") {
-        logStep("Tool call: search_properties", { args: toolCall.function.arguments });
+      const toolCalls = assistantMessage.tool_calls as Array<{
+        id: string;
+        function: { name: string; arguments: string | Record<string, unknown> };
+      }>;
 
-        const searchParams: SearchParams = typeof toolCall.function.arguments === "string"
-          ? JSON.parse(toolCall.function.arguments)
-          : toolCall.function.arguments;
+      // Lazily built when a support tool is called.
+      let userScopedClient: ReturnType<typeof createClient> | null = null;
+      let stripeClient: StripeLike | undefined;
+      const ensureSupportDeps = () => {
+        if (!userScopedClient) {
+          userScopedClient = createClient(supabaseUrl, supabaseAnonKey, {
+            auth: { persistSession: false },
+            global: { headers: { Authorization: `Bearer ${jwt}` } },
+          });
+        }
+        if (!stripeClient) {
+          const stripeKey = Deno.env.get("STRIPE_SECRET_KEY");
+          if (stripeKey) {
+            stripeClient = new Stripe(stripeKey, {
+              apiVersion: "2023-10-16",
+              httpClient: Stripe.createFetchHttpClient(),
+            }) as unknown as StripeLike;
+          }
+        }
+      };
 
-        // Use service role client for search (bypasses RLS)
-        const serviceClient = createClient(supabaseUrl, supabaseServiceKey, {
-          auth: { persistSession: false },
-        });
+      const toolResultMessages: Array<{ role: "tool"; tool_call_id: string; content: string }> = [];
 
-        const searchResponse = await searchProperties(serviceClient, searchParams, "TEXT-CHAT");
-        searchResults = searchResponse.results;
+      for (const call of toolCalls) {
+        const name = call.function?.name;
+        const rawArgs = call.function?.arguments;
+        const args: Record<string, unknown> = typeof rawArgs === "string"
+          ? (rawArgs ? JSON.parse(rawArgs) : {})
+          : (rawArgs ?? {});
 
-        logStep("Search completed", { resultCount: searchResults.length });
-
-        // Feed results back to LLM for natural language summary
-        const toolResultMessages = [
-          ...messages,
-          assistantMessage,
-          {
-            role: "tool" as const,
-            tool_call_id: toolCall.id,
+        if (name === "search_properties") {
+          logStep("Tool call: search_properties", { args });
+          const serviceClient = createClient(supabaseUrl, supabaseServiceKey, {
+            auth: { persistSession: false },
+          });
+          const searchResponse = await searchProperties(
+            serviceClient,
+            args as SearchParams,
+            "TEXT-CHAT",
+          );
+          searchResults = searchResponse.results;
+          toolResultMessages.push({
+            role: "tool",
+            tool_call_id: call.id,
             content: JSON.stringify({
               success: true,
               results: searchResults,
               total_count: searchResults.length,
             }),
-          },
-        ];
-
-        openRouterResponse = await fetch("https://openrouter.ai/api/v1/chat/completions", {
-          method: "POST",
-          headers: {
-            "Authorization": `Bearer ${openRouterKey}`,
-            "Content-Type": "application/json",
-            "HTTP-Referer": "https://rent-a-vacation.com",
-            "X-Title": "Rent-A-Vacation Text Chat",
-          },
-          body: JSON.stringify({
-            model: OPENROUTER_MODEL,
-            messages: toolResultMessages,
-            stream: true,
-            max_tokens: 1024,
-          }),
-        });
-
-        if (!openRouterResponse.ok) {
-          const errBody = await openRouterResponse.text();
-          logStep("OpenRouter follow-up error", { status: openRouterResponse.status, body: errBody });
-          return new Response(
-            JSON.stringify({ error: "Chat service temporarily unavailable" }),
-            { headers: { ...corsHeaders, "Content-Type": "application/json" }, status: 502 },
-          );
+          });
+          continue;
         }
 
-        // Stream the follow-up response as SSE
-        return streamSSEResponse(openRouterResponse, corsHeaders, searchResults);
+        if (isSupportTool(name)) {
+          ensureSupportDeps();
+          const userCtx: UserContext = {
+            userId: user.id,
+            userEmail: user.email ?? "",
+          };
+          logStep("Tool call: support", { name });
+          const toolResult = await dispatchSupportTool(
+            name,
+            userScopedClient as unknown as SupabaseLike,
+            userCtx,
+            args,
+            stripeClient,
+          );
+          toolResultMessages.push({
+            role: "tool",
+            tool_call_id: call.id,
+            content: JSON.stringify(toolResult),
+          });
+          continue;
+        }
+
+        // Unknown tool — tell the model so it can recover gracefully.
+        logStep("Tool call: unknown", { name });
+        toolResultMessages.push({
+          role: "tool",
+          tool_call_id: call.id,
+          content: JSON.stringify({ success: false, error: `Unknown tool: ${name}` }),
+        });
       }
+
+      // Feed all tool results back, stream the final response.
+      const followUpMessages = [...messages, assistantMessage, ...toolResultMessages];
+
+      openRouterResponse = await fetch("https://openrouter.ai/api/v1/chat/completions", {
+        method: "POST",
+        headers: {
+          "Authorization": `Bearer ${openRouterKey}`,
+          "Content-Type": "application/json",
+          "HTTP-Referer": "https://rent-a-vacation.com",
+          "X-Title": "Rent-A-Vacation Text Chat",
+        },
+        body: JSON.stringify({
+          model: OPENROUTER_MODEL,
+          messages: followUpMessages,
+          stream: true,
+          max_tokens: 1024,
+        }),
+      });
+
+      if (!openRouterResponse.ok) {
+        const errBody = await openRouterResponse.text();
+        logStep("OpenRouter follow-up error", {
+          status: openRouterResponse.status,
+          body: errBody,
+        });
+        return new Response(
+          JSON.stringify({ error: "Chat service temporarily unavailable" }),
+          { headers: { ...corsHeaders, "Content-Type": "application/json" }, status: 502 },
+        );
+      }
+
+      return streamSSEResponse(openRouterResponse, corsHeaders, searchResults);
     }
 
     // No tool call — check if we already have content, otherwise stream

--- a/supabase/functions/text-chat/support-tools.test.ts
+++ b/supabase/functions/text-chat/support-tools.test.ts
@@ -1,0 +1,306 @@
+// Unit tests for support agent tools.
+// Phase 22 C4 (#408) — each tool covers happy path + auth failure / RLS
+// rejection + domain-rule rejection where relevant.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createSupabaseMock } from "../../../src/test/helpers/supabase-mock";
+import {
+  lookupBooking,
+  checkRefundStatus,
+  checkDisputeStatus,
+  openDispute,
+  querySupportDocs,
+  dispatchSupportTool,
+  isSupportTool,
+  type StripeLike,
+  type UserContext,
+} from "./support-tools";
+
+const USER: UserContext = {
+  userId: "00000000-0000-0000-0000-000000000001",
+  userEmail: "traveler@example.com",
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ── lookup_booking @p0 ─────────────────────────────────────────────────────
+
+describe("lookup_booking @p0", () => {
+  it("returns a booking the authenticated user can see", async () => {
+    const booking = {
+      id: "bk-1",
+      listing_id: "ls-1",
+      renter_id: USER.userId,
+      status: "confirmed",
+      total_amount: 1200,
+    };
+    const supa = createSupabaseMock({
+      bookings: { data: booking, error: null },
+    });
+
+    const result = await lookupBooking(supa, USER, { booking_id: "bk-1" });
+
+    expect(result.success).toBe(true);
+    expect((result.data as { booking: typeof booking }).booking).toEqual(booking);
+  });
+
+  it("returns an auth-safe error when RLS hides the booking", async () => {
+    // RLS produces { data: null, error: null } on a miss via maybeSingle().
+    const supa = createSupabaseMock({ bookings: { data: null, error: null } });
+
+    const result = await lookupBooking(supa, USER, { booking_id: "bk-owned-by-someone-else" });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/no booking found/i);
+  });
+
+  it("rejects cross-account email lookups", async () => {
+    const supa = createSupabaseMock({ bookings: { data: [], error: null } });
+
+    const result = await lookupBooking(supa, USER, { email: "someone-else@example.com" });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/your own account/i);
+  });
+
+  it("lists recent bookings when only the user's own email is given", async () => {
+    const supa = createSupabaseMock({
+      bookings: { data: [{ id: "bk-1" }, { id: "bk-2" }], error: null },
+    });
+
+    const result = await lookupBooking(supa, USER, { email: USER.userEmail });
+
+    expect(result.success).toBe(true);
+    expect((result.data as { total: number }).total).toBe(2);
+  });
+
+  it("requires at least one of booking_id or email", async () => {
+    const supa = createSupabaseMock({});
+    const result = await lookupBooking(supa, USER, {});
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/required/i);
+  });
+});
+
+// ── check_refund_status ────────────────────────────────────────────────────
+
+describe("check_refund_status", () => {
+  it("returns DB state when refund is already processed (no Stripe call)", async () => {
+    const cancellation = {
+      id: "cr-1",
+      booking_id: "bk-1",
+      status: "refunded",
+      final_refund_amount: 500,
+      refund_reference: "re_123",
+      refund_processed_at: "2026-04-20T00:00:00Z",
+    };
+    const supa = createSupabaseMock({
+      cancellation_requests: { data: cancellation, error: null },
+    });
+    const stripe: StripeLike = {
+      refunds: { retrieve: vi.fn() },
+    };
+
+    const result = await checkRefundStatus(supa, USER, { booking_id: "bk-1" }, stripe);
+
+    expect(result.success).toBe(true);
+    expect(stripe.refunds.retrieve).not.toHaveBeenCalled();
+    expect((result.data as { source: string }).source).toBe("db");
+  });
+
+  it("reconciles with Stripe when refund is referenced but not yet processed", async () => {
+    const cancellation = {
+      id: "cr-2",
+      booking_id: "bk-2",
+      status: "approved",
+      refund_reference: "re_456",
+      refund_processed_at: null,
+    };
+    const supa = createSupabaseMock({
+      cancellation_requests: { data: cancellation, error: null },
+    });
+    const stripe: StripeLike = {
+      refunds: {
+        retrieve: vi.fn().mockResolvedValue({
+          id: "re_456",
+          status: "pending",
+          amount: 50000,
+          arrival_date: 1713830400,
+        }),
+      },
+    };
+
+    const result = await checkRefundStatus(supa, USER, { booking_id: "bk-2" }, stripe);
+
+    expect(result.success).toBe(true);
+    expect(stripe.refunds.retrieve).toHaveBeenCalledWith("re_456");
+    expect((result.data as { source: string }).source).toBe("db+stripe");
+    expect((result.data as { stripe_refund: { status: string } }).stripe_refund.status).toBe(
+      "pending",
+    );
+  });
+
+  it("fails closed: returns DB state with a note when Stripe throws", async () => {
+    const cancellation = {
+      id: "cr-3",
+      booking_id: "bk-3",
+      status: "approved",
+      refund_reference: "re_789",
+      refund_processed_at: null,
+    };
+    const supa = createSupabaseMock({
+      cancellation_requests: { data: cancellation, error: null },
+    });
+    const stripe: StripeLike = {
+      refunds: { retrieve: vi.fn().mockRejectedValue(new Error("stripe down")) },
+    };
+
+    const result = await checkRefundStatus(supa, USER, { booking_id: "bk-3" }, stripe);
+
+    expect(result.success).toBe(true);
+    expect(result.note).toMatch(/stripe/i);
+    expect((result.data as { source: string }).source).toBe("db");
+  });
+
+  it("reports no cancellation on file when none exists (auth-safe)", async () => {
+    const supa = createSupabaseMock({
+      cancellation_requests: { data: null, error: null },
+    });
+
+    const result = await checkRefundStatus(supa, USER, { booking_id: "bk-none" });
+
+    expect(result.success).toBe(true);
+    expect((result.data as { has_cancellation: boolean }).has_cancellation).toBe(false);
+  });
+});
+
+// ── check_dispute_status ───────────────────────────────────────────────────
+
+describe("check_dispute_status", () => {
+  it("returns disputes on a booking the user is part of", async () => {
+    const supa = createSupabaseMock({
+      disputes: { data: [{ id: "dp-1", status: "open" }], error: null },
+    });
+
+    const result = await checkDisputeStatus(supa, USER, { booking_id: "bk-1" });
+
+    expect(result.success).toBe(true);
+    expect((result.data as { total: number }).total).toBe(1);
+  });
+
+  it("returns an empty array (auth-safe) when RLS hides everything", async () => {
+    const supa = createSupabaseMock({ disputes: { data: [], error: null } });
+
+    const result = await checkDisputeStatus(supa, USER, { booking_id: "bk-other" });
+
+    expect(result.success).toBe(true);
+    expect((result.data as { total: number }).total).toBe(0);
+  });
+});
+
+// ── open_dispute ───────────────────────────────────────────────────────────
+
+describe("open_dispute", () => {
+  const validArgs = {
+    booking_id: "bk-1",
+    category: "owner_no_show",
+    description: "Owner never sent check-in details and is not responding to messages.",
+  };
+
+  it("opens a dispute when the user owns the booking", async () => {
+    const created = { id: "dp-new", status: "open", category: "owner_no_show" };
+    const supa = createSupabaseMock({ disputes: { data: created, error: null } });
+
+    const result = await openDispute(supa, USER, validArgs);
+
+    expect(result.success).toBe(true);
+    expect((result.data as { dispute: typeof created }).dispute).toEqual(created);
+    expect(result.note).toMatch(/RAV team/);
+  });
+
+  it("surfaces RLS rejection when the user does not own the booking", async () => {
+    const supa = createSupabaseMock({
+      disputes: {
+        data: null,
+        error: { message: 'new row violates row-level security policy', code: "42501" },
+      },
+    });
+
+    const result = await openDispute(supa, USER, validArgs);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/could not open dispute/i);
+  });
+
+  it("rejects invalid categories before touching the DB", async () => {
+    const supa = createSupabaseMock({});
+    const result = await openDispute(supa, USER, { ...validArgs, category: "made_up" });
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/invalid category/i);
+  });
+
+  it("requires a non-trivial description", async () => {
+    const supa = createSupabaseMock({});
+    const result = await openDispute(supa, USER, { ...validArgs, description: "bad" });
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/20 characters/i);
+  });
+});
+
+// ── query_support_docs ─────────────────────────────────────────────────────
+
+describe("query_support_docs", () => {
+  it("returns active docs matching a keyword query", async () => {
+    const docs = [
+      { slug: "policies/cancellation-policy", title: "Cancellation Policy", doc_type: "policy" },
+      { slug: "faqs/booking-faq", title: "Booking FAQ", doc_type: "faq" },
+    ];
+    const supa = createSupabaseMock({ support_docs: { data: docs, error: null } });
+
+    const result = await querySupportDocs(supa, USER, { query: "cancel refund" });
+
+    expect(result.success).toBe(true);
+    expect((result.data as { total: number }).total).toBe(2);
+  });
+
+  it("requires a non-empty query", async () => {
+    const supa = createSupabaseMock({});
+    const result = await querySupportDocs(supa, USER, { query: "   " });
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/required/i);
+  });
+
+  it("surfaces database errors as structured tool errors", async () => {
+    const supa = createSupabaseMock({
+      support_docs: { data: null, error: { message: "tsvector index missing" } },
+    });
+
+    const result = await querySupportDocs(supa, USER, { query: "refund" });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/doc search failed/i);
+  });
+});
+
+// ── registry + dispatcher ──────────────────────────────────────────────────
+
+describe("isSupportTool / dispatchSupportTool", () => {
+  it("accepts only the 5 declared tools", () => {
+    expect(isSupportTool("lookup_booking")).toBe(true);
+    expect(isSupportTool("query_support_docs")).toBe(true);
+    expect(isSupportTool("drop_table")).toBe(false);
+  });
+
+  it("dispatches to the right handler", async () => {
+    const supa = createSupabaseMock({
+      support_docs: { data: [{ slug: "policies/refund-policy" }], error: null },
+    });
+
+    const result = await dispatchSupportTool("query_support_docs", supa, USER, { query: "refund" });
+
+    expect(result.success).toBe(true);
+    expect((result.data as { total: number }).total).toBe(1);
+  });
+});

--- a/supabase/functions/text-chat/support-tools.ts
+++ b/supabase/functions/text-chat/support-tools.ts
@@ -1,0 +1,532 @@
+// Support tool handlers invoked by the RAVIO support agent.
+// Phase 22 C4 (#408) — DEC-036.
+//
+// Pure-logic module: accepts a minimal Supabase-like interface and user
+// context, returns structured JSON the agent can reason about. Runs in both
+// Deno (edge function) and Node (vitest) without runtime-specific imports.
+//
+// All queries are RLS-enforced — callers MUST pass a user-scoped client built
+// with the caller's JWT (Authorization header). Never pass a service-role
+// client here; tools must see only what the user is authorised to see.
+
+// ── Structural types ────────────────────────────────────────────────────────
+// Deliberately loose: the real @supabase/supabase-js client and the mocks in
+// src/test/helpers/supabase-mock.ts both satisfy this shape.
+
+type PgResult<T> = { data: T | null; error: { message: string; code?: string } | null };
+
+export interface SupabaseLike {
+  from: (table: string) => unknown;
+}
+
+export interface StripeLike {
+  refunds: {
+    retrieve: (id: string) => Promise<{
+      id: string;
+      status: string;
+      amount: number;
+      arrival_date?: number | null;
+      failure_reason?: string | null;
+    }>;
+  };
+}
+
+export interface UserContext {
+  userId: string;
+  userEmail: string;
+}
+
+export interface ToolResult<T = unknown> {
+  success: boolean;
+  data?: T;
+  error?: string;
+  note?: string;
+}
+
+// ── Safe field projections (sensitive fields never leave this module) ──────
+
+const SAFE_BOOKING_COLUMNS = [
+  "id",
+  "listing_id",
+  "renter_id",
+  "status",
+  "total_amount",
+  "base_amount",
+  "cleaning_fee",
+  "service_fee",
+  "tax_amount",
+  "guest_count",
+  "source_type",
+  "special_requests",
+  "paid_at",
+  "created_at",
+  "listings:listings(id, check_in_date, check_out_date, nightly_rate, status, source_type, property_id)",
+].join(", ");
+
+const SAFE_CANCELLATION_COLUMNS = [
+  "id",
+  "booking_id",
+  "status",
+  "reason",
+  "requested_refund_amount",
+  "policy_refund_amount",
+  "final_refund_amount",
+  "counter_offer_amount",
+  "days_until_checkin",
+  "refund_processed_at",
+  "refund_reference",
+  "created_at",
+  "responded_at",
+].join(", ");
+
+const SAFE_DISPUTE_COLUMNS = [
+  "id",
+  "booking_id",
+  "reporter_id",
+  "category",
+  "priority",
+  "status",
+  "description",
+  "resolution_notes",
+  "resolved_at",
+  "refund_amount",
+  "created_at",
+].join(", ");
+
+const VALID_DISPUTE_CATEGORIES = [
+  "property_not_as_described",
+  "access_issues",
+  "safety_concerns",
+  "cleanliness",
+  "cancellation_dispute",
+  "payment_dispute",
+  "owner_no_show",
+  "renter_damage",
+  "renter_no_show",
+  "unauthorized_guests",
+  "rule_violation",
+  "late_checkout",
+  "other",
+];
+
+// Minimum description length to deter accidental empty escalations.
+const MIN_DISPUTE_DESCRIPTION_LENGTH = 20;
+
+// ── Tool: lookup_booking ────────────────────────────────────────────────────
+
+export async function lookupBooking(
+  supabase: SupabaseLike,
+  userCtx: UserContext,
+  args: { booking_id?: string; email?: string },
+): Promise<ToolResult> {
+  const { booking_id, email } = args;
+
+  if (!booking_id && !email) {
+    return { success: false, error: "Either booking_id or email is required." };
+  }
+
+  // Email branch: must match the authenticated user's own email.
+  // No cross-account lookup — RLS would prevent it anyway, but reject early.
+  if (email && !booking_id) {
+    if (email.trim().toLowerCase() !== userCtx.userEmail.trim().toLowerCase()) {
+      return {
+        success: false,
+        error: "I can only look up bookings on your own account. Please confirm the email on your account matches.",
+      };
+    }
+
+    // Return the user's 10 most recent bookings.
+    const query = (supabase.from("bookings") as {
+      select: (cols: string) => {
+        eq: (col: string, val: string) => {
+          order: (col: string, opts: { ascending: boolean }) => {
+            limit: (n: number) => Promise<PgResult<unknown[]>>;
+          };
+        };
+      };
+    })
+      .select(SAFE_BOOKING_COLUMNS)
+      .eq("renter_id", userCtx.userId)
+      .order("created_at", { ascending: false })
+      .limit(10);
+
+    const { data, error } = await query;
+    if (error) return { success: false, error: `Lookup failed: ${error.message}` };
+    return { success: true, data: { bookings: data ?? [], total: (data ?? []).length } };
+  }
+
+  // booking_id branch: RLS scopes to bookings the user can see (as renter,
+  // or as owner of the listing). maybeSingle() returns null on no match.
+  const result = await (supabase.from("bookings") as {
+    select: (cols: string) => {
+      eq: (col: string, val: string) => {
+        maybeSingle: () => Promise<PgResult<unknown>>;
+      };
+    };
+  })
+    .select(SAFE_BOOKING_COLUMNS)
+    .eq("id", booking_id!)
+    .maybeSingle();
+
+  if (result.error) {
+    return { success: false, error: `Lookup failed: ${result.error.message}` };
+  }
+  if (!result.data) {
+    return {
+      success: false,
+      error: "No booking found with that ID on your account. If you believe this is an error, please confirm the booking ID.",
+    };
+  }
+  return { success: true, data: { booking: result.data } };
+}
+
+// ── Tool: check_refund_status (DB-first, live Stripe fallback) ─────────────
+
+export async function checkRefundStatus(
+  supabase: SupabaseLike,
+  userCtx: UserContext,
+  args: { booking_id: string },
+  stripe?: StripeLike,
+): Promise<ToolResult> {
+  if (!args.booking_id) {
+    return { success: false, error: "booking_id is required." };
+  }
+
+  // RLS enforces — users see only cancellations on bookings they participate in.
+  const result = await (supabase.from("cancellation_requests") as {
+    select: (cols: string) => {
+      eq: (col: string, val: string) => {
+        order: (col: string, opts: { ascending: boolean }) => {
+          limit: (n: number) => {
+            maybeSingle: () => Promise<PgResult<Record<string, unknown>>>;
+          };
+        };
+      };
+    };
+  })
+    .select(SAFE_CANCELLATION_COLUMNS)
+    .eq("booking_id", args.booking_id)
+    .order("created_at", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (result.error) {
+    return { success: false, error: `Refund lookup failed: ${result.error.message}` };
+  }
+  if (!result.data) {
+    return {
+      success: true,
+      data: { has_cancellation: false },
+      note: "No cancellation request on file for this booking.",
+    };
+  }
+
+  const cancellation = result.data;
+  const refundReference = cancellation.refund_reference as string | null;
+  const refundProcessedAt = cancellation.refund_processed_at as string | null;
+
+  // DB-first answer. Live Stripe reconcile only when the DB says "refund owed
+  // but not yet processed" or when arrival date could be useful.
+  // Fail-closed: Stripe errors never break the response — we return DB state
+  // with a note so the agent can still answer.
+  if (stripe && refundReference && !refundProcessedAt) {
+    try {
+      const stripeRefund = await stripe.refunds.retrieve(refundReference);
+      return {
+        success: true,
+        data: {
+          cancellation,
+          stripe_refund: {
+            id: stripeRefund.id,
+            status: stripeRefund.status,
+            amount: stripeRefund.amount,
+            arrival_date: stripeRefund.arrival_date ?? null,
+            failure_reason: stripeRefund.failure_reason ?? null,
+          },
+          source: "db+stripe",
+        },
+      };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return {
+        success: true,
+        data: { cancellation, source: "db" },
+        note: `Live Stripe state unavailable (${msg}); returning our last known record.`,
+      };
+    }
+  }
+
+  return {
+    success: true,
+    data: { cancellation, source: "db" },
+  };
+}
+
+// ── Tool: check_dispute_status ──────────────────────────────────────────────
+
+export async function checkDisputeStatus(
+  supabase: SupabaseLike,
+  _userCtx: UserContext,
+  args: { booking_id: string },
+): Promise<ToolResult> {
+  if (!args.booking_id) {
+    return { success: false, error: "booking_id is required." };
+  }
+
+  const result = await (supabase.from("disputes") as {
+    select: (cols: string) => {
+      eq: (col: string, val: string) => {
+        order: (col: string, opts: { ascending: boolean }) => Promise<PgResult<unknown[]>>;
+      };
+    };
+  })
+    .select(SAFE_DISPUTE_COLUMNS)
+    .eq("booking_id", args.booking_id)
+    .order("created_at", { ascending: false });
+
+  if (result.error) {
+    return { success: false, error: `Dispute lookup failed: ${result.error.message}` };
+  }
+
+  const disputes = result.data ?? [];
+  return {
+    success: true,
+    data: { disputes, total: disputes.length },
+  };
+}
+
+// ── Tool: open_dispute ──────────────────────────────────────────────────────
+
+export async function openDispute(
+  supabase: SupabaseLike,
+  userCtx: UserContext,
+  args: { booking_id: string; category: string; description: string },
+): Promise<ToolResult> {
+  const { booking_id, category, description } = args;
+
+  if (!booking_id || !category || !description) {
+    return { success: false, error: "booking_id, category, and description are all required." };
+  }
+  if (!VALID_DISPUTE_CATEGORIES.includes(category)) {
+    return {
+      success: false,
+      error: `Invalid category. Must be one of: ${VALID_DISPUTE_CATEGORIES.join(", ")}.`,
+    };
+  }
+  if (description.trim().length < MIN_DISPUTE_DESCRIPTION_LENGTH) {
+    return {
+      success: false,
+      error: `Please provide a description of at least ${MIN_DISPUTE_DESCRIPTION_LENGTH} characters explaining the issue.`,
+    };
+  }
+
+  // RLS policy "Users can create disputes" enforces reporter_id = auth.uid().
+  const result = await (supabase.from("disputes") as {
+    insert: (row: Record<string, unknown>) => {
+      select: (cols: string) => {
+        single: () => Promise<PgResult<Record<string, unknown>>>;
+      };
+    };
+  })
+    .insert({
+      booking_id,
+      reporter_id: userCtx.userId,
+      category,
+      description,
+      status: "open",
+    })
+    .select(SAFE_DISPUTE_COLUMNS)
+    .single();
+
+  if (result.error) {
+    return { success: false, error: `Could not open dispute: ${result.error.message}` };
+  }
+  return {
+    success: true,
+    data: { dispute: result.data },
+    note: "Dispute opened. The RAV team has been notified and will follow up.",
+  };
+}
+
+// ── Tool: query_support_docs ────────────────────────────────────────────────
+
+export async function querySupportDocs(
+  supabase: SupabaseLike,
+  _userCtx: UserContext,
+  args: { query: string; doc_type?: string },
+): Promise<ToolResult> {
+  const { query, doc_type } = args;
+
+  if (!query?.trim()) {
+    return { success: false, error: "query is required." };
+  }
+
+  // Base chain — RLS already limits to status='active' for non-staff.
+  type BaseChain = {
+    select: (cols: string) => BaseChain;
+    eq: (col: string, val: string) => BaseChain;
+    textSearch: (col: string, q: string, opts?: { type?: string }) => BaseChain;
+    limit: (n: number) => Promise<PgResult<unknown[]>>;
+  };
+
+  let chain = (supabase.from("support_docs") as BaseChain)
+    .select("slug, title, doc_type, audience, tags, sections, version")
+    .eq("status", "active");
+
+  if (doc_type) {
+    chain = chain.eq("doc_type", doc_type);
+  }
+
+  const result = await chain
+    .textSearch("search_tsv", query, { type: "websearch" })
+    .limit(5);
+
+  if (result.error) {
+    return { success: false, error: `Doc search failed: ${result.error.message}` };
+  }
+
+  return {
+    success: true,
+    data: { results: result.data ?? [], total: (result.data ?? []).length },
+  };
+}
+
+// ── Registry + dispatcher ───────────────────────────────────────────────────
+
+export const SUPPORT_TOOL_NAMES = [
+  "lookup_booking",
+  "check_refund_status",
+  "check_dispute_status",
+  "open_dispute",
+  "query_support_docs",
+] as const;
+
+export type SupportToolName = (typeof SUPPORT_TOOL_NAMES)[number];
+
+export function isSupportTool(name: string): name is SupportToolName {
+  return (SUPPORT_TOOL_NAMES as readonly string[]).includes(name);
+}
+
+export async function dispatchSupportTool(
+  name: SupportToolName,
+  supabase: SupabaseLike,
+  userCtx: UserContext,
+  args: Record<string, unknown>,
+  stripe?: StripeLike,
+): Promise<ToolResult> {
+  switch (name) {
+    case "lookup_booking":
+      return lookupBooking(supabase, userCtx, args as Parameters<typeof lookupBooking>[2]);
+    case "check_refund_status":
+      return checkRefundStatus(
+        supabase,
+        userCtx,
+        args as Parameters<typeof checkRefundStatus>[2],
+        stripe,
+      );
+    case "check_dispute_status":
+      return checkDisputeStatus(supabase, userCtx, args as Parameters<typeof checkDisputeStatus>[2]);
+    case "open_dispute":
+      return openDispute(supabase, userCtx, args as Parameters<typeof openDispute>[2]);
+    case "query_support_docs":
+      return querySupportDocs(supabase, userCtx, args as Parameters<typeof querySupportDocs>[2]);
+  }
+}
+
+// ── OpenRouter / Claude-compatible tool schemas ─────────────────────────────
+// Function-calling spec, same shape as the existing SEARCH_TOOL in index.ts.
+
+export const SUPPORT_TOOL_SCHEMAS = [
+  {
+    type: "function" as const,
+    function: {
+      name: "lookup_booking",
+      description:
+        "Look up a booking the authenticated user is part of. Provide booking_id for a specific booking, or just email (the user's own email) to list their 10 most recent bookings.",
+      parameters: {
+        type: "object",
+        properties: {
+          booking_id: { type: "string", description: "The UUID of the booking." },
+          email: {
+            type: "string",
+            description:
+              "The authenticated user's email. Must match the user's account email. Used only when booking_id is unknown.",
+          },
+        },
+      },
+    },
+  },
+  {
+    type: "function" as const,
+    function: {
+      name: "check_refund_status",
+      description:
+        "Return the latest cancellation and refund state for a booking, reconciled with Stripe when we have a refund reference but no processed timestamp.",
+      parameters: {
+        type: "object",
+        properties: {
+          booking_id: { type: "string", description: "The UUID of the booking." },
+        },
+        required: ["booking_id"],
+      },
+    },
+  },
+  {
+    type: "function" as const,
+    function: {
+      name: "check_dispute_status",
+      description: "Return any open or closed disputes on a booking the user is part of.",
+      parameters: {
+        type: "object",
+        properties: {
+          booking_id: { type: "string", description: "The UUID of the booking." },
+        },
+        required: ["booking_id"],
+      },
+    },
+  },
+  {
+    type: "function" as const,
+    function: {
+      name: "open_dispute",
+      description:
+        "Open a new dispute on a booking. Only call this after explicit user confirmation that they want to escalate. Provide a clear, specific description (20+ chars).",
+      parameters: {
+        type: "object",
+        properties: {
+          booking_id: { type: "string", description: "The UUID of the booking." },
+          category: {
+            type: "string",
+            enum: VALID_DISPUTE_CATEGORIES,
+            description: "The dispute category that best matches the issue.",
+          },
+          description: {
+            type: "string",
+            description: "Clear explanation of the issue, in the user's words where possible.",
+          },
+        },
+        required: ["booking_id", "category", "description"],
+      },
+    },
+  },
+  {
+    type: "function" as const,
+    function: {
+      name: "query_support_docs",
+      description:
+        "Keyword-search the Rent-A-Vacation support knowledge base (policies, FAQs, processes, guides). Call this BEFORE answering policy questions so the answer is grounded in current, approved content.",
+      parameters: {
+        type: "object",
+        properties: {
+          query: { type: "string", description: "Keyword query; plain English is fine." },
+          doc_type: {
+            type: "string",
+            enum: ["policy", "faq", "process", "guide"],
+            description: "Optional filter to a specific document type.",
+          },
+        },
+        required: ["query"],
+      },
+    },
+  },
+];

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,7 +8,10 @@ export default defineConfig({
     environment: "jsdom",
     globals: true,
     setupFiles: ["./src/test/setup.ts"],
-    include: ["src/**/*.{test,spec}.{ts,tsx}"],
+    include: [
+      "src/**/*.{test,spec}.{ts,tsx}",
+      "supabase/functions/**/*.{test,spec}.ts",
+    ],
     coverage: {
       provider: "v8",
       include: ["src/lib/**", "src/hooks/**", "src/contexts/**"],


### PR DESCRIPTION
## Summary

Paired PR for Phase 22 **C1 (#405)** and **C4 (#408)** — ships the RAVIO support agent's edge-fn surface and 5 tools. Builds on the documentation infrastructure shipped in Session 57 (docs/support/, migration 060, `ingest-support-docs`).

## What this adds

- **`context: 'support'` branch in `supabase/functions/text-chat/index.ts`** — dedicated empathetic system prompt grounded in the `support_docs` table, explicit escalation rules (confirm before opening disputes, never promise refund amounts from memory, cite tool output).
- **Generalised tool-call loop** — replaces the hardcoded single-call `search_properties` branch with a dispatcher that iterates all parallel `tool_calls`, routes each by name (rentals search vs the 5 support tools vs graceful unknown), and feeds all results back in one follow-up streaming call. Rentals behaviour preserved.
- **New `supabase/functions/text-chat/support-tools.ts`** — pure-logic module with 5 handlers:
  - `lookup_booking(booking_id | email)` — RLS-scoped; email branch only accepts the authenticated user's own email.
  - `check_refund_status(booking_id)` — **DB-first with live Stripe reconcile** when we have a `refund_reference` but no `refund_processed_at`. Fails closed: Stripe errors return DB state + a `note`.
  - `check_dispute_status(booking_id)`.
  - `open_dispute(booking_id, category, description)` — validates 13 categories + min description length; RLS enforces `reporter_id = auth.uid()` on insert.
  - `query_support_docs(query, doc_type?)` — tsvector keyword search against `support_docs` where `status = 'active'`.
- **RLS enforcement via user-scoped Supabase client** — built with `Authorization: Bearer <jwt>` so `auth.uid()` resolves inside policies. No service-role inside tools.
- **Sensitive-field redaction** — explicit column allow-lists; `payment_intent_id`, `stripe_transfer_id`, payout/admin fields never leave the module.
- **20 new unit tests** in `support-tools.test.ts` — 5 tools × happy path + auth/RLS failure + domain-rule rejection + registry/dispatcher coverage.
- Vitest `include` extended to `supabase/functions/**/*.test.ts` — pattern mirrors existing `_shared/rate-limit.ts` (minimal structural interface → testable under Vitest without Deno).

## What this does NOT include (scope boundaries)

- **#406 C2** — route-based context detection in `useTextChat` (frontend)
- **#407 C3** — intent classifier + "Switched to Support" chip
- **#409 C5** — `source: 'ravio_support'` enum on disputes + AdminDisputes filter
- No new migrations. No frontend changes. `text-chat` edge-fn deploy to PROD held per CLAUDE.md.

## Why DB+Stripe (not DB-only) for refund status

Customer support is a stated strategic differentiator for RAV. The user's real question is often "when will I see the money?" — which requires Stripe's live `arrival_date` for ACH refunds. DB-only would answer "did it go through" but miss timing. Live path fires only when DB indicates pending/unknown; on Stripe errors, falls back to DB state with a note.

## Test plan

- [ ] `npm run test` passes (1166/1166)
- [ ] `npm run build` passes
- [ ] `npx tsc --noEmit` clean
- [ ] `npm run test:p0` passes
- [ ] Manual smoke after DEV deploy (next session): POST to `text-chat` with `context: 'support'` + a support-flavoured message, verify RAVIO calls `query_support_docs` or `lookup_booking` appropriately

🤖 Generated with [Claude Code](https://claude.com/claude-code)