### PR TITLE
feat(support-agent): Phase 22 C2 — route-based context detection in useTextChat (#406)

### DIFF
--- a/docs/PRIORITY-ROADMAP.md
+++ b/docs/PRIORITY-ROADMAP.md
@@ -1,6 +1,6 @@
 ---
-last_updated: "2026-04-22T23:47:09"
-change_ref: "c820f23"
+last_updated: "2026-04-23T00:22:11"
+change_ref: "2ad0d63"
 change_type: "session-58"
 status: "active"
 ---
@@ -45,8 +45,7 @@ All unblocked follow-ups from Sessions 54-58. Pick in any order; they're indepen
 
 | Issue | Title | Est. | Why now |
 |-------|-------|------|---------|
-| **#406** | Phase 22 C2: Route-based context detection in `useTextChat` | 4-6h | Unblocked by Session 58 (#405 + #408 shipped). Auto-switch support vs discovery by route. Suggested prompts swap per context. Small frontend-only PR. |
-| **#407** | Phase 22 C3: Intent classifier + "Switched to Support" chip | 4-6h | Depends on #406. Fallback for ambiguous routes. Keyword classifier + model fallback. Chip UI + session override. |
+| **#407** | Phase 22 C3: Intent classifier + "Switched to Support" chip | 4-6h | Unblocked by Session 58 (#406 shipped). Fallback for ambiguous routes. Keyword classifier + model fallback. Chip UI + session override. |
 | **#409** | Phase 22 C5: Agent-opened disputes with `source: 'ravio_support'` tag | 4h | Unblocked by Session 58. Migration adds `source` enum to disputes table; `open_dispute` tool updated to set it; AdminDisputes UI shows badge + filter. |
 | **#410** | Phase 22 D1: Support conversation logging | 6-8h | Unblocked by Session 58. Extend `conversations` table so support turns are captured for metrics + replay. |
 | **#411** | Phase 22 D2: Admin "Support Interactions" tab + metrics | 1d | Depends on #410. Deflection rate, escalation rate, SLA. |
@@ -57,7 +56,7 @@ All unblocked follow-ups from Sessions 54-58. Pick in any order; they're indepen
 | **#371** | Edge function test harness | 1-2d (needs scoping) | Tech-debt follow-up from Tests-With-Features shortfalls. Enables future edge-fn work to be properly tested. |
 | **#393** | PLATFORM-INVENTORY.md — one-page mental model of everything built | 2-3h | Session 56 meta-ask: a single doc cataloging product + platform + dev-tooling + governance layers so the user can explain what they've built to investors, new collaborators, and future sessions. |
 
-> **Phase 22 epic (#395)** — Tracks A, B, E complete in Session 57; C1 + C4 (#405 + #408) shipped in Session 58. Remaining: #406, #407, #409 (Track C finale) + #410, #411 (Track D observability). Recommended next: #406 (small frontend-only) or #409 (completes the escalation loop end-to-end).
+> **Phase 22 epic (#395)** — Tracks A, B, E complete in Session 57; C1 + C4 + C2 (#405 + #408 + #406) shipped in Session 58 (2 PRs). Remaining: #407, #409 (Track C finale) + #410, #411 (Track D observability). Recommended next: **#409** (completes the escalation loop end-to-end — agent-opened disputes visible to admins).
 
 ### Tier B: Pre-Launch Important (Needs Human Input)
 
@@ -136,7 +135,7 @@ These unblock when the LLC is formed. Not code-dependent.
 
 | Date | Session | Changes |
 |------|---------|---------|
-| Apr 22, 2026 | 58 | **Phase 22 C1 + C4 SHIPPED (#405 + #408).** `text-chat` edge fn gains `context:'support'` branch + 5 agent tools (lookup_booking, check_refund_status, check_dispute_status, open_dispute, query_support_docs). `check_refund_status` uses DB-first with live Stripe reconcile; fails closed. 20 new unit tests. Phase 22 now 77% complete (17 of 22). Remaining Tier A: #406, #407, #409, #410, #411. |
+| Apr 22, 2026 | 58 | **Phase 22 C1 + C4 + C2 SHIPPED** across 2 PRs. PR #428 (C1 + C4): `text-chat` edge fn gains `context:'support'` + 5 agent tools; DB-first with live Stripe reconcile. PR #429 (C2): `detectChatContext(pathname)` utility + `useTextChat` auto-detection + new `<RavioFloatingChat />` mounted on /my-trips, /owner-dashboard, /account. Pre-existing `TextChatPanel` terminology drift fixed per DEC-031 (Bidding Guide → Marketplace, bid → Offer, travel request → Wish). 68 new unit tests (20 tools + 48 routing/detection). Phase 22 now 82% complete (18 of 22). Remaining Tier A: #407, #409, #410, #411. |
 | Apr 21, 2026 | 57 | **Phase 22 SHIPPED Tracks A + B + E (15 of 22 tickets, 8 PRs #418-#425).** Full documentation infrastructure end-to-end on DEV: 22 markdown files in `docs/support/`, migration 060 (support_docs), `ingest-support-docs` edge fn + GitHub Action, `docs-sync-check` extension, 6 legal-blocked drafts at status:draft pending #80. Issues closed: #396-#404, #412-#417. Remaining: Track C (#405-#409 RAVIO agent code) + Track D (#410, #411 observability) — next session. PROD deploys held per CLAUDE.md. |
 | Apr 20, 2026 | 57 (planning) | Phase 22 Customer Support Foundation SCOPED. Milestone #37 + epic #395 + 22 child issues #396-#417. DEC-036 logged: reject CrewAI, extend RAVIO text chat with `context: 'support'` + tool use; voice stays discovery-only. 20 support docs planned. Markdown canonical → Supabase `support_docs` sync. PR #418. |
 | Apr 20, 2026 | 56 | **DEC-034 Marketplace Flow Distinction SHIPPED end-to-end (#380 CLOSED)** via 5 incremental PRs (#385-#389). Migrations 058 + 059. `listing_source_type` enum + `ListingTypeBadge` everywhere. Critical search-filter fix. 3 new notification types. `/sdlc` doc-update checklist promoted to root `CLAUDE.md` (PR #390) so it applies to every session. 1146 tests. Issues unblocked: #376, #378, #381. |

--- a/docs/PROJECT-HUB.md
+++ b/docs/PROJECT-HUB.md
@@ -1,6 +1,6 @@
 ---
-last_updated: "2026-04-22T23:47:09"
-change_ref: "c820f23"
+last_updated: "2026-04-23T00:22:11"
+change_ref: "2ad0d63"
 change_type: "session-58"
 status: "active"
 ---
@@ -93,8 +93,8 @@ gh issue create --repo rent-a-vacation/rav-website --title "..." --label "..." -
 - Edge functions require `--no-verify-jwt` deployment flag
 
 ### Platform Status
-- **1166 automated tests** (135 test files, all passing), 0 type errors, 0 lint errors, build clean
-- **P0 tests:** 97 critical-path tests tagged `@p0` + 4 subscription P0s + 6 ListingTypeBadge P0s + 1 support-tool P0 — run with `npm run test:p0`
+- **1214 automated tests** (136 test files, all passing), 0 type errors, 0 lint errors, build clean
+- **P0 tests:** 97 critical-path tests tagged `@p0` + 4 subscription P0s + 6 ListingTypeBadge P0s + 1 support-tool P0 + 35 detectChatContext P0s — run with `npm run test:p0`
 - **CI reporting:** GitHub native via dorny/test-reporter (JUnit XML) — PR annotations on every run (Qase removed Mar 2026)
 - **Migrations created:** 001-060 (001-059 deployed to DEV + PROD; 060 deployed to DEV only — PROD held per CLAUDE.md) + 3 date-based MDM migrations
 - **Edge functions:** 35 total (27 deployed to PROD + 4 subscription functions on DEV + 3 SMS functions pending LLC/EIN + `ingest-support-docs` deployed to DEV only). `text-chat` gains a `context: 'support'` branch with 5 agent tools (Session 58, Phase 22 C1 + C4).
@@ -108,7 +108,20 @@ gh issue create --repo rent-a-vacation/rav-website --title "..." --label "..." -
 
 ### Session Handoff (Sessions 25-58)
 
-**Session 58 — Phase 22 Track C: RAVIO support agent wired up (#405 + #408, Apr 22, 2026):**
+**Session 58 — Phase 22 Track C: support agent + route-based context detection (#405 + #408 + #406, Apr 22, 2026):**
+
+**Second PR (#429) — C2 #406 route-based context detection:**
+- New `src/lib/chatContext.ts` with `detectChatContext(pathname)` — maps route prefixes (`/my-trips`, `/owner-dashboard`, `/account`, `/settings/*`, `/disputes/*`, `/messages`, `/checkout`, etc.) to `support`; `/rentals`, `/property/*`, `/tools/*`, `/destinations/*`, `/calculator`, `/rav-deals` to `rentals`; `/marketplace`, `/bidding*` to `bidding`; else `general`. 35 test cases covering every documented route + case-insensitivity + partial-segment edge cases.
+- `useTextChat` now accepts an OPTIONAL `context` prop; when omitted it auto-detects via `useLocation().pathname`. Explicit context (PropertyDetail, Rentals, BiddingMarketplace, HowItWorksPage) always wins. Chat history clears on context switch (route navigation triggers the same reset mechanism that was already in place).
+- `ChatContext` union extended with `"support"`.
+- New `<RavioFloatingChat />` helper — floating bottom-right button + panel with zero props; mounted on `/my-trips` (RenterDashboard), `/owner-dashboard`, `/account` (AccountSettings). These are the first surfaces where the support context is actually exercised end-to-end by a user.
+- **Terminology drift in `TextChatPanel` fixed inline** (pre-existing DEC-031 gaps; cleaned up while in the file per the user's direction to "stay consistent with the current plan"): `"Bidding Guide"` → `"Marketplace"`; prompt `"place a bid"` → `"submit an Offer"`; prompt `"travel request"` → `"Wish"`; prompt `"bidding work for this listing"` → `"Offers work on this Listing"`. All new strings conform to BRAND-LOCK §8 (plain nouns for marketplace mechanics) + §9 (Listing / Wish / Offer).
+- Support-context suggested prompts: "Where's my refund?", "How do I cancel my booking?", "I'm having a problem with my stay", "How do I file a dispute?" — locked vocabulary only; no new brand terms introduced.
+- **New feedback memory:** `avoid_churning_locked_terminology.md` — captures the principle that mid-session rename ideas get deferred; use locked vocab in-flight, flag the idea, do the rename in its own PR later. Precipitated by the user floating "Wish → Travel Wish" during #406 and then deciding to stay with DEC-031 for now.
+- **Scope held:** only the 4 pre-existing TextChatPanel drift strings were touched. Broader "wish / travel request / bid" cleanup across ~30 other files (UserGuide, Documentation, MyBidsDashboard, hooks, etc.) deliberately NOT included — that's a standalone terminology-audit PR if/when we do it.
+- Tests: 1166 → 1214 (+48). `chatContext.test.ts` (35), new auto-detection cases in `useTextChat.test.ts` (3), new support panel cases in `TextChatPanel.test.tsx` (2), plus existing tests validated against the new label strings.
+
+**First PR (#428) — C1 #405 + C4 #408:**
 - **Paired PR for C1 (#405) + C4 (#408).** `supabase/functions/text-chat/index.ts` gains a `context: 'support'` branch with a dedicated empathetic system prompt. All 5 agent tools implemented as pure-logic handlers in a new `support-tools.ts` module and wired into the edge function's tool-call loop.
 - **5 tools:** `lookup_booking` (booking_id or own-email lookup, RLS-scoped), `check_refund_status` (**DB-first with live Stripe reconcile** when the DB has a refund_reference but no processed timestamp; fails closed with a note on Stripe errors), `check_dispute_status`, `open_dispute` (validates 13 categories + min description length; enforces reporter_id via RLS), `query_support_docs` (keyword tsvector search against the `support_docs` table, status='active' only).
 - **Tool call loop generalised:** the edge function now iterates ALL tool_calls (parallel), dispatches by name (`search_properties` for rentals / any of the 5 support tools / graceful fallback for unknown), and feeds all results back in one follow-up streaming call. Rentals behaviour preserved.
@@ -119,7 +132,7 @@ gh issue create --repo rent-a-vacation/rav-website --title "..." --label "..." -
 - **New feedback memory captured:** "CS and UX as business differentiators" — user direction that when picking between cheap and robust implementations for support surfaces, bias toward the robust one even at latency/complexity cost. Drove the choice of DB+Stripe fallback over DB-only for `check_refund_status`.
 - **Tests:** 1146 → 1166 (+20). 134 → 135 files. 0 type errors, build clean (1m 5s).
 
-**End state:** Phase 22 at 17 of 22 tickets (77%). Remaining: #406, #407, #409 (Track C), #410, #411 (Track D). Next session should start with either #406 (frontend route detection — small, independent) or #409 (disputes.source enum + AdminDisputes filter — unblocks CS telemetry). PROD deploy of `text-chat` still held per CLAUDE.md — gets the support prompt + 5 tools on next deploy. `STRIPE_SECRET_KEY` env var is already set on both DEV and PROD (webhook + cancellation fns use it), so the live-Stripe reconcile path is ready on first deploy.
+**End state:** Phase 22 at 18 of 22 tickets (82%). Remaining: #407 (intent classifier + chip), #409 (disputes.source enum + AdminDisputes filter), #410 (conversation logging), #411 (admin support metrics). Recommended next pickup: **#409** — closes the escalation loop visibly in admin UI. Then #410/#411 as an observability pair. PROD deploy of `text-chat` still held per CLAUDE.md — gets the support prompt + 5 tools on next deploy. `STRIPE_SECRET_KEY` env var is already set on both DEV and PROD (webhook + cancellation fns use it), so the live-Stripe reconcile path is ready on first deploy.
 
 ---
 

--- a/docs/testing/TESTING-STATUS.md
+++ b/docs/testing/TESTING-STATUS.md
@@ -1,6 +1,6 @@
 ---
-last_updated: "2026-04-22T23:47:09"
-change_ref: "c820f23"
+last_updated: "2026-04-23T00:22:11"
+change_ref: "2ad0d63"
 change_type: "session-58"
 status: "active"
 ---
@@ -15,9 +15,9 @@ status: "active"
 
 | Metric | Value |
 |--------|-------|
-| **Total tests** | 1166 |
-| **Test files** | 135 |
-| **P0 critical-path tests** | 97 (tagged `@p0`) + 4 subscription P0s + 1 support-tool P0 |
+| **Total tests** | 1214 |
+| **Test files** | 136 |
+| **P0 critical-path tests** | 97 (tagged `@p0`) + 4 subscription P0s + 1 support-tool P0 + 35 detectChatContext P0s |
 | **E2E smoke tests** | 3 (Playwright) |
 | **Local run time** | ~2.5 min (full), ~2s (P0 only) |
 | **CI run time** | <3 min |

--- a/src/components/RavioFloatingChat.tsx
+++ b/src/components/RavioFloatingChat.tsx
@@ -1,0 +1,45 @@
+import { useState } from "react";
+import { TextChatButton } from "@/components/TextChatButton";
+import { TextChatPanel } from "@/components/TextChatPanel";
+import { useTextChat } from "@/hooks/useTextChat";
+import { cn } from "@/lib/utils";
+
+interface RavioFloatingChatProps {
+  className?: string;
+}
+
+/**
+ * Floating "Ask RAVIO" button + panel for pages that don't have a dedicated
+ * inline chat surface. Context is auto-detected from the current route
+ * (see `useTextChat` + `detectChatContext`). Drop-in with no props.
+ *
+ * Phase 22 C2 (#406). For pages that own an explicit context (PropertyDetail,
+ * Rentals, BiddingMarketplace, HowItWorksPage), keep the inline mount pattern.
+ */
+export function RavioFloatingChat({ className }: RavioFloatingChatProps) {
+  const [open, setOpen] = useState(false);
+  const { messages, status, error, sendMessage, clearHistory, context } = useTextChat();
+
+  return (
+    <>
+      <TextChatButton
+        onClick={() => setOpen(true)}
+        isOpen={open}
+        className={cn(
+          "fixed bottom-6 right-6 h-14 w-14 rounded-full shadow-lg z-40",
+          className,
+        )}
+      />
+      <TextChatPanel
+        open={open}
+        onOpenChange={setOpen}
+        messages={messages}
+        status={status}
+        error={error}
+        context={context}
+        onSendMessage={sendMessage}
+        onClearHistory={clearHistory}
+      />
+    </>
+  );
+}

--- a/src/components/TextChatPanel.test.tsx
+++ b/src/components/TextChatPanel.test.tsx
@@ -78,7 +78,18 @@ describe("TextChatPanel", () => {
 
   it("shows context badge for bidding", () => {
     renderWithProviders(<TextChatPanel {...defaultProps} context="bidding" />);
-    expect(screen.getByText("Bidding Guide")).toBeInTheDocument();
+    expect(screen.getByText("Marketplace")).toBeInTheDocument();
+  });
+
+  it("shows context badge for support", () => {
+    renderWithProviders(<TextChatPanel {...defaultProps} context="support" />);
+    expect(screen.getByText("Support")).toBeInTheDocument();
+  });
+
+  it("shows support suggested prompts", () => {
+    renderWithProviders(<TextChatPanel {...defaultProps} context="support" />);
+    expect(screen.getByText("Where's my refund?")).toBeInTheDocument();
+    expect(screen.getByText("How do I cancel my booking?")).toBeInTheDocument();
   });
 
   it("shows context badge for general", () => {

--- a/src/components/TextChatPanel.tsx
+++ b/src/components/TextChatPanel.tsx
@@ -18,7 +18,8 @@ import { cn } from "@/lib/utils";
 const CONTEXT_LABELS: Record<ChatContext, string> = {
   rentals: "Property Search",
   "property-detail": "Property Help",
-  bidding: "Bidding Guide",
+  bidding: "Marketplace",
+  support: "Support",
   general: "Platform Help",
 };
 
@@ -30,12 +31,18 @@ const SUGGESTED_PROMPTS: Record<ChatContext, string[]> = {
   ],
   "property-detail": [
     "What amenities does this have?",
-    "How does bidding work for this listing?",
+    "How do Offers work on this Listing?",
     "Are there similar properties nearby?",
   ],
   bidding: [
-    "How do I place a bid?",
-    "What is a travel request?",
+    "How do I submit an Offer?",
+    "What is a Wish?",
+  ],
+  support: [
+    "Where's my refund?",
+    "How do I cancel my booking?",
+    "I'm having a problem with my stay",
+    "How do I file a dispute?",
   ],
   general: [
     "How does Rent-A-Vacation work?",

--- a/src/hooks/useTextChat.test.ts
+++ b/src/hooks/useTextChat.test.ts
@@ -208,7 +208,7 @@ describe("useTextChat", () => {
     });
 
     await act(async () => {
-      result.current.sendMessage("How do I bid?");
+      result.current.sendMessage("How do I submit an Offer?");
     });
 
     await waitFor(() => {
@@ -220,11 +220,34 @@ describe("useTextChat", () => {
       expect.objectContaining({
         method: "POST",
         body: JSON.stringify({
-          message: "How do I bid?",
+          message: "How do I submit an Offer?",
           conversationHistory: [],
           context: "bidding",
         }),
       })
     );
+  });
+
+  describe("route-based auto-detection", () => {
+    it("falls back to support context on /my-trips when no prop supplied", () => {
+      const { result } = renderHook(() => useTextChat(), {
+        wrapper: createHookWrapper({ initialEntries: ["/my-trips"] }),
+      });
+      expect(result.current.context).toBe("support");
+    });
+
+    it("falls back to rentals context on /property/:id", () => {
+      const { result } = renderHook(() => useTextChat(), {
+        wrapper: createHookWrapper({ initialEntries: ["/property/abc-123"] }),
+      });
+      expect(result.current.context).toBe("rentals");
+    });
+
+    it("explicit context prop always wins over route detection", () => {
+      const { result } = renderHook(() => useTextChat({ context: "property-detail" }), {
+        wrapper: createHookWrapper({ initialEntries: ["/my-trips"] }),
+      });
+      expect(result.current.context).toBe("property-detail");
+    });
   });
 });

--- a/src/hooks/useTextChat.ts
+++ b/src/hooks/useTextChat.ts
@@ -1,8 +1,10 @@
-import { useState, useCallback, useRef, useEffect } from "react";
+import { useState, useCallback, useRef, useEffect, useMemo } from "react";
+import { useLocation } from "react-router-dom";
 import type { ChatMessage, ChatStatus, ChatContext } from "@/types/chat";
 import type { VoiceSearchResult } from "@/types/voice";
 import { supabase } from "@/lib/supabase";
 import { trackEvent } from "@/lib/posthog";
+import { detectChatContext } from "@/lib/chatContext";
 
 const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL as string;
 
@@ -12,10 +14,21 @@ function generateId(): string {
 }
 
 interface UseTextChatOptions {
-  context: ChatContext;
+  /**
+   * Explicit context override. Semantically-owned pages (PropertyDetail,
+   * Rentals, BiddingMarketplace) should pass their context directly.
+   * Omit to auto-detect from the current route via `detectChatContext`.
+   */
+  context?: ChatContext;
 }
 
-export function useTextChat({ context }: UseTextChatOptions) {
+export function useTextChat({ context: explicitContext }: UseTextChatOptions = {}) {
+  const location = useLocation();
+  const context = useMemo<ChatContext>(
+    () => explicitContext ?? detectChatContext(location.pathname),
+    [explicitContext, location.pathname],
+  );
+
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [status, setStatus] = useState<ChatStatus>("idle");
   const [error, setError] = useState<string | null>(null);
@@ -212,5 +225,6 @@ export function useTextChat({ context }: UseTextChatOptions) {
     error,
     sendMessage,
     clearHistory,
+    context,
   };
 }

--- a/src/lib/chatContext.test.ts
+++ b/src/lib/chatContext.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from "vitest";
+import { detectChatContext } from "./chatContext";
+
+describe("detectChatContext @p0", () => {
+  describe("support routes", () => {
+    it.each([
+      "/my-trips",
+      "/my-trips?tab=offers",
+      "/my-bookings",
+      "/account",
+      "/owner-dashboard",
+      "/owner-dashboard?tab=bookings-earnings",
+      "/settings/notifications",
+      "/disputes/abc-123",
+      "/messages",
+      "/messages/conversation-id",
+      "/notifications",
+      "/checkin",
+      "/checkout",
+      "/booking-success",
+      "/welcome",
+      "/pending-approval",
+      "/subscription-success",
+    ])("maps %s → support", (path) => {
+      expect(detectChatContext(path)).toBe("support");
+    });
+  });
+
+  describe("discovery routes", () => {
+    it.each([
+      "/rentals",
+      "/property/abc-123",
+      "/destinations",
+      "/destinations/orlando",
+      "/destinations/orlando/downtown",
+      "/tools",
+      "/tools/cost-comparator",
+      "/calculator",
+      "/rav-deals",
+    ])("maps %s → rentals", (path) => {
+      expect(detectChatContext(path)).toBe("rentals");
+    });
+  });
+
+  describe("marketplace routes", () => {
+    it.each(["/marketplace", "/marketplace?tab=wishes", "/bidding", "/bidding/old-path"])(
+      "maps %s → bidding",
+      (path) => {
+        expect(detectChatContext(path)).toBe("bidding");
+      },
+    );
+  });
+
+  describe("general fallback", () => {
+    it.each([
+      "/",
+      "/how-it-works",
+      "/faq",
+      "/contact",
+      "/user-guide",
+      "/documentation",
+      "/privacy",
+      "/terms",
+      "/developers",
+      "/api-docs",
+      "/unknown-route",
+    ])("maps %s → general", (path) => {
+      expect(detectChatContext(path)).toBe("general");
+    });
+  });
+
+  describe("edge cases", () => {
+    it("is case-insensitive", () => {
+      expect(detectChatContext("/MY-TRIPS")).toBe("support");
+      expect(detectChatContext("/Rentals")).toBe("rentals");
+    });
+
+    it("does not match partial path segments", () => {
+      // /rentals-promo is NOT /rentals; should fall through to general
+      expect(detectChatContext("/rentals-promo")).toBe("general");
+      // /accountant is NOT /account
+      expect(detectChatContext("/accountant")).toBe("general");
+    });
+  });
+});

--- a/src/lib/chatContext.ts
+++ b/src/lib/chatContext.ts
@@ -1,0 +1,58 @@
+import type { ChatContext } from "@/types/chat";
+
+// Route prefixes that map to each RAVIO chat context when no explicit context
+// is supplied by the caller. Order: check longer prefixes first via the
+// function below; this list is for readability only.
+//
+// Phase 22 C2 (#406) — DEC-036. Anticipates user flow per memory rule
+// "Rooted in Simplicity": users who are mid-account/booking ask support
+// questions; users browsing ask discovery questions.
+
+const SUPPORT_PREFIXES = [
+  "/my-trips",
+  "/my-bookings",
+  "/my-bids",
+  "/account",
+  "/owner-dashboard",
+  "/settings",
+  "/disputes",
+  "/messages",
+  "/notifications",
+  "/checkin",
+  "/checkout",
+  "/booking-success",
+  "/welcome",
+  "/pending-approval",
+  "/subscription-success",
+];
+
+const RENTALS_PREFIXES = [
+  "/rentals",
+  "/property",
+  "/destinations",
+  "/tools",
+  "/calculator",
+  "/rav-deals",
+];
+
+const BIDDING_PREFIXES = ["/marketplace", "/bidding"];
+
+function hasPrefix(pathname: string, prefixes: string[]): boolean {
+  const normalised = pathname.toLowerCase();
+  return prefixes.some(
+    (p) => normalised === p || normalised.startsWith(p + "/") || normalised.startsWith(p + "?"),
+  );
+}
+
+/**
+ * Derive the default RAVIO chat context for a given route pathname.
+ * Callers with semantically-owned contexts (e.g. PropertyDetail explicitly
+ * wants "property-detail") should continue to pass their context prop;
+ * this utility is the fallback for pages that don't care to specify.
+ */
+export function detectChatContext(pathname: string): ChatContext {
+  if (hasPrefix(pathname, SUPPORT_PREFIXES)) return "support";
+  if (hasPrefix(pathname, BIDDING_PREFIXES)) return "bidding";
+  if (hasPrefix(pathname, RENTALS_PREFIXES)) return "rentals";
+  return "general";
+}

--- a/src/pages/AccountSettings.tsx
+++ b/src/pages/AccountSettings.tsx
@@ -29,6 +29,7 @@ import { User, Mail, Phone, Lock, Shield, Calendar, Save, Loader2, Bell, Downloa
 import { SubscriptionManagement } from "@/components/SubscriptionManagement";
 import { MembershipPlans } from "@/components/MembershipPlans";
 import { Textarea } from "@/components/ui/textarea";
+import { RavioFloatingChat } from "@/components/RavioFloatingChat";
 
 const AccountSettings = () => {
   usePageMeta("Account Settings", "Manage your Rent-A-Vacation account profile, security, and preferences.");
@@ -701,6 +702,7 @@ const AccountSettings = () => {
       </main>
 
       <Footer />
+      <RavioFloatingChat />
     </div>
   );
 };

--- a/src/pages/OwnerDashboard.tsx
+++ b/src/pages/OwnerDashboard.tsx
@@ -53,6 +53,7 @@ import { SubscriptionManagement } from "@/components/SubscriptionManagement";
 import { ReferralDashboard } from "@/components/owner/ReferralDashboard";
 import { OwnerTaxInfo } from "@/components/owner/OwnerTaxInfo";
 import { useOwnerCommission } from "@/hooks/useOwnerCommission";
+import { RavioFloatingChat } from "@/components/RavioFloatingChat";
 import { useOwnerDashboardStats } from "@/hooks/owner/useOwnerDashboardStats";
 import { useOwnerEarnings } from "@/hooks/owner/useOwnerEarnings";
 import { useOwnerListingsData } from "@/hooks/owner/useOwnerListingsData";
@@ -749,6 +750,7 @@ const OwnerDashboard = () => {
           </TabsContent>
         </Tabs>
       </main>
+      <RavioFloatingChat />
     </div>
   );
 };

--- a/src/pages/RenterDashboard.tsx
+++ b/src/pages/RenterDashboard.tsx
@@ -26,6 +26,7 @@ import { useMyMembership } from '@/hooks/useMembership';
 import { canAccessConcierge } from '@/lib/tierGating';
 import { ConciergeRequestDialog } from '@/components/concierge/ConciergeRequestDialog';
 import { ConciergeRequestList } from '@/components/concierge/ConciergeRequestList';
+import { RavioFloatingChat } from '@/components/RavioFloatingChat';
 
 // Lazy-load heavy sub-pages
 const MyBookings = lazy(() => import('./MyBookings'));
@@ -340,6 +341,7 @@ const RenterDashboard = () => {
       </div>
 
       <Footer />
+      <RavioFloatingChat />
     </div>
   );
 };

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -10,4 +10,4 @@ export interface ChatMessage {
 
 export type ChatStatus = "idle" | "sending" | "streaming" | "error";
 
-export type ChatContext = "rentals" | "property-detail" | "bidding" | "general";
+export type ChatContext = "rentals" | "property-detail" | "bidding" | "support" | "general";


### PR DESCRIPTION
## Summary

Phase 22 **C2 (#406)**. Auto-switches RAVIO to the support context on account/booking/dashboard routes per DEC-036 [Rooted in Simplicity] — no explicit toggle. Builds on PR #428 (C1 + C4) which shipped earlier this session.

## What this adds

- **`src/lib/chatContext.ts`** — `detectChatContext(pathname)` maps route prefixes → `ChatContext`:
  - `support`: /my-trips, /my-bookings, /account, /owner-dashboard, /settings/*, /disputes/*, /messages, /notifications, /checkout, /booking-success, /welcome, /pending-approval, /subscription-success, /checkin
  - `rentals`: /rentals, /property/*, /destinations/*, /tools/*, /calculator, /rav-deals
  - `bidding`: /marketplace, /bidding*
  - `general`: everything else
  - Case-insensitive; does not match partial segments (/rentals-promo ≠ /rentals).
- **`useTextChat`** — `context` is now optional; falls back to `useLocation()` + the detector. Explicit context (PropertyDetail, Rentals, BiddingMarketplace, HowItWorksPage) always wins. The existing "clear history on context switch" effect covers route-driven transitions automatically.
- **`ChatContext` union** — extended with `'support'`.
- **`<RavioFloatingChat />`** — new single-element helper: floating bottom-right button + panel with zero props. Mounted on `/my-trips`, `/owner-dashboard`, `/account` so the support context is actually exercised end-to-end.

## Terminology cleanup (inline, in-file only)

Four pre-existing DEC-031 drift strings in `TextChatPanel` fixed while adding the support prompts:
- `"Bidding Guide"` → `"Marketplace"`
- Prompt `"How do I place a bid?"` → `"How do I submit an Offer?"`
- Prompt `"What is a travel request?"` → `"What is a Wish?"`
- Prompt `"How does bidding work for this listing?"` → `"How do Offers work on this Listing?"`

Support-context suggested prompts use locked vocabulary only (refund / booking / dispute / stay) — no new brand terms introduced.

**Broader wish/bid/travel-request cleanup across ~30 other files (UserGuide, Documentation, MyBidsDashboard, hooks, etc.) deliberately NOT included** — that's a standalone terminology-audit PR.

## What this does NOT include

- #407 C3 — intent classifier + "Switched to Support" chip (fallback for ambiguous routes)
- #409 C5 — `source: 'ravio_support'` enum on disputes + AdminDisputes filter
- #410/#411 Track D — conversation logging + admin metrics
- Global RAVIO mount across ALL routes (single header-level instance) — bigger refactor, separate decision.

## Tests

- **+48 tests** (1166 → 1214). 136 test files.
- `src/lib/chatContext.test.ts` — 35 cases covering every documented route + case-insensitivity + partial-segment edge cases.
- `src/hooks/useTextChat.test.ts` — 3 new cases: auto-detect on /my-trips, auto-detect on /property/:id, explicit prop overrides route.
- `src/components/TextChatPanel.test.tsx` — 2 new cases: support badge, support prompts.

## Test plan

- [ ] `npm run test` passes (1214/1214)
- [ ] `npm run build` passes
- [ ] `npx tsc --noEmit` clean
- [ ] Manual smoke post-deploy: navigate to /my-trips → click floating RAVIO button → verify "Support" badge + support prompts. Navigate to /rentals from same session → verify context switches and chat history clears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)