### PR TITLE
feat(support-agent): Phase 22 C3 — intent classifier + 'Switched to Support' chip (#407)

### DIFF
--- a/docs/PRIORITY-ROADMAP.md
+++ b/docs/PRIORITY-ROADMAP.md
@@ -1,6 +1,6 @@
 ---
-last_updated: "2026-04-23T00:43:36"
-change_ref: "83217fa"
+last_updated: "2026-04-23T01:32:26"
+change_ref: "9fc5af7"
 change_type: "session-58"
 status: "active"
 ---
@@ -45,8 +45,7 @@ All unblocked follow-ups from Sessions 54-58. Pick in any order; they're indepen
 
 | Issue | Title | Est. | Why now |
 |-------|-------|------|---------|
-| **#407** | Phase 22 C3: Intent classifier + "Switched to Support" chip | 4-6h | Unblocked by Session 58 (#406 shipped). Fallback for ambiguous routes. Keyword classifier + model fallback. Chip UI + session override. Last remaining Track C ticket. |
-| **#410** | Phase 22 D1: Support conversation logging | 6-8h | Unblocked by Session 58. Extend `conversations` table so support turns are captured for metrics + replay. |
+| **#410** | Phase 22 D1: Support conversation logging | 6-8h | Track C complete — Track D next. Extend `conversations` table so support turns are captured for metrics + replay. |
 | **#411** | Phase 22 D2: Admin "Support Interactions" tab + metrics | 1d | Depends on #410. Deflection rate, escalation rate, SLA. |
 | **#376** | Pre-Booked listing verification (resort reservation proof) | 1-2d | Unblocked by DEC-034 — proof-collection UX only meaningful after the flow distinction exists (which it now does). New schema fields + admin verify dialog + email templates. |
 | **#378** | "Open for Bidding" indicator everywhere (create-time toggle + consistent badge) | 3-4h | Unblocked by DEC-034 — integrates with the ListingTypeBadge visual system. |
@@ -55,7 +54,7 @@ All unblocked follow-ups from Sessions 54-58. Pick in any order; they're indepen
 | **#371** | Edge function test harness | 1-2d (needs scoping) | Tech-debt follow-up from Tests-With-Features shortfalls. Enables future edge-fn work to be properly tested. |
 | **#393** | PLATFORM-INVENTORY.md — one-page mental model of everything built | 2-3h | Session 56 meta-ask: a single doc cataloging product + platform + dev-tooling + governance layers so the user can explain what they've built to investors, new collaborators, and future sessions. |
 
-> **Phase 22 epic (#395)** — Tracks A, B, E complete in Session 57; C1 + C4 + C2 + C5 (#405 + #408 + #406 + #409) shipped in Session 58 (3 PRs). Remaining: **#407** (last Track C ticket) + #410, #411 (Track D observability). Recommended next: **#407** (closes Track C entirely, then Track D lands as a focused observability pair).
+> **Phase 22 epic (#395)** — Tracks A, B, C, E all complete. C1+C4+C2+C5+C3 (#405+#408+#406+#409+#407) shipped in Session 58 (4 PRs). Remaining: Track D observability only — #410 conversation logging, then #411 admin Support Interactions tab + metrics.
 
 ### Tier B: Pre-Launch Important (Needs Human Input)
 
@@ -134,7 +133,7 @@ These unblock when the LLC is formed. Not code-dependent.
 
 | Date | Session | Changes |
 |------|---------|---------|
-| Apr 22, 2026 | 58 | **Phase 22 C1 + C4 + C2 + C5 SHIPPED** across 3 PRs. PR #428 (C1+C4): `text-chat` gains `context:'support'` + 5 agent tools; DB-first with live Stripe reconcile. PR #429 (C2): `detectChatContext(pathname)` + `useTextChat` auto-detect + `<RavioFloatingChat />` on /my-trips, /owner-dashboard, /account. PR #430 (C5): Migration 061 `dispute_source` enum + column; `openDispute` tool tags escalations `source='ravio_support'`; AdminDisputes gains source filter + "via RAVIO" badges. 69 new unit tests total this session. Phase 22 now 86% complete (19 of 22). Remaining Tier A: #407, #410, #411. |
+| Apr 22, 2026 | 58 | **Phase 22 Track C COMPLETE** — 4 PRs across the session. PR #428 (C1+C4): text-chat `context:'support'` + 5 agent tools; DB-first with live Stripe reconcile. PR #429 (C2): `detectChatContext(pathname)` + `useTextChat` auto-detect + `<RavioFloatingChat />` on /my-trips, /owner-dashboard, /account. PR #430 (C5): Migration 061 `dispute_source` enum; `openDispute` tags `source='ravio_support'`; AdminDisputes source filter + "via RAVIO" badges. PR #431 (C3): `intent-classifier.ts` (keyword-first + model fallback) + SSE `classified_context` event + "Switched to X — back" chip in TextChatPanel with session-scoped dismissal. 103 new tests total this session. Phase 22 now 91% complete (20 of 22). Remaining Tier A: #410, #411 (Track D observability). |
 | Apr 21, 2026 | 57 | **Phase 22 SHIPPED Tracks A + B + E (15 of 22 tickets, 8 PRs #418-#425).** Full documentation infrastructure end-to-end on DEV: 22 markdown files in `docs/support/`, migration 060 (support_docs), `ingest-support-docs` edge fn + GitHub Action, `docs-sync-check` extension, 6 legal-blocked drafts at status:draft pending #80. Issues closed: #396-#404, #412-#417. Remaining: Track C (#405-#409 RAVIO agent code) + Track D (#410, #411 observability) — next session. PROD deploys held per CLAUDE.md. |
 | Apr 20, 2026 | 57 (planning) | Phase 22 Customer Support Foundation SCOPED. Milestone #37 + epic #395 + 22 child issues #396-#417. DEC-036 logged: reject CrewAI, extend RAVIO text chat with `context: 'support'` + tool use; voice stays discovery-only. 20 support docs planned. Markdown canonical → Supabase `support_docs` sync. PR #418. |
 | Apr 20, 2026 | 56 | **DEC-034 Marketplace Flow Distinction SHIPPED end-to-end (#380 CLOSED)** via 5 incremental PRs (#385-#389). Migrations 058 + 059. `listing_source_type` enum + `ListingTypeBadge` everywhere. Critical search-filter fix. 3 new notification types. `/sdlc` doc-update checklist promoted to root `CLAUDE.md` (PR #390) so it applies to every session. 1146 tests. Issues unblocked: #376, #378, #381. |

--- a/docs/PROJECT-HUB.md
+++ b/docs/PROJECT-HUB.md
@@ -1,6 +1,6 @@
 ---
-last_updated: "2026-04-23T00:43:36"
-change_ref: "83217fa"
+last_updated: "2026-04-23T01:32:26"
+change_ref: "9fc5af7"
 change_type: "session-58"
 status: "active"
 ---
@@ -93,8 +93,8 @@ gh issue create --repo rent-a-vacation/rav-website --title "..." --label "..." -
 - Edge functions require `--no-verify-jwt` deployment flag
 
 ### Platform Status
-- **1215 automated tests** (136 test files, all passing), 0 type errors, 0 lint errors, build clean
-- **P0 tests:** 97 critical-path tests tagged `@p0` + 4 subscription P0s + 6 ListingTypeBadge P0s + 1 support-tool P0 + 35 detectChatContext P0s — run with `npm run test:p0`
+- **1249 automated tests** (137 test files, all passing), 0 type errors, 0 lint errors, build clean
+- **P0 tests:** 97 critical-path tests tagged `@p0` + 4 subscription P0s + 6 ListingTypeBadge P0s + 1 support-tool P0 + 35 detectChatContext P0s + 17 intent-classifier P0s — run with `npm run test:p0`
 - **CI reporting:** GitHub native via dorny/test-reporter (JUnit XML) — PR annotations on every run (Qase removed Mar 2026)
 - **Migrations created:** 001-061 (001-059 deployed to DEV + PROD; 060 + 061 deployed to DEV only — PROD held per CLAUDE.md) + 3 date-based MDM migrations
 - **Edge functions:** 35 total (27 deployed to PROD + 4 subscription functions on DEV + 3 SMS functions pending LLC/EIN + `ingest-support-docs` deployed to DEV only). `text-chat` gains a `context: 'support'` branch with 5 agent tools (Session 58, Phase 22 C1 + C4).
@@ -108,7 +108,16 @@ gh issue create --repo rent-a-vacation/rav-website --title "..." --label "..." -
 
 ### Session Handoff (Sessions 25-58)
 
-**Session 58 — Phase 22 Track C: support agent + route detection + agent-dispute source tagging (#405 + #408 + #406 + #409, Apr 22, 2026):**
+**Session 58 — Phase 22 Track C: support agent + route detection + agent-dispute tagging + intent classifier — Track C COMPLETE (#405 + #408 + #406 + #409 + #407, Apr 22, 2026):**
+
+**Fourth PR (#431) — C3 #407 intent classifier + "Switched to Support" chip:**
+- New `supabase/functions/text-chat/intent-classifier.ts` — keyword-first classifier with OpenRouter model fallback. Returns `'support'` / `'rentals'` / `null`. 20 unit tests (keyword coverage, model fallback, fail-closed on HTTP/network errors, payload truncation, keyword-short-circuit behavior).
+- Edge fn integration — classifier fires only when `context === 'general'` AND first message AND frontend hasn't dismissed. Emits new SSE event `classified_context` before tokens; uses resolved context for system prompt + tool selection for that turn.
+- `useTextChat` parses the new SSE event → state `classifiedContext`; `dismissClassification()` handler flips session-scoped `classifierDismissedRef` which forces `disableClassifier: true` on future sends (survives history clear within session; resets on route change). PostHog events: `text_chat_classified`, `text_chat_classification_reverted`.
+- `TextChatPanel` renders a subtle chip above messages when `classifiedContext !== context`: "Switched to **{context label}** — back to general help". Click dismisses. Chip reuses existing `CONTEXT_LABELS` — no new brand strings.
+- `RavioFloatingChat` passes the new state + handler through.
+- **Tests:** 1215 → 1249 (+34). intent-classifier.test.ts (20), useTextChat classifier cases (3), TextChatPanel chip cases (2), plus auto-update of one existing test for new `disableClassifier` body field.
+- **Phase 22 Track C COMPLETE.** Only Track D observability (#410 + #411) remains.
 
 **Third PR (#430) — C5 #409 agent-opened dispute source tagging:**
 - Migration 061 — new `dispute_source` enum (`user_filed`, `ravio_support`) + `source` column on `disputes` with default `'user_filed'` + index. All existing rows keep `user_filed` implicitly; no data migration needed.
@@ -140,7 +149,7 @@ gh issue create --repo rent-a-vacation/rav-website --title "..." --label "..." -
 - **New feedback memory captured:** "CS and UX as business differentiators" — user direction that when picking between cheap and robust implementations for support surfaces, bias toward the robust one even at latency/complexity cost. Drove the choice of DB+Stripe fallback over DB-only for `check_refund_status`.
 - **Tests:** 1146 → 1166 (+20). 134 → 135 files. 0 type errors, build clean (1m 5s).
 
-**End state:** Phase 22 at 19 of 22 tickets (86%). Remaining: **#407** (intent classifier + "Switched to Support" chip), **#410** (support conversation logging), **#411** (admin Support Interactions tab + metrics). Recommended next: #407 (closes Track C entirely); then #410 → #411 as the observability pair. PROD deploy of `text-chat` + migrations 060 + 061 still held per CLAUDE.md. `STRIPE_SECRET_KEY` already set on both DEV and PROD so the live-Stripe reconcile path in `check_refund_status` works day-one.
+**End state:** Phase 22 at **20 of 22 tickets (91%) — Track C COMPLETE**. Remaining: **#410** (support conversation logging), **#411** (admin Support Interactions tab + metrics). Recommended next: #410 → #411 as a focused observability pair. PROD deploy of `text-chat` + migrations 060 + 061 still held per CLAUDE.md. `STRIPE_SECRET_KEY` already set on both DEV and PROD.
 
 ---
 

--- a/docs/testing/TESTING-STATUS.md
+++ b/docs/testing/TESTING-STATUS.md
@@ -1,6 +1,6 @@
 ---
-last_updated: "2026-04-23T00:43:36"
-change_ref: "83217fa"
+last_updated: "2026-04-23T01:32:26"
+change_ref: "9fc5af7"
 change_type: "session-58"
 status: "active"
 ---
@@ -15,9 +15,9 @@ status: "active"
 
 | Metric | Value |
 |--------|-------|
-| **Total tests** | 1215 |
-| **Test files** | 136 |
-| **P0 critical-path tests** | 97 (tagged `@p0`) + 4 subscription P0s + 1 support-tool P0 + 35 detectChatContext P0s |
+| **Total tests** | 1249 |
+| **Test files** | 137 |
+| **P0 critical-path tests** | 97 (tagged `@p0`) + 4 subscription P0s + 1 support-tool P0 + 35 detectChatContext P0s + 17 intent-classifier P0s |
 | **E2E smoke tests** | 3 (Playwright) |
 | **Local run time** | ~2.5 min (full), ~2s (P0 only) |
 | **CI run time** | <3 min |

--- a/src/components/RavioFloatingChat.tsx
+++ b/src/components/RavioFloatingChat.tsx
@@ -18,7 +18,16 @@ interface RavioFloatingChatProps {
  */
 export function RavioFloatingChat({ className }: RavioFloatingChatProps) {
   const [open, setOpen] = useState(false);
-  const { messages, status, error, sendMessage, clearHistory, context } = useTextChat();
+  const {
+    messages,
+    status,
+    error,
+    sendMessage,
+    clearHistory,
+    context,
+    classifiedContext,
+    dismissClassification,
+  } = useTextChat();
 
   return (
     <>
@@ -39,6 +48,8 @@ export function RavioFloatingChat({ className }: RavioFloatingChatProps) {
         context={context}
         onSendMessage={sendMessage}
         onClearHistory={clearHistory}
+        classifiedContext={classifiedContext}
+        onDismissClassification={dismissClassification}
       />
     </>
   );

--- a/src/components/TextChatPanel.test.tsx
+++ b/src/components/TextChatPanel.test.tsx
@@ -92,6 +92,38 @@ describe("TextChatPanel", () => {
     expect(screen.getByText("How do I cancel my booking?")).toBeInTheDocument();
   });
 
+  it("renders classifier chip when classifiedContext differs from context (#407)", () => {
+    const onDismiss = vi.fn();
+    renderWithProviders(
+      <TextChatPanel
+        {...defaultProps}
+        context="general"
+        classifiedContext="support"
+        onDismissClassification={onDismiss}
+      />
+    );
+    const chip = screen.getByRole("button", {
+      name: /dismiss support context/i,
+    });
+    expect(chip).toBeInTheDocument();
+    fireEvent.click(chip);
+    expect(onDismiss).toHaveBeenCalled();
+  });
+
+  it("does NOT render chip when classifiedContext matches context", () => {
+    renderWithProviders(
+      <TextChatPanel
+        {...defaultProps}
+        context="support"
+        classifiedContext="support"
+        onDismissClassification={vi.fn()}
+      />
+    );
+    expect(
+      screen.queryByRole("button", { name: /dismiss support context/i })
+    ).not.toBeInTheDocument();
+  });
+
   it("shows context badge for general", () => {
     renderWithProviders(<TextChatPanel {...defaultProps} context="general" />);
     expect(screen.getByText("Platform Help")).toBeInTheDocument();

--- a/src/components/TextChatPanel.tsx
+++ b/src/components/TextChatPanel.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useEffect } from "react";
 import { Link } from "react-router-dom";
-import { Send, X, Trash2, MapPin, Users, AlertCircle } from "lucide-react";
+import { Send, X, Trash2, MapPin, Users, AlertCircle, ArrowLeftCircle } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
@@ -59,6 +59,12 @@ interface TextChatPanelProps {
   context: ChatContext;
   onSendMessage: (text: string) => void;
   onClearHistory: () => void;
+  /** Phase 22 C3 (#407) — server-classified context; when set and different
+   *  from `context`, renders the "Switched to X — [back]" chip. */
+  classifiedContext?: ChatContext | null;
+  /** Dismisses the classifier chip and tells the hook to suppress future
+   *  classifications for this session. */
+  onDismissClassification?: () => void;
 }
 
 function TypingIndicator() {
@@ -111,6 +117,8 @@ export function TextChatPanel({
   context,
   onSendMessage,
   onClearHistory,
+  classifiedContext,
+  onDismissClassification,
 }: TextChatPanelProps) {
   const [input, setInput] = useState("");
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -183,6 +191,24 @@ export function TextChatPanel({
             </div>
           </div>
         </SheetHeader>
+
+        {/* Classifier chip — only when server swapped the context on an
+            ambiguous route. Keeps the swap discoverable and reversible. */}
+        {classifiedContext && classifiedContext !== context && onDismissClassification && (
+          <div className="px-4 py-2 border-b bg-muted/30 shrink-0">
+            <button
+              type="button"
+              onClick={onDismissClassification}
+              className="flex items-center gap-2 text-xs text-muted-foreground hover:text-foreground transition-colors"
+              aria-label={`Dismiss ${CONTEXT_LABELS[classifiedContext]} context and go back to general help`}
+            >
+              <ArrowLeftCircle className="h-3.5 w-3.5" />
+              <span>
+                Switched to <strong className="text-foreground">{CONTEXT_LABELS[classifiedContext]}</strong> — back to general help
+              </span>
+            </button>
+          </div>
+        )}
 
         {/* Messages */}
         <ScrollArea className="flex-1 px-4" ref={scrollRef}>

--- a/src/hooks/useTextChat.test.ts
+++ b/src/hooks/useTextChat.test.ts
@@ -16,8 +16,15 @@ vi.mock("@/lib/supabase", () => ({
 // Must import after mock
 const { useTextChat } = await import("./useTextChat");
 
-function createMockSSEResponse(tokens: string[], searchResults?: unknown[]) {
+function createMockSSEResponse(
+  tokens: string[],
+  searchResults?: unknown[],
+  classifiedContext?: "support" | "rentals",
+) {
   let sseData = "";
+  if (classifiedContext) {
+    sseData += `event: classified_context\ndata: ${JSON.stringify({ classified: classifiedContext })}\n\n`;
+  }
   if (searchResults) {
     sseData += `event: search_results\ndata: ${JSON.stringify(searchResults)}\n\n`;
   }
@@ -223,6 +230,7 @@ describe("useTextChat", () => {
           message: "How do I submit an Offer?",
           conversationHistory: [],
           context: "bidding",
+          disableClassifier: false,
         }),
       })
     );
@@ -248,6 +256,70 @@ describe("useTextChat", () => {
         wrapper: createHookWrapper({ initialEntries: ["/my-trips"] }),
       });
       expect(result.current.context).toBe("property-detail");
+    });
+  });
+
+  describe("intent classifier (#407)", () => {
+    it("captures classified_context from SSE stream", async () => {
+      vi.mocked(fetch).mockResolvedValueOnce(
+        createMockSSEResponse(["ok"], undefined, "support")
+      );
+      const { result } = renderHook(() => useTextChat({ context: "general" }), {
+        wrapper: createHookWrapper(),
+      });
+
+      expect(result.current.classifiedContext).toBeNull();
+
+      await act(async () => {
+        result.current.sendMessage("Where is my refund?");
+      });
+      await waitFor(() => {
+        expect(result.current.status).toBe("idle");
+      });
+
+      expect(result.current.classifiedContext).toBe("support");
+    });
+
+    it("starts with no classification and stays null when server doesn't emit", async () => {
+      vi.mocked(fetch).mockResolvedValueOnce(createMockSSEResponse(["hi"]));
+      const { result } = renderHook(() => useTextChat({ context: "general" }), {
+        wrapper: createHookWrapper(),
+      });
+
+      await act(async () => {
+        result.current.sendMessage("hello");
+      });
+      await waitFor(() => expect(result.current.status).toBe("idle"));
+
+      expect(result.current.classifiedContext).toBeNull();
+    });
+
+    it("dismissClassification clears the chip and sets disableClassifier on next send", async () => {
+      vi.mocked(fetch)
+        .mockResolvedValueOnce(createMockSSEResponse(["r1"], undefined, "support"))
+        .mockResolvedValueOnce(createMockSSEResponse(["r2"]));
+
+      const { result } = renderHook(() => useTextChat({ context: "general" }), {
+        wrapper: createHookWrapper(),
+      });
+
+      await act(async () => {
+        result.current.sendMessage("where's my refund");
+      });
+      await waitFor(() => expect(result.current.status).toBe("idle"));
+      expect(result.current.classifiedContext).toBe("support");
+
+      act(() => result.current.dismissClassification());
+      expect(result.current.classifiedContext).toBeNull();
+
+      await act(async () => {
+        result.current.sendMessage("just saying hi");
+      });
+      await waitFor(() => expect(result.current.status).toBe("idle"));
+
+      const secondCall = vi.mocked(fetch).mock.calls[1];
+      const body = JSON.parse((secondCall[1] as RequestInit).body as string);
+      expect(body.disableClassifier).toBe(true);
     });
   });
 });

--- a/src/hooks/useTextChat.ts
+++ b/src/hooks/useTextChat.ts
@@ -33,8 +33,18 @@ export function useTextChat({ context: explicitContext }: UseTextChatOptions = {
   const [status, setStatus] = useState<ChatStatus>("idle");
   const [error, setError] = useState<string | null>(null);
 
+  // Intent classifier (Phase 22 C3 / #407) — server may swap the context
+  // on ambiguous first messages (context='general'). Stored separately from
+  // the route/explicit context so the chip can show the delta.
+  const [classifiedContext, setClassifiedContext] = useState<ChatContext | null>(null);
+
   const abortControllerRef = useRef<AbortController | null>(null);
   const contextRef = useRef(context);
+  // Session-scoped override — true once the user has dismissed the classifier
+  // chip. While active, subsequent sends tell the server to skip the classifier
+  // even if history is cleared (so a cleared-and-re-asked ambiguous message
+  // doesn't re-trigger the chip the user already rejected).
+  const classifierDismissedRef = useRef(false);
 
   // Clear conversation when context changes
   useEffect(() => {
@@ -43,6 +53,8 @@ export function useTextChat({ context: explicitContext }: UseTextChatOptions = {
       setMessages([]);
       setStatus("idle");
       setError(null);
+      setClassifiedContext(null);
+      classifierDismissedRef.current = false;
       abortControllerRef.current?.abort();
     }
   }, [context]);
@@ -101,6 +113,7 @@ export function useTextChat({ context: explicitContext }: UseTextChatOptions = {
             message: trimmed,
             conversationHistory,
             context: contextRef.current,
+            disableClassifier: classifierDismissedRef.current,
           }),
           signal: abortControllerRef.current.signal,
         },
@@ -167,6 +180,23 @@ export function useTextChat({ context: explicitContext }: UseTextChatOptions = {
             continue;
           }
 
+          if (currentEvent === "classified_context") {
+            try {
+              const payload = JSON.parse(data) as { classified?: ChatContext };
+              if (payload.classified) {
+                setClassifiedContext(payload.classified);
+                trackEvent("text_chat_classified", {
+                  route_context: contextRef.current,
+                  classified: payload.classified,
+                });
+              }
+            } catch {
+              // Skip malformed classifier payload
+            }
+            currentEvent = "";
+            continue;
+          }
+
           if (currentEvent === "done" || data === "[DONE]") {
             currentEvent = "";
             continue;
@@ -217,6 +247,19 @@ export function useTextChat({ context: explicitContext }: UseTextChatOptions = {
     setMessages([]);
     setStatus("idle");
     setError(null);
+    setClassifiedContext(null);
+    // Clearing history does NOT reset the dismissal — if the user already
+    // said "no I don't want support," we respect that across history clears
+    // within the same session. A route change (contextRef effect above)
+    // fully resets both.
+  }, []);
+
+  const dismissClassification = useCallback(() => {
+    setClassifiedContext(null);
+    classifierDismissedRef.current = true;
+    trackEvent("text_chat_classification_reverted", {
+      route_context: contextRef.current,
+    });
   }, []);
 
   return {
@@ -226,5 +269,7 @@ export function useTextChat({ context: explicitContext }: UseTextChatOptions = {
     sendMessage,
     clearHistory,
     context,
+    classifiedContext,
+    dismissClassification,
   };
 }

--- a/supabase/functions/text-chat/index.ts
+++ b/supabase/functions/text-chat/index.ts
@@ -12,6 +12,7 @@ import {
   type SupabaseLike,
   type UserContext,
 } from "./support-tools.ts";
+import { classifyIntent, type ClassifiedContext } from "./intent-classifier.ts";
 
 // --- CORS: Same allowlist pattern as voice-search ---
 function isAllowedOrigin(origin: string): boolean {
@@ -168,6 +169,10 @@ interface TextChatRequest {
   message: string;
   conversationHistory: ChatMessage[];
   context: string;
+  /** Session-scoped flag set by the frontend once the user dismisses the
+   *  classifier chip — tells the edge fn to skip the classifier even if
+   *  history is empty. See useTextChat.dismissClassification. */
+  disableClassifier?: boolean;
 }
 
 // OpenRouter model — Gemini 3 Flash: fast, cheap ($0.50/M tokens), supports tool calling
@@ -235,7 +240,7 @@ serve(async (req) => {
     }
 
     // Parse request
-    const { message, conversationHistory, context }: TextChatRequest = await req.json();
+    const { message, conversationHistory, context, disableClassifier }: TextChatRequest = await req.json();
     if (!message?.trim()) {
       return new Response(
         JSON.stringify({ error: "Message is required" }),
@@ -243,8 +248,26 @@ serve(async (req) => {
       );
     }
 
-    const systemPrompt = SYSTEM_PROMPTS[context] || SYSTEM_PROMPTS.general;
-    logStep("Context selected", { context, messageLength: message.length });
+    // Intent classification — fires only on ambiguous first messages AND
+    // when the frontend hasn't flagged a session-scoped override (see
+    // useTextChat.dismissClassification). See intent-classifier.ts.
+    let classifiedContext: ClassifiedContext | null = null;
+    let effectiveContext = context;
+    const isFirstMessage = !conversationHistory || conversationHistory.length === 0;
+    if (context === "general" && isFirstMessage && !disableClassifier) {
+      classifiedContext = await classifyIntent(message, Deno.env.get("OPENROUTER_API_KEY") ?? null);
+      if (classifiedContext) {
+        effectiveContext = classifiedContext;
+        logStep("Intent classifier swapped context", {
+          from: context,
+          to: classifiedContext,
+          userId: user.id,
+        });
+      }
+    }
+
+    const systemPrompt = SYSTEM_PROMPTS[effectiveContext] || SYSTEM_PROMPTS.general;
+    logStep("Context selected", { context: effectiveContext, messageLength: message.length });
 
     // Build messages array for OpenRouter
     const messages: ChatMessage[] = [
@@ -264,11 +287,15 @@ serve(async (req) => {
 
     // Determine which tools this context exposes to the model
     let tools: unknown[] | undefined;
-    if (context === "rentals") tools = [SEARCH_TOOL];
-    else if (context === "support") tools = SUPPORT_TOOL_SCHEMAS;
+    if (effectiveContext === "rentals") tools = [SEARCH_TOOL];
+    else if (effectiveContext === "support") tools = SUPPORT_TOOL_SCHEMAS;
 
     // First OpenRouter call (may trigger tool call)
-    logStep("Calling OpenRouter", { model: OPENROUTER_MODEL, toolsEnabled: !!tools, context });
+    logStep("Calling OpenRouter", {
+      model: OPENROUTER_MODEL,
+      toolsEnabled: !!tools,
+      context: effectiveContext,
+    });
     let openRouterResponse = await fetch("https://openrouter.ai/api/v1/chat/completions", {
       method: "POST",
       headers: {
@@ -423,7 +450,7 @@ serve(async (req) => {
         );
       }
 
-      return streamSSEResponse(openRouterResponse, corsHeaders, searchResults);
+      return streamSSEResponse(openRouterResponse, corsHeaders, searchResults, classifiedContext);
     }
 
     // No tool call — check if we already have content, otherwise stream
@@ -455,7 +482,7 @@ serve(async (req) => {
       }
     }
 
-    return streamSSEResponse(openRouterResponse, corsHeaders, searchResults);
+    return streamSSEResponse(openRouterResponse, corsHeaders, searchResults, classifiedContext);
 
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
@@ -470,17 +497,28 @@ serve(async (req) => {
 
 /**
  * Transforms an OpenRouter streaming response into SSE events for the client.
- * Sends search results as a separate event before the text stream.
+ * Sends search results + classified-context events before the text stream.
  */
 function streamSSEResponse(
   openRouterResponse: Response,
   corsHeaders: Record<string, string>,
   searchResults?: SearchResult[],
+  classifiedContext?: ClassifiedContext | null,
 ): Response {
   const encoder = new TextEncoder();
 
   const readable = new ReadableStream({
     async start(controller) {
+      // Intent classifier result — emit first so the client can update the
+      // chip before any tokens arrive.
+      if (classifiedContext) {
+        controller.enqueue(
+          encoder.encode(
+            `event: classified_context\ndata: ${JSON.stringify({ classified: classifiedContext })}\n\n`,
+          ),
+        );
+      }
+
       // Send search results as a separate SSE event if present
       if (searchResults && searchResults.length > 0) {
         controller.enqueue(

--- a/supabase/functions/text-chat/intent-classifier.test.ts
+++ b/supabase/functions/text-chat/intent-classifier.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  classifyByKeywords,
+  classifyByModel,
+  classifyIntent,
+} from "./intent-classifier";
+
+describe("classifyByKeywords @p0", () => {
+  it.each([
+    "Where's my refund?",
+    "I need to cancel my booking",
+    "I want to file a dispute",
+    "I was charged twice",
+    "My booking number is 123",
+    "I can't log into my account",
+    "When will my payout arrive?",
+  ])("classifies support: %s", (msg) => {
+    expect(classifyByKeywords(msg)).toBe("support");
+  });
+
+  it.each([
+    "Find me a condo in Orlando",
+    "Show me beach rentals under $1500",
+    "Looking for ski resorts in Aspen",
+    "What's available in Maui for spring break?",
+    "Browse 2-bedroom stays",
+  ])("classifies rentals: %s", (msg) => {
+    expect(classifyByKeywords(msg)).toBe("rentals");
+  });
+
+  it.each([
+    "Hi there",
+    "How does this work?",
+    "Thanks!",
+    "Tell me more",
+  ])("returns null for ambiguous: %s", (msg) => {
+    expect(classifyByKeywords(msg)).toBeNull();
+  });
+
+  it("returns null when both sets match (user is ambiguous)", () => {
+    // "cancel" hits support; "find" hits rentals → can't tell
+    expect(classifyByKeywords("Find me a condo but I also need to cancel my booking"))
+      .toBeNull();
+  });
+
+  it("is case-insensitive", () => {
+    expect(classifyByKeywords("WHERE'S MY REFUND")).toBe("support");
+  });
+});
+
+describe("classifyByModel", () => {
+  function mockFetch(responseBody: unknown, ok = true) {
+    return vi.fn().mockResolvedValue({
+      ok,
+      json: () => Promise.resolve(responseBody),
+    }) as unknown as typeof fetch;
+  }
+
+  it("returns support when model says 'support'", async () => {
+    const fetchImpl = mockFetch({
+      choices: [{ message: { content: "support" } }],
+    });
+
+    const result = await classifyByModel("help me with something", "fake-key", {
+      fetchImpl,
+    });
+
+    expect(result).toBe("support");
+  });
+
+  it("returns rentals when model says 'rentals'", async () => {
+    const fetchImpl = mockFetch({
+      choices: [{ message: { content: "rentals" } }],
+    });
+
+    const result = await classifyByModel("I need a place", "fake-key", { fetchImpl });
+
+    expect(result).toBe("rentals");
+  });
+
+  it("returns null when model says 'unclear'", async () => {
+    const fetchImpl = mockFetch({
+      choices: [{ message: { content: "unclear" } }],
+    });
+
+    const result = await classifyByModel("hi", "fake-key", { fetchImpl });
+
+    expect(result).toBeNull();
+  });
+
+  it("fails closed on HTTP error — returns null, never throws", async () => {
+    const fetchImpl = mockFetch({}, false);
+    const result = await classifyByModel("test", "fake-key", { fetchImpl });
+    expect(result).toBeNull();
+  });
+
+  it("fails closed on network error — returns null, never throws", async () => {
+    const fetchImpl = vi.fn().mockRejectedValue(new Error("network down"));
+    const result = await classifyByModel("test", "fake-key", {
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    expect(result).toBeNull();
+  });
+
+  it("trims model response whitespace + case", async () => {
+    const fetchImpl = mockFetch({
+      choices: [{ message: { content: "  SUPPORT \n" } }],
+    });
+    const result = await classifyByModel("test", "fake-key", { fetchImpl });
+    expect(result).toBe("support");
+  });
+
+  it("truncates overlong messages before sending", async () => {
+    const longMessage = "refund ".repeat(200); // 1400 chars
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ choices: [{ message: { content: "support" } }] }),
+    }) as unknown as typeof fetch;
+
+    await classifyByModel(longMessage, "fake-key", { fetchImpl });
+
+    const call = (fetchImpl as unknown as ReturnType<typeof vi.fn>).mock.calls[0];
+    const body = JSON.parse(call[1].body as string);
+    const userMessage = body.messages[1].content as string;
+    expect(userMessage.length).toBeLessThanOrEqual(500);
+  });
+});
+
+describe("classifyIntent (keyword-first + model fallback)", () => {
+  it("short-circuits to keyword classifier on clear signals, no model call", async () => {
+    const fetchSpy = vi.fn();
+    const result = await classifyIntent("Where's my refund?", "fake-key", {
+      fetchImpl: fetchSpy as unknown as typeof fetch,
+    });
+
+    expect(result).toBe("support");
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("falls through to model when keywords are ambiguous", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ choices: [{ message: { content: "rentals" } }] }),
+    }) as unknown as typeof fetch;
+
+    const result = await classifyIntent("Thinking about March", "fake-key", { fetchImpl });
+
+    expect(result).toBe("rentals");
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns null when no OpenRouter key and keywords ambiguous (no swap)", async () => {
+    const result = await classifyIntent("Thinking about March", null);
+    expect(result).toBeNull();
+  });
+
+  it("returns null for empty input", async () => {
+    const result = await classifyIntent("   ", "fake-key");
+    expect(result).toBeNull();
+  });
+});

--- a/supabase/functions/text-chat/intent-classifier.ts
+++ b/supabase/functions/text-chat/intent-classifier.ts
@@ -1,0 +1,196 @@
+// Lightweight intent classifier for ambiguous-route RAVIO messages.
+// Phase 22 C3 (#407) — DEC-036.
+//
+// Runs only when the route-detected context is 'general' (home, /help, /faq)
+// and the user has sent their first message. Returns:
+//   'support'  — account/booking/refund/dispute questions
+//   'rentals'  — find/browse/search discovery questions
+//   null       — keep the 'general' fallback (no chip, no swap)
+//
+// Two-stage pipeline:
+//   1. Keyword heuristics (zero latency, covers ~80% of cases)
+//   2. Small model fallback via OpenRouter (only when keywords are ambiguous)
+//
+// The output is the *classified* context; the edge fn decides whether to
+// actually swap the system prompt + tools based on whether it differs from
+// the route-detected context.
+
+export type ClassifiedContext = "support" | "rentals";
+
+// Keyword sets — intentionally narrow. Prefer keeping confidence HIGH by
+// matching only terms that are unambiguous on their own. Ambiguous terms
+// (e.g. "booking" on its own matches both contexts) go in the model fallback.
+
+const SUPPORT_KEYWORDS = [
+  // Refund / money
+  "refund",
+  "refunded",
+  "money back",
+  "charge",
+  "charged twice",
+  "double-charged",
+  "chargeback",
+  // Cancellation
+  "cancel my",
+  "cancel the booking",
+  "cancel booking",
+  "cancellation",
+  // Disputes / problems
+  "dispute",
+  "file a complaint",
+  "report an issue",
+  "report a problem",
+  "file a claim",
+  // Bookings I already have
+  "my booking",
+  "my bookings",
+  "my reservation",
+  "my stay",
+  "i booked",
+  "my offer",
+  "my offers",
+  // Personal-state
+  "where's my",
+  "wheres my",
+  "didn't get",
+  "never received",
+  "something's wrong",
+  "havent received",
+  "haven't received",
+  // Account
+  "my account",
+  "password",
+  "delete my account",
+  "change my email",
+  // Owner-specific support
+  "my listing",
+  "my listings",
+  "my payout",
+  "payout",
+];
+
+const RENTALS_KEYWORDS = [
+  "find",
+  "search for",
+  "looking for",
+  "show me",
+  "available",
+  "vacancies",
+  "browse",
+  "near ",
+  "in orlando",
+  "in maui",
+  "in aspen",
+  "in hawaii",
+  "in florida",
+  "cheap",
+  "under $",
+  "beach",
+  "mountain",
+  "ski",
+  "condo",
+  "resort in",
+  "hotel",
+  "vacation in",
+  "trip to",
+  "bedrooms",
+  "sleeps",
+  "what's available",
+  "whats available",
+  "stays in",
+];
+
+function containsAny(text: string, keywords: string[]): boolean {
+  const lower = text.toLowerCase();
+  return keywords.some((kw) => lower.includes(kw));
+}
+
+export function classifyByKeywords(message: string): ClassifiedContext | null {
+  const hasSupport = containsAny(message, SUPPORT_KEYWORDS);
+  const hasRentals = containsAny(message, RENTALS_KEYWORDS);
+
+  if (hasSupport && !hasRentals) return "support";
+  if (hasRentals && !hasSupport) return "rentals";
+  // Both or neither → ambiguous
+  return null;
+}
+
+// Model fallback prompt — one-shot classifier. Cheap because:
+//   - 30-40 input tokens
+//   - max_tokens=5 (response is one word)
+//   - called only on ambiguous messages on general routes
+const CLASSIFIER_SYSTEM_PROMPT = `You classify a user message to a travel marketplace assistant into exactly one of:
+- support: questions about their existing bookings, refunds, cancellations, disputes, account, payouts, or personal problems
+- rentals: browsing/discovery — searching for vacation properties, destinations, dates, amenities
+- unclear: cannot tell from this message alone
+
+Respond with a single lowercase word: support, rentals, or unclear. No punctuation, no explanation.`;
+
+interface OpenRouterLike {
+  (input: RequestInfo | URL, init?: RequestInit): Promise<Response>;
+}
+
+/**
+ * Model fallback classifier. Only call when keyword classifier returned null.
+ * Fails closed: on any error, returns null (no swap, keeps 'general' context).
+ */
+export async function classifyByModel(
+  message: string,
+  openRouterKey: string,
+  options: { model?: string; fetchImpl?: OpenRouterLike } = {},
+): Promise<ClassifiedContext | null> {
+  const model = options.model ?? "google/gemini-3-flash-preview";
+  const fetchImpl = options.fetchImpl ?? fetch;
+
+  try {
+    const response = await fetchImpl("https://openrouter.ai/api/v1/chat/completions", {
+      method: "POST",
+      headers: {
+        "Authorization": `Bearer ${openRouterKey}`,
+        "Content-Type": "application/json",
+        "HTTP-Referer": "https://rent-a-vacation.com",
+        "X-Title": "Rent-A-Vacation Intent Classifier",
+      },
+      body: JSON.stringify({
+        model,
+        messages: [
+          { role: "system", content: CLASSIFIER_SYSTEM_PROMPT },
+          { role: "user", content: message.slice(0, 500) },
+        ],
+        stream: false,
+        max_tokens: 5,
+        temperature: 0,
+      }),
+    });
+
+    if (!response.ok) return null;
+
+    const body = await response.json();
+    const raw = (body.choices?.[0]?.message?.content ?? "").toString().trim().toLowerCase();
+    if (raw === "support") return "support";
+    if (raw === "rentals") return "rentals";
+    // "unclear" or anything else → null
+    return null;
+  } catch {
+    // Classifier errors must never break the main chat — fail closed.
+    return null;
+  }
+}
+
+/**
+ * Full classifier pipeline. Keyword first, model fallback only when ambiguous.
+ */
+export async function classifyIntent(
+  message: string,
+  openRouterKey: string | null,
+  options: { model?: string; fetchImpl?: OpenRouterLike } = {},
+): Promise<ClassifiedContext | null> {
+  const trimmed = message.trim();
+  if (!trimmed) return null;
+
+  const byKeyword = classifyByKeywords(trimmed);
+  if (byKeyword) return byKeyword;
+
+  if (!openRouterKey) return null;
+  return classifyByModel(trimmed, openRouterKey, options);
+}


### PR DESCRIPTION
## Summary

Phase 22 **C3 (#407) — closes Track C**. When a user opens RAVIO on an ambiguous route (`/`, `/how-it-works`, `/faq`) the edge fn classifies their first message and swaps to the support or rentals persona for that turn. A subtle chip above the messages surfaces the swap and lets the user revert with one click; the revert is session-scoped and suppresses future classifications even across history clears.

## What this adds

**Classifier (`supabase/functions/text-chat/intent-classifier.ts`):**
- **Keyword-first** — narrow support/rentals keyword sets, zero latency, returns null for ambiguous. Happy path for clear messages = no extra work.
- **Model fallback** via OpenRouter only when keywords are ambiguous. Cheap (~35 input tokens, max_tokens=5, temperature=0).
- **Fails closed** on HTTP/network errors — returns null, never breaks chat.
- 20 unit tests (keyword coverage, model fallback, error modes, payload truncation).

**Edge fn integration:**
- Fires only when `context === 'general'` AND first message AND frontend hasn't flagged `disableClassifier: true`.
- Emits new SSE event `classified_context` before tokens.
- Uses resolved context for system prompt + tool selection for this turn.

**Frontend (`useTextChat` + `TextChatPanel`):**
- Parses `classified_context` SSE event into `classifiedContext` state.
- `dismissClassification()` clears chip + flips session-scoped ref that forces `disableClassifier: true` on future sends. Dismissal survives history clear; resets on route change.
- `TextChatPanel` renders chip above messages when `classifiedContext !== context`: **"Switched to {label} — back to general help"**. Brand-locked copy, reuses existing `CONTEXT_LABELS` (no new strings).
- `RavioFloatingChat` wires the new state through.
- PostHog events: `text_chat_classified`, `text_chat_classification_reverted`.

## Scope held

- No DB tables / migrations (logging is #410's scope).
- Explicit-context callsites (PropertyDetail, Rentals, BiddingMarketplace, HowItWorksPage) unaffected — classifier only fires for `context === 'general'`.
- PROD deploy held per CLAUDE.md.

## Tests

- **+34 tests** (1215 → 1249). 137 test files.
- `intent-classifier.test.ts` (20): keyword matching (support/rentals/ambiguous), case-insensitivity, model fallback branches, fail-closed on HTTP/network errors, payload truncation.
- `useTextChat.test.ts` (3 new): SSE event capture, default null, dismissClassification + disableClassifier body.
- `TextChatPanel.test.tsx` (2 new): chip renders when classified differs; chip absent when same.

## Test plan

- [ ] `npm run test` passes (1249/1249)
- [ ] `npm run build` passes
- [ ] `npx tsc --noEmit` clean
- [ ] Manual smoke post-deploy: on homepage `/`, ask RAVIO "Where's my refund?" → chip appears + support answer. Click chip → chip disappears. Clear history, type "Where's my refund?" again → NO chip (dismissal survives history clear). Navigate to `/rentals` → chip state fully reset.

## Phase 22 status after merge

- Tracks A, B, C, E all complete ✅
- Remaining: **Track D** — #410 conversation logging, #411 admin Support Interactions tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)