### PR TITLE
feat(marketplace): Pre-Booked listing reservation proof + Open-for-Offers badges (#376 + #378)

### DIFF
--- a/docs/PRIORITY-ROADMAP.md
+++ b/docs/PRIORITY-ROADMAP.md
@@ -1,6 +1,6 @@
 ---
-last_updated: "2026-04-23T10:15:43"
-change_ref: "2c593e2"
+last_updated: "2026-04-24T18:29:19"
+change_ref: "27a34e1"
 change_type: "session-58"
 status: "active"
 ---
@@ -45,8 +45,6 @@ All unblocked follow-ups from Sessions 54-58. Pick in any order; they're indepen
 
 | Issue | Title | Est. | Why now |
 |-------|-------|------|---------|
-| **#376** | Pre-Booked listing verification (resort reservation proof) | 1-2d | Unblocked by DEC-034 — proof-collection UX only meaningful after the flow distinction exists (which it now does). New schema fields + admin verify dialog + email templates. |
-| **#378** | "Open for Bidding" indicator everywhere (create-time toggle + consistent badge) | 3-4h | Unblocked by DEC-034 — integrates with the ListingTypeBadge visual system. |
 | **#381** | Role-relevant landing-view ordering | 6-8h | Surface most-time-sensitive items on each dashboard's Overview tab per "rooted in simplicity" principle. |
 | **#377** | Cancel-listing cascade (bulk bid rejection + booking cancellation + notifications) | 1d | Standalone, coordinates with DEC-034 wish-matched handling. New edge function + atomic cascade. |
 | **#371** | Edge function test harness | 1-2d (needs scoping) | Tech-debt follow-up from Tests-With-Features shortfalls. Enables future edge-fn work to be properly tested. |
@@ -131,6 +129,7 @@ These unblock when the LLC is formed. Not code-dependent.
 
 | Date | Session | Changes |
 |------|---------|---------|
+| Apr 24, 2026 | 59 | **#376 + #378 bundled + shipped.** Migration 064 adds `listing_proof_status` enum + 9 new columns on `listings` + `listing-proofs` private storage bucket (10 MB cap, PDF/JPEG/PNG) + 4 RLS policies + 2 notification_catalog entries. Owner gets proof step in `ListProperty` with file+number+attestation; rejected listings get alert + `ReuploadProofDialog`. Admin gets `ProofVerifyDialog` with embedded preview, phone-verification notes, and Approve-button gating. #378 ships consistent Direct / Bidding-Open badges across ListProperty / OwnerListings / AdminListings / ListingCard / PropertyDetail. 17 new tests (pure-logic util). Help-text-everywhere memory captured. |
 | Apr 22-23, 2026 | 58 | **PHASE 22 COMPLETE — 22/22 tickets shipped across 6 PRs this session.** PR #428 (C1+C4): text-chat `context:'support'` + 5 agent tools; DB-first with live Stripe reconcile. PR #429 (C2): route-based context detection + `<RavioFloatingChat />` on /my-trips, /owner-dashboard, /account. PR #430 (C5): Migration 061 `dispute_source` enum; AdminDisputes "via RAVIO" badges. PR #431 (C3): `intent-classifier.ts` + SSE `classified_context` + "Switched to X — back" chip. PR #432 (D1): Migration 062 `support_conversations` + `support_messages` + full transcript capture + escalation stamping. PR #433 (D2): Migration 063 `get_support_metrics` RPC + `AdminSupportInteractions` tab (metrics cards, filter bar, transcripts table, detail dialog) + `RavioChatRating` thumbs UI. 145 new tests total this session. |
 | Apr 21, 2026 | 57 | **Phase 22 SHIPPED Tracks A + B + E (15 of 22 tickets, 8 PRs #418-#425).** Full documentation infrastructure end-to-end on DEV: 22 markdown files in `docs/support/`, migration 060 (support_docs), `ingest-support-docs` edge fn + GitHub Action, `docs-sync-check` extension, 6 legal-blocked drafts at status:draft pending #80. Issues closed: #396-#404, #412-#417. Remaining: Track C (#405-#409 RAVIO agent code) + Track D (#410, #411 observability) — next session. PROD deploys held per CLAUDE.md. |
 | Apr 20, 2026 | 57 (planning) | Phase 22 Customer Support Foundation SCOPED. Milestone #37 + epic #395 + 22 child issues #396-#417. DEC-036 logged: reject CrewAI, extend RAVIO text chat with `context: 'support'` + tool use; voice stays discovery-only. 20 support docs planned. Markdown canonical → Supabase `support_docs` sync. PR #418. |

--- a/docs/PROJECT-HUB.md
+++ b/docs/PROJECT-HUB.md
@@ -1,6 +1,6 @@
 ---
-last_updated: "2026-04-23T10:15:43"
-change_ref: "2c593e2"
+last_updated: "2026-04-24T18:29:19"
+change_ref: "27a34e1"
 change_type: "session-58"
 status: "active"
 ---
@@ -93,20 +93,35 @@ gh issue create --repo rent-a-vacation/rav-website --title "..." --label "..." -
 - Edge functions require `--no-verify-jwt` deployment flag
 
 ### Platform Status
-- **1291 automated tests** (139 test files, all passing), 0 type errors, 0 lint errors, build clean
+- **1308 automated tests** (140 test files, all passing), 0 type errors, 0 lint errors, build clean
 - **P0 tests:** 97 critical-path tests tagged `@p0` + 4 subscription P0s + 6 ListingTypeBadge P0s + 1 support-tool P0 + 35 detectChatContext P0s + 17 intent-classifier P0s — run with `npm run test:p0`
 - **CI reporting:** GitHub native via dorny/test-reporter (JUnit XML) — PR annotations on every run (Qase removed Mar 2026)
-- **Migrations created:** 001-063 (001-059 deployed to DEV + PROD; 060 + 061 + 062 + 063 deployed to DEV only — PROD held per CLAUDE.md) + 3 date-based MDM migrations
+- **Migrations created:** 001-064 (001-059 deployed to DEV + PROD; 060 + 061 + 062 + 063 + 064 deployed to DEV only — PROD held per CLAUDE.md) + 3 date-based MDM migrations
 - **Edge functions:** 35 total (27 deployed to PROD + 4 subscription functions on DEV + 3 SMS functions pending LLC/EIN + `ingest-support-docs` deployed to DEV only). `text-chat` gains a `context: 'support'` branch with 5 agent tools (Session 58, Phase 22 C1 + C4).
 - **Stripe Subscription:** Sandbox configured — 4 products, webhook (11 events), Customer Portal. Subscription epic #263 CLOSED (all 9 stories complete)
 - **Stripe Tax:** env-gated via `STRIPE_TAX_ENABLED` (Session 54). Unset on both DEV + PROD → `automatic_tax` disabled → bookings work without tax collection. Flip to `"true"` on PROD only after live Stripe Tax fully activated post-#127.
 - **Marketplace flow distinction (DEC-034):** `listings.source_type` + `bookings.source_type` + `bookings.travel_proposal_id` live. Pre-Booked Stay = instant confirm; Wish-Matched Stay = owner-confirmation required. Implemented via #380 Phases 1–5 (PRs #385–#389).
 - **PROD platform:** locked (Staff Only Mode enabled)
 - **Supabase CLI:** currently linked to DEV
-- **dev and main:** in sync at Session 57 end; Session 58 PR for Phase 22 C1 + C4 (#405 + #408) open at time of writing
+- **dev and main:** in sync at Session 58 end (Phase 22 complete); Session 59 PR for #376 + #378 open at time of writing
 - **GitHub Project:** RAV Roadmap — 202 issues, all with Status/Category/Sub-Category/Type populated. Auto-add workflow enabled. PRs excluded.
 
-### Session Handoff (Sessions 25-58)
+### Session Handoff (Sessions 25-59)
+
+**Session 59 — Pre-Booked reservation verification + Open-for-Offers surfacing (#376 + #378, Apr 24, 2026):**
+- **One bundled PR (#376 + #378)** because both touched `ListProperty`, `OwnerListings`, and `AdminListings` in overlapping ways. Scoping via the 7-decision matrix with the user: all 7 leans confirmed + 3 anti-scam layers agreed (attestation, file-hash dedup, admin phone-verification checklist).
+- **#376 Pre-Booked reservation proof.** Migration 064 adds: `listing_proof_status` enum (`not_required`/`required`/`submitted`/`verified`/`rejected`), 9 columns on `listings` (confirmation number, proof path + SHA-256 hash, verification by/at, rejection reason, owner attestation timestamp, admin phone-verification notes), `listing-proofs` private storage bucket with 10 MB cap and PDF/JPEG/PNG allowed-list, 4 RLS policies, backfill that grandfathers pre-existing Pre-Booked active/booked listings as `verified`, 2 new `notification_catalog` entries for proof_verified/rejected. UNIQUE index on `confirmation_proof_hash` enforces cross-owner proof dedup.
+- **Owner flow** in `ListProperty` Step 2: confirmation-number field + file upload (validated via `validateProofFile`) + legal-language attestation checkbox. Client-side pre-check queries for duplicate proof hash before upload so owners get a fast friendly error if they reuse a file. Listing id is generated client-side via `crypto.randomUUID()` so the storage path can be scoped before insert; on insert failure the orphan file is cleaned up. On success, listing lands in `proof_status='submitted'` awaiting admin review.
+- **Owner recovery flow.** `OwnerListings` now shows proof status badges on all listing statuses (awaiting upload / pending review / verified / rejected). When rejected, a red alert block shows the admin's rejection reason plus a "Re-upload proof" button that opens the new `ReuploadProofDialog` (confirmation-number + file + attestation). Re-upload flips the listing back to `proof_status='submitted'` for another admin pass.
+- **Admin flow** in `AdminListings`: new "Model" column (Direct / Bidding) + "Proof" column (color-coded badge) + column tooltips. New `ProofVerifyDialog` with embedded PDF/image preview via short-lived signed URL, admin phone-verification notes field (for the process-based anti-scam layer), Verify / Reject branch. Approve button on Pre-Booked listings is disabled with an explanatory tooltip when proof isn't verified yet. Verify success + reject both fire `notification-dispatcher` to the owner (fire-and-forget, non-blocking).
+- **#378 Open-for-Offers surfacing.** New bidding-config section in `ListProperty` Step 2 (toggle + conditional min-bid / ends-at / reserve-price / counter-offers fields, all with muted subtext). New "Bidding Open" badge on `ListingCard` (search results) positioned bottom-right of the image. New persistent "Open for Offers" badge on `PropertyDetail` next to the type badge above the fold (previously buried in a collapsible). Consistent amber for Bidding Open, emerald for Direct Booking across owner + admin + search surfaces.
+- **Pure-logic util** `src/lib/listingProof.ts` — `hashFile` (SHA-256 via Web Crypto with FileReader fallback for older test envs), `validateProofFile` (MIME + size guard), `buildProofStoragePath` (path-traversal sanitizer), status dictionaries for labels + badge classes + help text. **17 unit tests.**
+- **Test helper** `renderWithProviders` updated to wrap in `TooltipProvider` (mirrors `App.tsx`) so admin-tab tests that use tooltips don't need to import it themselves.
+- **New durable feedback memory:** "Help Text Everywhere" — every new form field, column, button, dialog gets short non-intrusive guiding text. This PR systematically applies that rule to every new control.
+- **Scope held:** per-listing SMS alerts (blocked on A2P 10DLC), trust-level gating of proof requirement (post-launch enhancement), OCR extraction of reservation details (v1.5), direct brand-API verification integrations (partnership-dependent).
+- Tests: 1291 → 1308 (+17). Migrations 064 held from PROD per CLAUDE.md.
+
+---
 
 **Session 58 — PHASE 22 COMPLETE — RAVIO Customer Support Foundation end-to-end (#405+#408+#406+#409+#407+#410+#411, Apr 22-23, 2026):**
 

--- a/docs/testing/TESTING-STATUS.md
+++ b/docs/testing/TESTING-STATUS.md
@@ -1,6 +1,6 @@
 ---
-last_updated: "2026-04-23T10:15:43"
-change_ref: "2c593e2"
+last_updated: "2026-04-24T18:29:19"
+change_ref: "27a34e1"
 change_type: "session-58"
 status: "active"
 ---
@@ -15,8 +15,8 @@ status: "active"
 
 | Metric | Value |
 |--------|-------|
-| **Total tests** | 1291 |
-| **Test files** | 139 |
+| **Total tests** | 1308 |
+| **Test files** | 140 |
 | **P0 critical-path tests** | 97 (tagged `@p0`) + 4 subscription P0s + 1 support-tool P0 + 35 detectChatContext P0s + 17 intent-classifier P0s |
 | **E2E smoke tests** | 3 (Playwright) |
 | **Local run time** | ~2.5 min (full), ~2s (P0 only) |

--- a/src/components/ListingCard.tsx
+++ b/src/components/ListingCard.tsx
@@ -10,6 +10,7 @@ import {
   Clock,
   Crown,
   Zap,
+  Gavel,
 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { type ActiveListing } from "@/hooks/useListings";
@@ -170,6 +171,17 @@ export function ListingCard({
             className="absolute top-3 left-3 mt-8 text-xs font-medium bg-amber-500/90 text-white border-0"
           >
             <Crown className="w-3 h-3 mr-1" />Featured
+          </Badge>
+        )}
+        {/* #378 Bidding Open badge — shown whenever bidding is active.
+            Amber signals "open for Offers" consistently with owner/admin badges. */}
+        {listing.open_for_bidding && listing.bidding_ends_at && new Date(listing.bidding_ends_at) > new Date() && (
+          <Badge
+            variant="secondary"
+            className="absolute bottom-3 right-3 text-xs font-medium bg-amber-500/95 text-white border-0"
+          >
+            <Gavel className="w-3 h-3 mr-1" />
+            Bidding Open
           </Badge>
         )}
         {/* Image overlay slot (compare checkbox, etc.) */}

--- a/src/components/admin/AdminListings.tsx
+++ b/src/components/admin/AdminListings.tsx
@@ -38,6 +38,17 @@ import type { Listing, Property, Profile, ListingStatus } from "@/types/database
 import { AdminEntityLink, type AdminNavigationProps } from "./AdminEntityLink";
 import { AgeBadge } from "./AgeBadge";
 import AdminListingEditDialog from "./AdminListingEditDialog";
+import { ProofVerifyDialog } from "./ProofVerifyDialog";
+import {
+  PROOF_STATUS_LABELS,
+  PROOF_STATUS_BADGE_CLASSES,
+} from "@/lib/listingProof";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { Gavel, HelpCircle, Shield } from "lucide-react";
 
 const REJECTION_TEMPLATES = [
   "Incomplete property details",
@@ -85,6 +96,10 @@ const AdminListings = ({ initialSearch = "", onNavigateToEntity }: AdminNavigati
   const [isBulkProcessing, setIsBulkProcessing] = useState(false);
   const [editListing, setEditListing] = useState<ListingWithDetails | null>(null);
   const [editDialogOpen, setEditDialogOpen] = useState(false);
+
+  // #376 proof verify dialog
+  const [proofListing, setProofListing] = useState<ListingWithDetails | null>(null);
+  const [proofDialogOpen, setProofDialogOpen] = useState(false);
 
   useEffect(() => {
     if (initialSearch) setSearchQuery(initialSearch);
@@ -445,6 +460,28 @@ const AdminListings = ({ initialSearch = "", onNavigateToEntity }: AdminNavigati
                   <TableHead>Owner</TableHead>
                   <TableHead>Dates</TableHead>
                   <TableHead>Pricing</TableHead>
+                  <TableHead>
+                    <Tooltip>
+                      <TooltipTrigger className="flex items-center gap-1">
+                        Model
+                        <HelpCircle className="h-3 w-3 text-muted-foreground" />
+                      </TooltipTrigger>
+                      <TooltipContent side="top">
+                        Direct booking vs. open for Offers. Bidding Open means travelers can submit Offers until the deadline.
+                      </TooltipContent>
+                    </Tooltip>
+                  </TableHead>
+                  <TableHead>
+                    <Tooltip>
+                      <TooltipTrigger className="flex items-center gap-1">
+                        Proof
+                        <HelpCircle className="h-3 w-3 text-muted-foreground" />
+                      </TooltipTrigger>
+                      <TooltipContent side="top">
+                        Reservation proof verification status. Only Pre-Booked Stays require proof — Wish-Matched confirm post-acceptance.
+                      </TooltipContent>
+                    </Tooltip>
+                  </TableHead>
                   <TableHead>Status</TableHead>
                   <TableHead className="text-right">Actions</TableHead>
                 </TableRow>
@@ -495,6 +532,26 @@ const AdminListings = ({ initialSearch = "", onNavigateToEntity }: AdminNavigati
                       </div>
                     </TableCell>
                     <TableCell>
+                      {listing.open_for_bidding ? (
+                        <Badge variant="outline" className="border-amber-400 text-amber-700">
+                          <Gavel className="h-3 w-3 mr-1" />
+                          Bidding
+                        </Badge>
+                      ) : (
+                        <Badge variant="outline" className="border-emerald-400 text-emerald-700">
+                          Direct
+                        </Badge>
+                      )}
+                    </TableCell>
+                    <TableCell>
+                      <Badge
+                        variant="outline"
+                        className={PROOF_STATUS_BADGE_CLASSES[listing.proof_status ?? "not_required"]}
+                      >
+                        {PROOF_STATUS_LABELS[listing.proof_status ?? "not_required"]}
+                      </Badge>
+                    </TableCell>
+                    <TableCell>
                       <div className="flex flex-col gap-1">
                         <Badge className={STATUS_COLORS[listing.status]}>
                           {STATUS_LABELS[listing.status]}
@@ -511,28 +568,59 @@ const AdminListings = ({ initialSearch = "", onNavigateToEntity }: AdminNavigati
                     </TableCell>
                     <TableCell className="text-right">
                       <div className="flex justify-end gap-2">
-                        {listing.status === "pending_approval" && (
-                          <>
-                            <Button
-                              size="sm"
-                              variant="outline"
-                              className="text-green-600 hover:text-green-700"
-                              onClick={() => handleApprove(listing.id)}
-                            >
-                              <Check className="h-4 w-4 mr-1" />
-                              Approve
-                            </Button>
-                            <Button
-                              size="sm"
-                              variant="outline"
-                              className="text-red-600 hover:text-red-700"
-                              onClick={() => openRejectDialog(listing.id)}
-                            >
-                              <X className="h-4 w-4 mr-1" />
-                              Reject
-                            </Button>
-                          </>
+                        {(listing.proof_status === "submitted" || listing.proof_status === "rejected") && (
+                          <Button
+                            size="sm"
+                            variant="outline"
+                            className="text-primary"
+                            onClick={() => {
+                              setProofListing(listing);
+                              setProofDialogOpen(true);
+                            }}
+                          >
+                            <Shield className="h-4 w-4 mr-1" />
+                            {listing.proof_status === "rejected" ? "View Proof" : "Verify Proof"}
+                          </Button>
                         )}
+                        {listing.status === "pending_approval" && (() => {
+                          const proofBlocksApprove =
+                            listing.source_type === "pre_booked" &&
+                            listing.proof_status !== "verified";
+                          return (
+                            <>
+                              <Tooltip>
+                                <TooltipTrigger asChild>
+                                  <span>
+                                    <Button
+                                      size="sm"
+                                      variant="outline"
+                                      className="text-green-600 hover:text-green-700"
+                                      onClick={() => handleApprove(listing.id)}
+                                      disabled={proofBlocksApprove}
+                                    >
+                                      <Check className="h-4 w-4 mr-1" />
+                                      Approve
+                                    </Button>
+                                  </span>
+                                </TooltipTrigger>
+                                {proofBlocksApprove && (
+                                  <TooltipContent side="top">
+                                    Reservation proof must be verified before this Pre-Booked Stay can go active.
+                                  </TooltipContent>
+                                )}
+                              </Tooltip>
+                              <Button
+                                size="sm"
+                                variant="outline"
+                                className="text-red-600 hover:text-red-700"
+                                onClick={() => openRejectDialog(listing.id)}
+                              >
+                                <X className="h-4 w-4 mr-1" />
+                                Reject
+                              </Button>
+                            </>
+                          );
+                        })()}
                         {isRavAdmin() && (
                           <Button
                             variant="ghost"
@@ -653,6 +741,17 @@ const AdminListings = ({ initialSearch = "", onNavigateToEntity }: AdminNavigati
         open={editDialogOpen}
         onOpenChange={setEditDialogOpen}
         onSaved={fetchListings}
+      />
+
+      <ProofVerifyDialog
+        listing={proofListing}
+        open={proofDialogOpen}
+        onOpenChange={(open) => {
+          setProofDialogOpen(open);
+          if (!open) setProofListing(null);
+        }}
+        onVerified={fetchListings}
+        onRejected={fetchListings}
       />
     </div>
   );

--- a/src/components/admin/ProofVerifyDialog.tsx
+++ b/src/components/admin/ProofVerifyDialog.tsx
@@ -1,0 +1,329 @@
+import { useEffect, useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  AlertTriangle,
+  Check,
+  Download,
+  FileText,
+  Loader2,
+  Phone,
+  Shield,
+  X,
+} from "lucide-react";
+import { supabase } from "@/lib/supabase";
+import { useAuth } from "@/hooks/useAuth";
+import { toast } from "sonner";
+
+interface ProofVerifyDialogProps {
+  listing: {
+    id: string;
+    owner_id?: string;
+    resort_confirmation_number: string | null;
+    confirmation_proof_path: string | null;
+    admin_phone_verification_notes: string | null;
+    property?: { resort_name?: string | null } | null;
+    owner?: { id?: string; full_name?: string | null; email?: string | null } | null;
+  } | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onVerified?: () => void;
+  onRejected?: () => void;
+}
+
+/**
+ * Admin verify/reject dialog for Pre-Booked listing reservation proof (#376).
+ *
+ * Embedded PDF/image viewer via a signed URL so admins can review without
+ * leaving the tab. Supports the documented anti-scam workflow:
+ *   - Note which resort-staff member was spoken to during phone verification
+ *   - Verify → stamps confirmation_verified_at / _by, flips to 'verified'
+ *   - Reject → captures reason, flips to 'rejected', owner gets re-upload cue
+ */
+export function ProofVerifyDialog({
+  listing,
+  open,
+  onOpenChange,
+  onVerified,
+  onRejected,
+}: ProofVerifyDialogProps) {
+  const { user } = useAuth();
+  const [signedUrl, setSignedUrl] = useState<string | null>(null);
+  const [phoneNotes, setPhoneNotes] = useState("");
+  const [rejectionReason, setRejectionReason] = useState("");
+  const [showRejectForm, setShowRejectForm] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (open && listing?.confirmation_proof_path) {
+      setPhoneNotes(listing.admin_phone_verification_notes ?? "");
+      setRejectionReason("");
+      setShowRejectForm(false);
+
+      // Private bucket — issue a short-lived signed URL for the preview.
+      supabase.storage
+        .from("listing-proofs")
+        .createSignedUrl(listing.confirmation_proof_path, 300)
+        .then(({ data, error }) => {
+          if (error) {
+            console.error("Failed to create signed URL:", error);
+            setSignedUrl(null);
+            return;
+          }
+          setSignedUrl(data?.signedUrl ?? null);
+        });
+    } else {
+      setSignedUrl(null);
+    }
+  }, [open, listing?.confirmation_proof_path, listing?.admin_phone_verification_notes]);
+
+  if (!listing) return null;
+
+  const isPdf = listing.confirmation_proof_path?.toLowerCase().endsWith(".pdf");
+
+  async function handleVerify() {
+    if (!user || !listing) return;
+    setSubmitting(true);
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const { error } = await (supabase as any)
+        .from("listings")
+        .update({
+          proof_status: "verified",
+          confirmation_verified_at: new Date().toISOString(),
+          confirmation_verified_by: user.id,
+          admin_phone_verification_notes: phoneNotes.trim() || null,
+          proof_rejected_reason: null,
+        })
+        .eq("id", listing.id);
+      if (error) throw error;
+
+      // Notify owner — fire-and-forget; don't block the UI on email failure.
+      const ownerId = listing.owner?.id ?? listing.owner_id;
+      if (ownerId) {
+        supabase.functions
+          .invoke("notification-dispatcher", {
+            body: {
+              type_key: "listing_proof_verified",
+              user_id: ownerId,
+              payload: {
+                title: "Reservation proof verified",
+                message: listing.property?.resort_name
+                  ? `Your proof for ${listing.property.resort_name} was verified. Your Listing is one step closer to going live.`
+                  : "Your reservation proof was verified.",
+                listing_id: listing.id,
+              },
+            },
+          })
+          .catch((e) => console.error("notification-dispatcher failed:", e));
+      }
+
+      toast.success("Proof verified. Owner is notified.");
+      onOpenChange(false);
+      onVerified?.();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Verify failed");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  async function handleReject() {
+    if (!listing || !rejectionReason.trim()) return;
+    setSubmitting(true);
+    try {
+      const reasonText = rejectionReason.trim();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const { error } = await (supabase as any)
+        .from("listings")
+        .update({
+          proof_status: "rejected",
+          proof_rejected_reason: reasonText,
+          admin_phone_verification_notes: phoneNotes.trim() || null,
+        })
+        .eq("id", listing.id);
+      if (error) throw error;
+
+      const ownerId = listing.owner?.id ?? listing.owner_id;
+      if (ownerId) {
+        supabase.functions
+          .invoke("notification-dispatcher", {
+            body: {
+              type_key: "listing_proof_rejected",
+              user_id: ownerId,
+              payload: {
+                title: "Reservation proof needs another look",
+                message: `${reasonText} Please re-upload the correct reservation file from your RAV dashboard.`,
+                listing_id: listing.id,
+              },
+            },
+          })
+          .catch((e) => console.error("notification-dispatcher failed:", e));
+      }
+
+      toast.success("Proof rejected. Owner will be prompted to re-upload.");
+      onOpenChange(false);
+      onRejected?.();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Reject failed");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-3xl max-h-[90vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Shield className="w-5 h-5" />
+            Verify Reservation Proof
+          </DialogTitle>
+          <DialogDescription>
+            {listing.property?.resort_name} · {listing.owner?.full_name} ({listing.owner?.email})
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          {/* Summary */}
+          <div className="grid grid-cols-2 gap-3 text-sm">
+            <div>
+              <Label className="text-xs text-muted-foreground">Resort Confirmation Number</Label>
+              <p className="font-mono">{listing.resort_confirmation_number ?? "—"}</p>
+            </div>
+            <div>
+              <Label className="text-xs text-muted-foreground">Proof File</Label>
+              <p className="flex items-center gap-1 text-xs text-muted-foreground">
+                <FileText className="w-3 h-3" />
+                {listing.confirmation_proof_path?.split("/").pop() ?? "—"}
+                {signedUrl && (
+                  <a
+                    href={signedUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-primary underline ml-2 inline-flex items-center gap-1"
+                  >
+                    <Download className="w-3 h-3" /> open
+                  </a>
+                )}
+              </p>
+            </div>
+          </div>
+
+          {/* Embedded preview */}
+          <div className="border rounded-md overflow-hidden bg-muted/20">
+            {!signedUrl ? (
+              <div className="h-64 flex items-center justify-center text-muted-foreground text-sm">
+                <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                Loading proof…
+              </div>
+            ) : isPdf ? (
+              <iframe
+                title="Reservation proof PDF"
+                src={signedUrl}
+                className="w-full h-96 bg-white"
+              />
+            ) : (
+              <img
+                src={signedUrl}
+                alt="Reservation proof"
+                className="w-full max-h-96 object-contain bg-white"
+              />
+            )}
+          </div>
+
+          {/* Phone verification checklist — anti-scam layer G */}
+          <div>
+            <Label className="text-sm font-medium flex items-center gap-1">
+              <Phone className="w-3.5 h-3.5" />
+              Phone Verification Notes
+              <span className="text-xs text-muted-foreground font-normal ml-1">— recommended</span>
+            </Label>
+            <Textarea
+              value={phoneNotes}
+              onChange={(e) => setPhoneNotes(e.target.value)}
+              placeholder="e.g. Called resort front desk 4/24. Reservation confirmed under owner's name for dates."
+              rows={2}
+            />
+            <p className="text-xs text-muted-foreground mt-1">
+              Optional but strongly recommended. Documenting a resort phone-check is our strongest anti-scam signal.
+            </p>
+          </div>
+
+          {/* Reject form (conditional) */}
+          {showRejectForm && (
+            <div className="bg-red-50 border border-red-200 rounded-md p-3 space-y-2">
+              <Label className="text-sm font-medium flex items-center gap-1 text-red-800">
+                <AlertTriangle className="w-3.5 h-3.5" />
+                Rejection Reason
+              </Label>
+              <Textarea
+                value={rejectionReason}
+                onChange={(e) => setRejectionReason(e.target.value)}
+                placeholder="Explain what was wrong — owner will see this in their listing alert."
+                rows={3}
+              />
+              <p className="text-xs text-red-700">
+                Written in plain language — the owner will read this verbatim.
+              </p>
+            </div>
+          )}
+        </div>
+
+        <DialogFooter className="flex-wrap gap-2">
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={submitting}>
+            Close
+          </Button>
+          {showRejectForm ? (
+            <>
+              <Button
+                variant="outline"
+                onClick={() => {
+                  setShowRejectForm(false);
+                  setRejectionReason("");
+                }}
+                disabled={submitting}
+              >
+                Cancel Reject
+              </Button>
+              <Button
+                variant="destructive"
+                onClick={handleReject}
+                disabled={submitting || !rejectionReason.trim()}
+              >
+                {submitting ? <Loader2 className="w-4 h-4 mr-2 animate-spin" /> : <X className="w-4 h-4 mr-2" />}
+                Confirm Reject
+              </Button>
+            </>
+          ) : (
+            <>
+              <Button
+                variant="outline"
+                className="text-red-600 border-red-300 hover:bg-red-50"
+                onClick={() => setShowRejectForm(true)}
+                disabled={submitting}
+              >
+                <X className="w-4 h-4 mr-2" />
+                Reject
+              </Button>
+              <Button onClick={handleVerify} disabled={submitting}>
+                {submitting ? <Loader2 className="w-4 h-4 mr-2 animate-spin" /> : <Check className="w-4 h-4 mr-2" />}
+                Verify &amp; Approve Proof
+              </Button>
+            </>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/owner/OwnerListings.tsx
+++ b/src/components/owner/OwnerListings.tsx
@@ -45,6 +45,7 @@ import type { Property, Listing, ListingStatus, CancellationPolicy, Database } f
 import { CANCELLATION_POLICY_LABELS, CANCELLATION_POLICY_DESCRIPTIONS } from "@/types/database";
 import { OpenForBiddingDialog } from "@/components/bidding/OpenForBiddingDialog";
 import { BidsManagerDialog } from "@/components/bidding/BidsManagerDialog";
+import { ReuploadProofDialog } from "@/components/owner/ReuploadProofDialog";
 import { ActionSuccessCard } from "@/components/ActionSuccessCard";
 import { sendListingSubmittedEmail } from "@/lib/email";
 import { ListingFairValueBadge } from "@/components/fair-value/ListingFairValueBadge";
@@ -122,6 +123,10 @@ const OwnerListings = () => {
   const [biddingDialogOpen, setBiddingDialogOpen] = useState(false);
   const [bidsManagerOpen, setBidsManagerOpen] = useState(false);
   const [selectedListingForBidding, setSelectedListingForBidding] = useState<ListingWithProperty | null>(null);
+
+  // #376 proof reupload dialog state
+  const [reuploadOpen, setReuploadOpen] = useState(false);
+  const [reuploadListing, setReuploadListing] = useState<ListingWithProperty | null>(null);
 
   // Fetch listings and properties
   const fetchData = async () => {
@@ -692,6 +697,26 @@ const OwnerListings = () => {
                           </Badge>
                         )
                       )}
+                      {/* #376 Proof status — shown on all statuses when relevant */}
+                      {listing.proof_status && listing.proof_status !== 'not_required' && listing.proof_status !== 'verified' && (
+                        <Badge
+                          variant="outline"
+                          className={
+                            listing.proof_status === 'rejected'
+                              ? 'border-red-400 text-red-700'
+                              : listing.proof_status === 'submitted'
+                              ? 'border-blue-400 text-blue-700'
+                              : 'border-amber-400 text-amber-700'
+                          }
+                        >
+                          Proof: {listing.proof_status === 'submitted' ? 'Pending Review' : listing.proof_status === 'rejected' ? 'Rejected' : 'Upload Required'}
+                        </Badge>
+                      )}
+                      {listing.proof_status === 'verified' && (
+                        <Badge variant="outline" className="border-emerald-400 text-emerald-700">
+                          Proof Verified
+                        </Badge>
+                      )}
                     </div>
                     <CardTitle className="text-lg">
                       {listing.property?.resort_name}
@@ -720,6 +745,31 @@ const OwnerListings = () => {
                 </div>
               </CardHeader>
               <CardContent>
+                {/* #376 Proof rejected alert ---------------------------- */}
+                {listing.proof_status === 'rejected' && (
+                  <div className="mb-4 bg-red-50 border border-red-200 rounded-md p-3">
+                    <p className="text-sm font-medium text-red-800 mb-1">
+                      Reservation proof rejected
+                    </p>
+                    {listing.proof_rejected_reason && (
+                      <p className="text-sm text-red-700 mb-2">
+                        {listing.proof_rejected_reason}
+                      </p>
+                    )}
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      className="border-red-300 text-red-800 hover:bg-red-100"
+                      onClick={() => {
+                        setReuploadListing(listing);
+                        setReuploadOpen(true);
+                      }}
+                    >
+                      Re-upload proof
+                    </Button>
+                  </div>
+                )}
+
                 <div className="flex flex-wrap items-center gap-4 text-sm mb-4">
                   <div className="flex items-center gap-2">
                     <Calendar className="h-4 w-4 text-muted-foreground" />
@@ -871,6 +921,21 @@ const OwnerListings = () => {
             setBidsManagerOpen(open);
             if (!open) setSelectedListingForBidding(null);
           }}
+        />
+      )}
+
+      {/* #376 Re-upload Proof Dialog */}
+      {reuploadListing && (
+        <ReuploadProofDialog
+          listingId={reuploadListing.id}
+          existingConfirmationNumber={reuploadListing.resort_confirmation_number ?? null}
+          rejectedReason={reuploadListing.proof_rejected_reason ?? null}
+          open={reuploadOpen}
+          onOpenChange={(open) => {
+            setReuploadOpen(open);
+            if (!open) setReuploadListing(null);
+          }}
+          onSuccess={() => fetchData()}
         />
       )}
 

--- a/src/components/owner/ReuploadProofDialog.tsx
+++ b/src/components/owner/ReuploadProofDialog.tsx
@@ -1,0 +1,230 @@
+import { useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Checkbox } from "@/components/ui/checkbox";
+import { AlertTriangle, Loader2, Shield } from "lucide-react";
+import { supabase } from "@/lib/supabase";
+import { useAuth } from "@/hooks/useAuth";
+import {
+  hashFile,
+  validateProofFile,
+  buildProofStoragePath,
+  MAX_PROOF_FILE_SIZE_BYTES,
+} from "@/lib/listingProof";
+import { toast } from "sonner";
+
+interface ReuploadProofDialogProps {
+  listingId: string;
+  existingConfirmationNumber: string | null;
+  rejectedReason: string | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSuccess?: () => void;
+}
+
+/**
+ * Re-upload dialog for an owner whose reservation proof was rejected (#376).
+ * Updates the existing listing row rather than creating a new one. The admin
+ * will see the new proof with proof_status='submitted' back in their queue.
+ */
+export function ReuploadProofDialog({
+  listingId,
+  existingConfirmationNumber,
+  rejectedReason,
+  open,
+  onOpenChange,
+  onSuccess,
+}: ReuploadProofDialogProps) {
+  const { user } = useAuth();
+  const [confirmationNumber, setConfirmationNumber] = useState(
+    existingConfirmationNumber ?? "",
+  );
+  const [file, setFile] = useState<File | null>(null);
+  const [fileError, setFileError] = useState<string | null>(null);
+  const [attestationAccepted, setAttestationAccepted] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+
+  function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const f = e.target.files?.[0] ?? null;
+    if (!f) {
+      setFile(null);
+      setFileError(null);
+      return;
+    }
+    const err = validateProofFile(f);
+    if (err) {
+      setFile(null);
+      setFileError(err.message);
+      return;
+    }
+    setFile(f);
+    setFileError(null);
+  }
+
+  const canSubmit =
+    !!user &&
+    confirmationNumber.trim().length >= 4 &&
+    file !== null &&
+    !fileError &&
+    attestationAccepted &&
+    !submitting;
+
+  async function handleSubmit() {
+    if (!user || !file) return;
+    setSubmitting(true);
+    try {
+      const proofHash = await hashFile(file);
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const { data: existingHashRow } = await (supabase as any)
+        .from("listings")
+        .select("id")
+        .eq("confirmation_proof_hash", proofHash)
+        .neq("id", listingId)
+        .maybeSingle();
+      if (existingHashRow) {
+        throw new Error(
+          "This proof file has already been used on another listing. Please upload the reservation email for this specific trip.",
+        );
+      }
+
+      const proofPath = buildProofStoragePath(user.id, listingId, file.name);
+      const { error: uploadError } = await supabase.storage
+        .from("listing-proofs")
+        .upload(proofPath, file, { contentType: file.type, upsert: false });
+      if (uploadError) throw new Error(`Proof upload failed: ${uploadError.message}`);
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const { error: updateError } = await (supabase as any)
+        .from("listings")
+        .update({
+          resort_confirmation_number: confirmationNumber.trim(),
+          confirmation_proof_path: proofPath,
+          confirmation_proof_hash: proofHash,
+          owner_attestation_accepted_at: new Date().toISOString(),
+          proof_status: "submitted",
+          proof_rejected_reason: null,
+        })
+        .eq("id", listingId);
+
+      if (updateError) {
+        await supabase.storage.from("listing-proofs").remove([proofPath]);
+        throw new Error(updateError.message);
+      }
+
+      toast.success("Proof resubmitted — our team will review shortly.");
+      onOpenChange(false);
+      onSuccess?.();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Resubmit failed");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Shield className="w-5 h-5" />
+            Re-upload Reservation Proof
+          </DialogTitle>
+          <DialogDescription>
+            Update the confirmation number and file, then confirm. Our team will review again within
+            a business day.
+          </DialogDescription>
+        </DialogHeader>
+
+        {rejectedReason && (
+          <div className="bg-red-50 border border-red-200 rounded-md p-3 text-sm">
+            <p className="font-medium text-red-800 mb-1 flex items-center gap-1.5">
+              <AlertTriangle className="w-4 h-4" />
+              Why the previous upload was rejected
+            </p>
+            <p className="text-red-700">{rejectedReason}</p>
+          </div>
+        )}
+
+        <div className="space-y-4">
+          <div>
+            <Label htmlFor="reupload-number" className="text-sm font-medium">
+              Resort Confirmation Number
+            </Label>
+            <Input
+              id="reupload-number"
+              type="text"
+              value={confirmationNumber}
+              onChange={(e) => setConfirmationNumber(e.target.value)}
+              placeholder="e.g. HLT-8472291"
+            />
+            <p className="text-xs text-muted-foreground mt-1">
+              The code on your reservation email from the resort.
+            </p>
+          </div>
+
+          <div>
+            <Label htmlFor="reupload-file" className="text-sm font-medium">
+              Upload Reservation Email (PDF / JPG / PNG)
+            </Label>
+            <Input
+              id="reupload-file"
+              type="file"
+              accept="application/pdf,image/jpeg,image/png"
+              onChange={handleFileChange}
+              className="mt-1"
+            />
+            {fileError ? (
+              <p className="text-xs text-destructive mt-1 flex items-start gap-1">
+                <AlertTriangle className="w-3 h-3 mt-0.5 flex-shrink-0" />
+                <span>{fileError}</span>
+              </p>
+            ) : (
+              <p className="text-xs text-muted-foreground mt-1">
+                Up to {Math.round(MAX_PROOF_FILE_SIZE_BYTES / 1024 / 1024)}&nbsp;MB. Only RAV staff and you can see this file.
+              </p>
+            )}
+          </div>
+
+          <div className="flex items-start gap-2 pt-1">
+            <Checkbox
+              id="reupload-attestation"
+              checked={attestationAccepted}
+              onCheckedChange={(checked) => setAttestationAccepted(!!checked)}
+            />
+            <Label htmlFor="reupload-attestation" className="text-xs leading-snug">
+              I confirm this reservation is genuine and held under my name.
+              I understand misrepresenting a reservation may result in account
+              suspension and legal action.
+            </Label>
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={submitting}>
+            Cancel
+          </Button>
+          <Button onClick={handleSubmit} disabled={!canSubmit}>
+            {submitting ? (
+              <>
+                <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                Submitting...
+              </>
+            ) : (
+              "Resubmit Proof"
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/lib/listingProof.test.ts
+++ b/src/lib/listingProof.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from "vitest";
+import {
+  isProofRequired,
+  PROOF_STATUS_LABELS,
+  PROOF_STATUS_BADGE_CLASSES,
+  PROOF_STATUS_DESCRIPTIONS,
+  validateProofFile,
+  buildProofStoragePath,
+  hashFile,
+  MAX_PROOF_FILE_SIZE_BYTES,
+} from "./listingProof";
+
+describe("isProofRequired @p0", () => {
+  it("requires proof for pre_booked", () => {
+    expect(isProofRequired("pre_booked")).toBe(true);
+  });
+  it("does not require proof for wish_matched (proof is post-acceptance)", () => {
+    expect(isProofRequired("wish_matched")).toBe(false);
+  });
+});
+
+describe("status dictionaries are exhaustive and consistent", () => {
+  const statuses = [
+    "not_required",
+    "required",
+    "submitted",
+    "verified",
+    "rejected",
+  ] as const;
+
+  it.each(statuses)("has label, badge class, and description for %s", (status) => {
+    expect(PROOF_STATUS_LABELS[status]).toBeTruthy();
+    expect(PROOF_STATUS_BADGE_CLASSES[status]).toBeTruthy();
+    expect(PROOF_STATUS_DESCRIPTIONS[status]).toBeTruthy();
+  });
+
+  it("descriptions stay under ~15 words per the help-text-everywhere rule", () => {
+    for (const status of statuses) {
+      const wordCount = PROOF_STATUS_DESCRIPTIONS[status].split(/\s+/).length;
+      expect(wordCount).toBeLessThanOrEqual(18);
+    }
+  });
+});
+
+describe("validateProofFile", () => {
+  function makeFile(name: string, type: string, size: number): File {
+    return new File([new Uint8Array(size)], name, { type });
+  }
+
+  it("accepts a PDF under 10 MB", () => {
+    expect(validateProofFile(makeFile("proof.pdf", "application/pdf", 1024))).toBeNull();
+  });
+
+  it("accepts JPEG and PNG", () => {
+    expect(validateProofFile(makeFile("a.jpg", "image/jpeg", 1024))).toBeNull();
+    expect(validateProofFile(makeFile("a.png", "image/png", 1024))).toBeNull();
+  });
+
+  it("rejects unsupported MIME types with helpful copy", () => {
+    const err = validateProofFile(makeFile("a.docx", "application/msword", 1024));
+    expect(err?.field).toBe("mime");
+    expect(err?.message).toMatch(/PDF, JPEG, or PNG/);
+  });
+
+  it("rejects files over the 10 MB cap with helpful copy", () => {
+    const err = validateProofFile(
+      makeFile("big.pdf", "application/pdf", MAX_PROOF_FILE_SIZE_BYTES + 1),
+    );
+    expect(err?.field).toBe("size");
+    expect(err?.message).toMatch(/10 MB/);
+  });
+});
+
+describe("buildProofStoragePath", () => {
+  it("scopes the path under the owner's user id (matches RLS folder check)", () => {
+    const path = buildProofStoragePath("owner-123", "listing-abc", "conf.pdf");
+    expect(path.startsWith("owner-123/listing-abc/")).toBe(true);
+  });
+
+  it("sanitizes dangerous characters in file names", () => {
+    const path = buildProofStoragePath("o1", "l1", "../../etc/passwd");
+    expect(path).not.toContain("..");
+    expect(path).not.toContain("/etc/");
+  });
+});
+
+describe("hashFile", () => {
+  it("produces a 64-character lowercase hex SHA-256", async () => {
+    const file = new File(["hello world"], "test.txt", { type: "text/plain" });
+    const hash = await hashFile(file);
+    expect(hash).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("is stable for the same content", async () => {
+    const a = new File(["same"], "a.txt", { type: "text/plain" });
+    const b = new File(["same"], "b.txt", { type: "text/plain" });
+    expect(await hashFile(a)).toBe(await hashFile(b));
+  });
+
+  it("differs when content differs", async () => {
+    const a = new File(["one"], "a.txt", { type: "text/plain" });
+    const b = new File(["two"], "b.txt", { type: "text/plain" });
+    expect(await hashFile(a)).not.toBe(await hashFile(b));
+  });
+});

--- a/src/lib/listingProof.ts
+++ b/src/lib/listingProof.ts
@@ -1,0 +1,123 @@
+// Pure-logic helpers for the Pre-Booked listing proof workflow.
+// #376 — owner uploads resort-reservation proof at list-creation time;
+// admin verifies before the listing becomes active.
+
+import type { Database } from "@/types/database";
+
+export type ListingProofStatus = Database["public"]["Enums"]["listing_proof_status"];
+export type ListingSourceType = Database["public"]["Enums"]["listing_source_type"];
+
+/**
+ * Only Pre-Booked listings require proof at list-creation time. Wish-Matched
+ * listings collect their confirmation post-acceptance via booking_confirmations.
+ */
+export function isProofRequired(sourceType: ListingSourceType): boolean {
+  return sourceType === "pre_booked";
+}
+
+export const PROOF_STATUS_LABELS: Record<ListingProofStatus, string> = {
+  not_required: "Not required",
+  required: "Awaiting upload",
+  submitted: "Pending review",
+  verified: "Verified",
+  rejected: "Rejected",
+};
+
+/**
+ * Tailwind class string mapping proof status to a consistent badge color.
+ * Exported as strings (not a component) so both owner and admin surfaces
+ * render the same visual treatment without importing each other.
+ */
+export const PROOF_STATUS_BADGE_CLASSES: Record<ListingProofStatus, string> = {
+  not_required: "bg-slate-100 text-slate-600",
+  required: "bg-amber-100 text-amber-800",
+  submitted: "bg-blue-100 text-blue-800",
+  verified: "bg-emerald-100 text-emerald-800",
+  rejected: "bg-red-100 text-red-700",
+};
+
+/**
+ * Short guiding copy for each status, shown under the badge on admin +
+ * owner surfaces. Must stay under ~15 words per the help-text-everywhere rule.
+ */
+export const PROOF_STATUS_DESCRIPTIONS: Record<ListingProofStatus, string> = {
+  not_required:
+    "Wish-Matched listings confirm after a traveler accepts the Offer.",
+  required: "Owner needs to upload a reservation proof before we can verify.",
+  submitted: "Admin review pending — we'll confirm this with the resort.",
+  verified: "Admin confirmed the reservation is genuine.",
+  rejected: "Previous upload was rejected. Owner needs to re-upload with a correct file.",
+};
+
+async function readAsArrayBuffer(file: File | Blob): Promise<ArrayBuffer> {
+  // Browsers + modern jsdom expose File.arrayBuffer(); fall back to FileReader
+  // for older test envs.
+  if (typeof (file as Blob).arrayBuffer === "function") {
+    return (file as Blob).arrayBuffer();
+  }
+  return new Promise<ArrayBuffer>((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result as ArrayBuffer);
+    reader.onerror = () => reject(reader.error);
+    reader.readAsArrayBuffer(file as Blob);
+  });
+}
+
+/**
+ * Compute SHA-256 hash of a File using the Web Crypto API. Used to enforce
+ * cross-owner dedup — the same proof PDF cannot be reused on a different
+ * owner's listing (migration 064 adds a UNIQUE index on this column).
+ * Returns a lowercase hex string.
+ */
+export async function hashFile(file: File | Blob): Promise<string> {
+  const buffer = await readAsArrayBuffer(file);
+  const digest = await crypto.subtle.digest("SHA-256", buffer);
+  return Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+export const MAX_PROOF_FILE_SIZE_BYTES = 10 * 1024 * 1024; // 10 MB
+export const ACCEPTED_PROOF_MIME_TYPES = [
+  "application/pdf",
+  "image/jpeg",
+  "image/png",
+] as const;
+
+export interface ProofFileValidationError {
+  field: "file" | "mime" | "size";
+  message: string;
+}
+
+export function validateProofFile(file: File): ProofFileValidationError | null {
+  if (!file) {
+    return { field: "file", message: "Please choose a file to upload." };
+  }
+  if (!(ACCEPTED_PROOF_MIME_TYPES as readonly string[]).includes(file.type)) {
+    return {
+      field: "mime",
+      message: "File must be a PDF, JPEG, or PNG — that's what resort confirmation emails typically come as.",
+    };
+  }
+  if (file.size > MAX_PROOF_FILE_SIZE_BYTES) {
+    return {
+      field: "size",
+      message: "File is over 10 MB. Most resort confirmations are well under this — try saving the email as PDF without attachments.",
+    };
+  }
+  return null;
+}
+
+/**
+ * Build the storage object path for a given owner's proof file. Path layout
+ * aligns with the migration-064 RLS policy (folder prefix = owner's user id).
+ */
+export function buildProofStoragePath(ownerId: string, listingId: string, fileName: string): string {
+  // Strip path-traversal sequences first, then replace anything that isn't a
+  // safe character set.
+  const sanitized = fileName
+    .replace(/\.{2,}/g, "") // collapse any "..", "...", etc.
+    .replace(/[/\\]/g, "_") // path separators → underscore
+    .replace(/[^a-zA-Z0-9._-]/g, "_"); // everything else non-safe → underscore
+  return `${ownerId}/${listingId}/${Date.now()}-${sanitized}`;
+}

--- a/src/lib/listingProof.ts
+++ b/src/lib/listingProof.ts
@@ -49,15 +49,37 @@ export const PROOF_STATUS_DESCRIPTIONS: Record<ListingProofStatus, string> = {
   rejected: "Previous upload was rejected. Owner needs to re-upload with a correct file.",
 };
 
-async function readAsArrayBuffer(file: File | Blob): Promise<ArrayBuffer> {
-  // Browsers + modern jsdom expose File.arrayBuffer(); fall back to FileReader
-  // for older test envs.
+/**
+ * Normalize a File/Blob into a Uint8Array across environments. Browsers +
+ * modern jsdom expose File.arrayBuffer(); older jsdom in CI doesn't, and its
+ * FileReader shim can return values that crypto.subtle.digest rejects. We
+ * coerce everything to Uint8Array (which SubtleCrypto always accepts as a
+ * TypedArray) so the hash path is identical on Windows local + Ubuntu CI.
+ */
+async function readAsUint8Array(file: File | Blob): Promise<Uint8Array> {
   if (typeof (file as Blob).arrayBuffer === "function") {
-    return (file as Blob).arrayBuffer();
+    const buf = await (file as Blob).arrayBuffer();
+    return new Uint8Array(buf);
   }
-  return new Promise<ArrayBuffer>((resolve, reject) => {
+  if (typeof (file as Blob).text === "function") {
+    // Text path — safe for the content files we accept (PDF/JPEG/PNG) since
+    // they're read as bytes by the browser; TextEncoder round-trips arbitrary
+    // bytes consistently enough for dedup purposes (same bytes → same hash).
+    return new TextEncoder().encode(await (file as Blob).text());
+  }
+  return new Promise<Uint8Array>((resolve, reject) => {
     const reader = new FileReader();
-    reader.onload = () => resolve(reader.result as ArrayBuffer);
+    reader.onload = () => {
+      const result = reader.result;
+      if (result instanceof ArrayBuffer) {
+        resolve(new Uint8Array(result));
+      } else if (result && typeof result === "object" && "byteLength" in (result as object)) {
+        // Node Buffer / jsdom Buffer-like
+        resolve(new Uint8Array(result as unknown as ArrayBufferLike));
+      } else {
+        resolve(new TextEncoder().encode(String(result ?? "")));
+      }
+    };
     reader.onerror = () => reject(reader.error);
     reader.readAsArrayBuffer(file as Blob);
   });
@@ -70,8 +92,8 @@ async function readAsArrayBuffer(file: File | Blob): Promise<ArrayBuffer> {
  * Returns a lowercase hex string.
  */
 export async function hashFile(file: File | Blob): Promise<string> {
-  const buffer = await readAsArrayBuffer(file);
-  const digest = await crypto.subtle.digest("SHA-256", buffer);
+  const bytes = await readAsUint8Array(file);
+  const digest = await crypto.subtle.digest("SHA-256", bytes);
   return Array.from(new Uint8Array(digest))
     .map((b) => b.toString(16).padStart(2, "0"))
     .join("");

--- a/src/pages/ListProperty.tsx
+++ b/src/pages/ListProperty.tsx
@@ -25,7 +25,19 @@ import {
   Users,
   Star,
   MapPin,
+  FileUp,
+  Gavel,
+  AlertTriangle,
 } from "lucide-react";
+import { Switch } from "@/components/ui/switch";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Label } from "@/components/ui/label";
+import {
+  hashFile,
+  validateProofFile,
+  buildProofStoragePath,
+  MAX_PROOF_FILE_SIZE_BYTES,
+} from "@/lib/listingProof";
 import type { VacationClubBrand, Resort, ResortUnitType } from "@/types/database";
 import { supabase } from "@/lib/supabase";
 import { PricingSuggestion } from "@/components/owner/PricingSuggestion";
@@ -115,6 +127,15 @@ interface ListPropertyDraft {
   nightlyRate: string;
   cleaningFee: string;
   cancellationPolicy: CancellationPolicy;
+  // #376 proof + #378 bidding (file is NOT persisted in draft — too big for
+  // localStorage; confirmation number + bidding fields are fine)
+  resortConfirmationNumber?: string;
+  ownerAttestationAccepted?: boolean;
+  openForBidding?: boolean;
+  minBidAmount?: string;
+  biddingEndsAt?: string;
+  reservePrice?: string;
+  allowCounterOffers?: boolean;
 }
 
 function saveDraft(draft: ListPropertyDraft) {
@@ -170,6 +191,25 @@ const ListProperty = () => {
   const [cleaningFee, setCleaningFee] = useState(draft?.cleaningFee || "");
   const [cancellationPolicy, setCancellationPolicy] = useState<CancellationPolicy>(draft?.cancellationPolicy || "");
 
+  // #376 Pre-Booked reservation proof
+  const [resortConfirmationNumber, setResortConfirmationNumber] = useState(
+    draft?.resortConfirmationNumber || "",
+  );
+  const [proofFile, setProofFile] = useState<File | null>(null);
+  const [proofFileError, setProofFileError] = useState<string | null>(null);
+  const [ownerAttestationAccepted, setOwnerAttestationAccepted] = useState(
+    draft?.ownerAttestationAccepted || false,
+  );
+
+  // #378 Bidding configuration (data model already exists on listings)
+  const [openForBidding, setOpenForBidding] = useState(draft?.openForBidding || false);
+  const [minBidAmount, setMinBidAmount] = useState(draft?.minBidAmount || "");
+  const [biddingEndsAt, setBiddingEndsAt] = useState(draft?.biddingEndsAt || "");
+  const [reservePrice, setReservePrice] = useState(draft?.reservePrice || "");
+  const [allowCounterOffers, setAllowCounterOffers] = useState(
+    draft?.allowCounterOffers ?? true,
+  );
+
   // Submission state
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
@@ -186,7 +226,8 @@ const ListProperty = () => {
 
   const todayStr = new Date().toISOString().split("T")[0];
 
-  // Auto-save draft on form changes
+  // Auto-save draft on form changes. Note: proofFile is deliberately NOT
+  // persisted — too large for localStorage. Owner re-selects on reload.
   useEffect(() => {
     if (formStep > 1 || selectedBrand || resortName) {
       saveDraft({
@@ -204,9 +245,16 @@ const ListProperty = () => {
         nightlyRate,
         cleaningFee,
         cancellationPolicy,
+        resortConfirmationNumber,
+        ownerAttestationAccepted,
+        openForBidding,
+        minBidAmount,
+        biddingEndsAt,
+        reservePrice,
+        allowCounterOffers,
       });
     }
-  }, [formStep, selectedBrand, isManualEntry, resortName, location, bedrooms, bathrooms, sleeps, description, checkInDate, checkOutDate, nightlyRate, cleaningFee, cancellationPolicy]);
+  }, [formStep, selectedBrand, isManualEntry, resortName, location, bedrooms, bathrooms, sleeps, description, checkInDate, checkOutDate, nightlyRate, cleaningFee, cancellationPolicy, resortConfirmationNumber, ownerAttestationAccepted, openForBidding, minBidAmount, biddingEndsAt, reservePrice, allowCounterOffers]);
 
   // Load full resort details when selected
   useEffect(() => {
@@ -266,9 +314,45 @@ const ListProperty = () => {
       ? resortName && location && bedrooms && bathrooms && sleeps
       : selectedResort && selectedUnitType;
 
+  // Proof requirements (#376) — Pre-Booked listings require proof at list time.
+  const proofReady =
+    resortConfirmationNumber.trim().length >= 4 &&
+    proofFile !== null &&
+    !proofFileError &&
+    ownerAttestationAccepted;
+
+  // Bidding requirements (#378) — when enabled, minimum fields must be set.
+  const biddingReady =
+    !openForBidding ||
+    (
+      minBidAmount !== "" &&
+      parseFloat(minBidAmount) > 0 &&
+      biddingEndsAt !== "" &&
+      new Date(biddingEndsAt) > new Date()
+    );
+
   const canProceedStep2 =
-    checkInDate && checkOutDate && nightlyRate && cancellationPolicy &&
-    calculateNights(checkInDate, checkOutDate) > 0;
+    !!(checkInDate && checkOutDate && nightlyRate && cancellationPolicy &&
+      calculateNights(checkInDate, checkOutDate) > 0) &&
+    proofReady &&
+    biddingReady;
+
+  function handleProofFileChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0] ?? null;
+    if (!file) {
+      setProofFile(null);
+      setProofFileError(null);
+      return;
+    }
+    const err = validateProofFile(file);
+    if (err) {
+      setProofFile(null);
+      setProofFileError(err.message);
+      return;
+    }
+    setProofFile(file);
+    setProofFileError(null);
+  }
 
   async function handleSubmit() {
     if (!user || !isPropertyOwner()) return;
@@ -304,7 +388,42 @@ const ListProperty = () => {
 
       if (propError || !newProperty) throw new Error(propError?.message || "Failed to create property");
 
-      // 2. Create listing (use tier-aware commission rate)
+      // 2. Prepare proof: hash file client-side, pre-check for dedup so the
+      //    owner gets a fast, human-readable error if they're reusing a file.
+      //    The DB-level UNIQUE index is the authoritative guard; this is just
+      //    a UX nicety that avoids a wasted storage upload.
+      if (!proofFile) {
+        throw new Error("Reservation proof is required.");
+      }
+      const proofHash = await hashFile(proofFile);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const { data: existingHashRow } = await (supabase as any)
+        .from("listings")
+        .select("id")
+        .eq("confirmation_proof_hash", proofHash)
+        .maybeSingle();
+      if (existingHashRow) {
+        throw new Error(
+          "This proof file has already been used on another listing. Please upload the reservation email for this specific trip.",
+        );
+      }
+
+      // 3. Generate listing id client-side so we can scope the storage path
+      //    to the listing before inserting. If the upload succeeds but the
+      //    insert fails, we orphan the file — acceptable (cleanup job can
+      //    sweep; owner retries without re-uploading).
+      const newListingId = (globalThis.crypto ?? crypto).randomUUID();
+      const proofPath = buildProofStoragePath(user.id, newListingId, proofFile.name);
+
+      const { error: uploadError } = await supabase.storage
+        .from("listing-proofs")
+        .upload(proofPath, proofFile, {
+          contentType: proofFile.type,
+          upsert: false,
+        });
+      if (uploadError) throw new Error(`Proof upload failed: ${uploadError.message}`);
+
+      // 4. Create listing (use tier-aware commission rate)
       const rate = parseFloat(nightlyRate);
       const cleaning = parseFloat(cleaningFee) || 0;
       const nights = calculateNights(checkInDate, checkOutDate);
@@ -313,6 +432,7 @@ const ListProperty = () => {
       const finalPrice = ownerPrice + ravMarkup;
 
       const listingData = {
+        id: newListingId,
         property_id: (newProperty as { id: string }).id,
         owner_id: user.id,
         check_in_date: checkInDate,
@@ -325,13 +445,30 @@ const ListProperty = () => {
         final_price: finalPrice,
         cancellation_policy: cancellationPolicy,
         status: "pending_approval",
+        // #376 proof fields
+        resort_confirmation_number: resortConfirmationNumber.trim(),
+        confirmation_proof_path: proofPath,
+        confirmation_proof_hash: proofHash,
+        owner_attestation_accepted_at: new Date().toISOString(),
+        proof_status: "submitted",
+        // #378 bidding fields (only when enabled)
+        open_for_bidding: openForBidding,
+        min_bid_amount: openForBidding ? parseFloat(minBidAmount) : null,
+        bidding_ends_at: openForBidding ? new Date(biddingEndsAt).toISOString() : null,
+        reserve_price: openForBidding && reservePrice ? parseFloat(reservePrice) : null,
+        allow_counter_offers: openForBidding ? allowCounterOffers : true,
       };
 
       const { error: listError } = await supabase
         .from("listings")
         .insert(listingData as never);
 
-      if (listError) throw new Error(listError.message);
+      if (listError) {
+        // Best-effort cleanup of the orphaned proof file so storage doesn't
+        // leak when the insert fails (e.g. FK or constraint violation).
+        await supabase.storage.from("listing-proofs").remove([proofPath]);
+        throw new Error(listError.message);
+      }
 
       // Track listing creation
       trackEvent('listing_created', {
@@ -780,6 +917,165 @@ const ListProperty = () => {
                     </Select>
                   </div>
 
+                  {/* #378 Open for Bidding toggle ---------------------- */}
+                  <div className="rounded-lg border p-4 space-y-3 bg-card">
+                    <div className="flex items-start justify-between gap-4">
+                      <div className="flex-1">
+                        <div className="flex items-center gap-2">
+                          <Gavel className="w-4 h-4 text-primary" />
+                          <Label htmlFor="open-for-bidding" className="font-medium">
+                            Open for Offers
+                          </Label>
+                        </div>
+                        <p className="text-xs text-muted-foreground mt-1">
+                          Let travelers submit Offers for your Listing in addition to booking at
+                          the direct price. You set a minimum and a deadline.
+                        </p>
+                      </div>
+                      <Switch
+                        id="open-for-bidding"
+                        checked={openForBidding}
+                        onCheckedChange={setOpenForBidding}
+                      />
+                    </div>
+
+                    {openForBidding && (
+                      <div className="space-y-3 pt-2 border-t">
+                        <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+                          <div>
+                            <Label htmlFor="min-bid" className="text-xs font-medium">
+                              Minimum Offer ($)
+                            </Label>
+                            <Input
+                              id="min-bid"
+                              type="number"
+                              min="1"
+                              value={minBidAmount}
+                              onChange={(e) => setMinBidAmount(e.target.value)}
+                              placeholder="e.g. 150"
+                            />
+                            <p className="text-xs text-muted-foreground mt-1">
+                              Travelers can't submit an Offer below this.
+                            </p>
+                          </div>
+                          <div>
+                            <Label htmlFor="bidding-ends" className="text-xs font-medium">
+                              Offers Close
+                            </Label>
+                            <Input
+                              id="bidding-ends"
+                              type="datetime-local"
+                              min={new Date(Date.now() + 60_000).toISOString().slice(0, 16)}
+                              value={biddingEndsAt}
+                              onChange={(e) => setBiddingEndsAt(e.target.value)}
+                            />
+                            <p className="text-xs text-muted-foreground mt-1">
+                              After this, no new Offers accepted.
+                            </p>
+                          </div>
+                        </div>
+                        <div>
+                          <Label htmlFor="reserve-price" className="text-xs font-medium">
+                            Reserve Price ($)
+                            <span className="text-muted-foreground font-normal"> — optional</span>
+                          </Label>
+                          <Input
+                            id="reserve-price"
+                            type="number"
+                            min="0"
+                            value={reservePrice}
+                            onChange={(e) => setReservePrice(e.target.value)}
+                            placeholder="e.g. 250"
+                          />
+                          <p className="text-xs text-muted-foreground mt-1">
+                            Hidden floor — Offers below this are auto-declined. Leave blank to review every Offer yourself.
+                          </p>
+                        </div>
+                        <div className="flex items-start gap-2">
+                          <Checkbox
+                            id="allow-counter"
+                            checked={allowCounterOffers}
+                            onCheckedChange={(checked) => setAllowCounterOffers(!!checked)}
+                          />
+                          <div className="flex-1">
+                            <Label htmlFor="allow-counter" className="text-sm">
+                              Allow counter-offers
+                            </Label>
+                            <p className="text-xs text-muted-foreground">
+                              Travelers can negotiate back after you counter their Offer.
+                            </p>
+                          </div>
+                        </div>
+                      </div>
+                    )}
+                  </div>
+
+                  {/* #376 Reservation Proof --------------------------------- */}
+                  <div className="rounded-lg border p-4 space-y-3 bg-card">
+                    <div className="flex items-center gap-2">
+                      <Shield className="w-4 h-4 text-primary" />
+                      <h4 className="font-medium">Reservation Proof</h4>
+                    </div>
+                    <p className="text-xs text-muted-foreground">
+                      Since you already have this resort reservation, we verify it before your Listing goes live. This protects travelers (and you) from double-booking issues. It only takes a day or two.
+                    </p>
+
+                    <div>
+                      <Label htmlFor="confirmation-number" className="text-xs font-medium">
+                        Resort Confirmation Number
+                      </Label>
+                      <Input
+                        id="confirmation-number"
+                        type="text"
+                        value={resortConfirmationNumber}
+                        onChange={(e) => setResortConfirmationNumber(e.target.value)}
+                        placeholder="e.g. HLT-8472291"
+                      />
+                      <p className="text-xs text-muted-foreground mt-1">
+                        The confirmation code on your reservation email from the resort.
+                      </p>
+                    </div>
+
+                    <div>
+                      <Label htmlFor="proof-file" className="text-xs font-medium">
+                        Upload Reservation Email (PDF / JPG / PNG)
+                      </Label>
+                      <div className="flex items-center gap-2 mt-1">
+                        <Input
+                          id="proof-file"
+                          type="file"
+                          accept="application/pdf,image/jpeg,image/png"
+                          onChange={handleProofFileChange}
+                          className="flex-1"
+                        />
+                        {proofFile && <FileUp className="w-4 h-4 text-emerald-600" />}
+                      </div>
+                      {proofFileError ? (
+                        <p className="text-xs text-destructive mt-1 flex items-start gap-1">
+                          <AlertTriangle className="w-3 h-3 mt-0.5 flex-shrink-0" />
+                          <span>{proofFileError}</span>
+                        </p>
+                      ) : (
+                        <p className="text-xs text-muted-foreground mt-1">
+                          Your confirmation email as PDF is easiest. Up to {Math.round(MAX_PROOF_FILE_SIZE_BYTES / 1024 / 1024)}&nbsp;MB. Only RAV staff and you can see this file.
+                        </p>
+                      )}
+                    </div>
+
+                    <div className="flex items-start gap-2 pt-1">
+                      <Checkbox
+                        id="attestation"
+                        checked={ownerAttestationAccepted}
+                        onCheckedChange={(checked) => setOwnerAttestationAccepted(!!checked)}
+                      />
+                      <Label htmlFor="attestation" className="text-xs leading-snug">
+                        I confirm this reservation is genuine and held under my name.
+                        I understand misrepresenting a reservation may result in account
+                        suspension and legal action.
+                      </Label>
+                    </div>
+                  </div>
+
                   {/* Pricing preview */}
                   {pricingPreview && (
                     <div className="bg-primary/5 rounded-lg p-4 space-y-2">
@@ -901,6 +1197,8 @@ const ListProperty = () => {
                               formStep, selectedBrand, isManualEntry, resortName, location,
                               bedrooms, bathrooms, sleeps, description,
                               checkInDate, checkOutDate, nightlyRate, cleaningFee, cancellationPolicy,
+                              resortConfirmationNumber, ownerAttestationAccepted,
+                              openForBidding, minBidAmount, biddingEndsAt, reservePrice, allowCounterOffers,
                             });
                             navigate("/signup");
                           }}
@@ -925,6 +1223,8 @@ const ListProperty = () => {
                               formStep, selectedBrand, isManualEntry, resortName, location,
                               bedrooms, bathrooms, sleeps, description,
                               checkInDate, checkOutDate, nightlyRate, cleaningFee, cancellationPolicy,
+                              resortConfirmationNumber, ownerAttestationAccepted,
+                              openForBidding, minBidAmount, biddingEndsAt, reservePrice, allowCounterOffers,
                             });
                             setUpgradeDialogOpen(true);
                           }}

--- a/src/pages/PropertyDetail.tsx
+++ b/src/pages/PropertyDetail.tsx
@@ -29,6 +29,7 @@ import {
   Clock,
   ShieldCheck,
   Shield,
+  Gavel,
 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { ListingTypeBadge } from "@/components/marketplace/ListingTypeBadge";
@@ -375,6 +376,14 @@ const PropertyDetail = () => {
                 {/* Social proof + type badges */}
                 <div className="flex flex-wrap items-center gap-2 mb-4">
                   <ListingTypeBadge type={(listing as { source_type?: "pre_booked" | "wish_matched" })?.source_type ?? "pre_booked"} />
+                  {/* #378 Persistent bidding badge — used to be buried in the
+                      "Need Help?" collapsible; now above the fold next to type. */}
+                  {isBiddable && (
+                    <Badge className="bg-amber-500/95 text-white border-0">
+                      <Gavel className="w-3 h-3 mr-1" />
+                      Open for Offers
+                    </Badge>
+                  )}
                   {popularityLabel && (
                     <Badge className="bg-orange-500/90 text-white border-0">
                       <Flame className="w-3 h-3 mr-1" />

--- a/src/test/helpers/render.tsx
+++ b/src/test/helpers/render.tsx
@@ -2,6 +2,7 @@ import React, { type ReactElement } from "react";
 import { render, type RenderOptions } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter } from "react-router-dom";
+import { TooltipProvider } from "@/components/ui/tooltip";
 
 interface ProvidersOptions {
   /** Initial route entries for MemoryRouter */
@@ -29,7 +30,9 @@ function createWrapper(options: ProvidersOptions = {}) {
   return function Wrapper({ children }: { children: React.ReactNode }) {
     return (
       <QueryClientProvider client={queryClient}>
-        <MemoryRouter initialEntries={initialEntries}>{children}</MemoryRouter>
+        <MemoryRouter initialEntries={initialEntries}>
+          <TooltipProvider>{children}</TooltipProvider>
+        </MemoryRouter>
       </QueryClientProvider>
     );
   };

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -734,6 +734,7 @@ export type Database = {
       }
       listings: {
         Row: {
+          admin_phone_verification_notes: string | null
           allow_counter_offers: boolean
           approved_at: string | null
           approved_by: string | null
@@ -742,6 +743,10 @@ export type Database = {
           check_in_date: string
           check_out_date: string
           cleaning_fee: number | null
+          confirmation_proof_hash: string | null
+          confirmation_proof_path: string | null
+          confirmation_verified_at: string | null
+          confirmation_verified_by: string | null
           created_at: string
           final_price: number
           id: string
@@ -749,17 +754,22 @@ export type Database = {
           nightly_rate: number
           notes: string | null
           open_for_bidding: boolean
+          owner_attestation_accepted_at: string | null
           owner_id: string
           owner_price: number
+          proof_rejected_reason: string | null
+          proof_status: Database["public"]["Enums"]["listing_proof_status"]
           property_id: string
           rav_markup: number
           reserve_price: number | null
+          resort_confirmation_number: string | null
           resort_fee: number | null
           source_type: Database["public"]["Enums"]["listing_source_type"]
           status: Database["public"]["Enums"]["listing_status"]
           updated_at: string
         }
         Insert: {
+          admin_phone_verification_notes?: string | null
           allow_counter_offers?: boolean
           approved_at?: string | null
           approved_by?: string | null
@@ -768,6 +778,10 @@ export type Database = {
           check_in_date: string
           check_out_date: string
           cleaning_fee?: number | null
+          confirmation_proof_hash?: string | null
+          confirmation_proof_path?: string | null
+          confirmation_verified_at?: string | null
+          confirmation_verified_by?: string | null
           created_at?: string
           final_price: number
           id?: string
@@ -775,17 +789,22 @@ export type Database = {
           nightly_rate?: number
           notes?: string | null
           open_for_bidding?: boolean
+          owner_attestation_accepted_at?: string | null
           owner_id: string
           owner_price: number
+          proof_rejected_reason?: string | null
+          proof_status?: Database["public"]["Enums"]["listing_proof_status"]
           property_id: string
           rav_markup?: number
           reserve_price?: number | null
+          resort_confirmation_number?: string | null
           resort_fee?: number | null
           source_type?: Database["public"]["Enums"]["listing_source_type"]
           status?: Database["public"]["Enums"]["listing_status"]
           updated_at?: string
         }
         Update: {
+          admin_phone_verification_notes?: string | null
           allow_counter_offers?: boolean
           approved_at?: string | null
           approved_by?: string | null
@@ -794,6 +813,10 @@ export type Database = {
           check_in_date?: string
           check_out_date?: string
           cleaning_fee?: number | null
+          confirmation_proof_hash?: string | null
+          confirmation_proof_path?: string | null
+          confirmation_verified_at?: string | null
+          confirmation_verified_by?: string | null
           created_at?: string
           final_price?: number
           id?: string
@@ -801,11 +824,15 @@ export type Database = {
           nightly_rate?: number
           notes?: string | null
           open_for_bidding?: boolean
+          owner_attestation_accepted_at?: string | null
           owner_id?: string
           owner_price?: number
+          proof_rejected_reason?: string | null
+          proof_status?: Database["public"]["Enums"]["listing_proof_status"]
           property_id?: string
           rav_markup?: number
           reserve_price?: number | null
+          resort_confirmation_number?: string | null
           resort_fee?: number | null
           source_type?: Database["public"]["Enums"]["listing_source_type"]
           status?: Database["public"]["Enums"]["listing_status"]
@@ -2392,6 +2419,12 @@ export type Database = {
         | "released"
         | "refunded"
         | "disputed"
+      listing_proof_status:
+        | "not_required"
+        | "required"
+        | "submitted"
+        | "verified"
+        | "rejected"
       listing_source_type: "pre_booked" | "wish_matched"
       listing_status:
         | "draft"

--- a/supabase/migrations/064_listing_proof.sql
+++ b/supabase/migrations/064_listing_proof.sql
@@ -1,0 +1,185 @@
+-- Migration 064: Pre-Booked listing reservation proof workflow
+-- #376 (Audit #2) — DEC-034 follow-up. Owner uploads resort-reservation
+-- proof at list-creation time for Pre-Booked Stays; admin verifies before
+-- listing becomes active/visible. Wish-Matched Stays are out of scope —
+-- their proof path runs post-acceptance via booking_confirmations.
+--
+-- Anti-scam layers in v1:
+--   A. confirmation number + file upload
+--   B. owner attestation checkbox with legal language (stored as timestamp)
+--   C. file-hash dedup — unique index rejects reuse of the same proof file
+--      across owners' listings
+--   D. admin manual review via AdminListings verify/reject dialog
+--   G. admin phone-verification checklist (stored as admin_phone_verification_notes)
+--
+-- CHECK constraint is intentionally NOT enforced at the DB layer — the
+-- workflow (pending_approval → verified → active) is enforced by app logic
+-- + admin UI. A mixed status/source_type/proof_status CHECK would block
+-- legitimate admin rework paths.
+
+-- ── Enum ────────────────────────────────────────────────────────────────────
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'listing_proof_status') THEN
+    CREATE TYPE public.listing_proof_status AS ENUM (
+      'not_required',  -- wish_matched listings; proof collected post-acceptance
+      'required',      -- pre_booked listing submitted, owner has not uploaded yet
+      'submitted',     -- owner uploaded proof, awaiting admin review
+      'verified',      -- admin approved proof; listing can go active
+      'rejected'       -- admin rejected; owner must re-upload. proof_rejected_reason populated.
+    );
+  END IF;
+END $$;
+
+-- ── Columns on listings ─────────────────────────────────────────────────────
+ALTER TABLE public.listings
+  ADD COLUMN IF NOT EXISTS proof_status public.listing_proof_status
+    NOT NULL DEFAULT 'not_required',
+  ADD COLUMN IF NOT EXISTS resort_confirmation_number       text,
+  ADD COLUMN IF NOT EXISTS confirmation_proof_path          text,
+  ADD COLUMN IF NOT EXISTS confirmation_proof_hash          text,
+  ADD COLUMN IF NOT EXISTS proof_rejected_reason            text,
+  ADD COLUMN IF NOT EXISTS confirmation_verified_at         timestamptz,
+  ADD COLUMN IF NOT EXISTS confirmation_verified_by         uuid REFERENCES public.profiles(id),
+  ADD COLUMN IF NOT EXISTS owner_attestation_accepted_at    timestamptz,
+  ADD COLUMN IF NOT EXISTS admin_phone_verification_notes   text;
+
+COMMENT ON COLUMN public.listings.proof_status IS
+  'Proof-of-reservation lifecycle for Pre-Booked listings. not_required for wish_matched (proof is post-acceptance via booking_confirmations).';
+COMMENT ON COLUMN public.listings.resort_confirmation_number IS
+  'Reservation confirmation number the owner received from the resort (e.g. HLT-8472291).';
+COMMENT ON COLUMN public.listings.confirmation_proof_path IS
+  'Supabase Storage object path within listing-proofs bucket. Private; RAV team + owner read only.';
+COMMENT ON COLUMN public.listings.confirmation_proof_hash IS
+  'SHA-256 of the uploaded proof file. Unique across the table so the same PDF cannot be reused on multiple owners listings.';
+COMMENT ON COLUMN public.listings.owner_attestation_accepted_at IS
+  'Set when owner checks the legal attestation box confirming the reservation is genuine.';
+COMMENT ON COLUMN public.listings.admin_phone_verification_notes IS
+  'Free text record of admin calling the resort to verify. Supports the documented verification process (#376 anti-scam layer G).';
+
+-- ── Indexes ─────────────────────────────────────────────────────────────────
+CREATE UNIQUE INDEX IF NOT EXISTS idx_listings_proof_hash_unique
+  ON public.listings (confirmation_proof_hash)
+  WHERE confirmation_proof_hash IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_listings_proof_status
+  ON public.listings (proof_status)
+  WHERE proof_status IN ('required', 'submitted', 'rejected');
+
+-- ── Backfill: grandfather existing Pre-Booked listings ──────────────────────
+-- Any Pre-Booked listing that is already active/booked/completed at migration
+-- time predates this workflow. Mark them verified using approved_at so the
+-- admin queue only surfaces genuinely new work.
+UPDATE public.listings
+SET
+  proof_status              = 'verified',
+  confirmation_verified_at  = COALESCE(approved_at, created_at),
+  confirmation_verified_by  = approved_by
+WHERE source_type = 'pre_booked'
+  AND status IN ('active', 'booked', 'completed')
+  AND proof_status = 'not_required';
+
+-- ── Storage bucket: listing-proofs ──────────────────────────────────────────
+-- Private bucket. 10 MB per file (Supabase free-tier guardrail).
+-- Accepts PDF / JPEG / PNG only.
+INSERT INTO storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+VALUES (
+  'listing-proofs',
+  'listing-proofs',
+  false,
+  10485760,  -- 10 MB
+  ARRAY['application/pdf', 'image/jpeg', 'image/png']
+)
+ON CONFLICT (id) DO UPDATE SET
+  public             = EXCLUDED.public,
+  file_size_limit    = EXCLUDED.file_size_limit,
+  allowed_mime_types = EXCLUDED.allowed_mime_types;
+
+-- ── Storage RLS ─────────────────────────────────────────────────────────────
+-- Owners upload to listing-proofs/{owner_id}/** so the folder-prefix check
+-- aligns path ownership with auth.uid().
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE policyname = 'Owners upload listing proofs' AND tablename = 'objects'
+  ) THEN
+    CREATE POLICY "Owners upload listing proofs"
+      ON storage.objects FOR INSERT
+      TO authenticated
+      WITH CHECK (
+        bucket_id = 'listing-proofs'
+        AND (storage.foldername(name))[1] = auth.uid()::text
+      );
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE policyname = 'Owners read own listing proofs' AND tablename = 'objects'
+  ) THEN
+    CREATE POLICY "Owners read own listing proofs"
+      ON storage.objects FOR SELECT
+      TO authenticated
+      USING (
+        bucket_id = 'listing-proofs'
+        AND (storage.foldername(name))[1] = auth.uid()::text
+      );
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE policyname = 'Owners delete own listing proofs' AND tablename = 'objects'
+  ) THEN
+    CREATE POLICY "Owners delete own listing proofs"
+      ON storage.objects FOR DELETE
+      TO authenticated
+      USING (
+        bucket_id = 'listing-proofs'
+        AND (storage.foldername(name))[1] = auth.uid()::text
+      );
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE policyname = 'RAV team reads all listing proofs' AND tablename = 'objects'
+  ) THEN
+    CREATE POLICY "RAV team reads all listing proofs"
+      ON storage.objects FOR SELECT
+      TO authenticated
+      USING (
+        bucket_id = 'listing-proofs'
+        AND public.is_rav_team(auth.uid())
+      );
+  END IF;
+END $$;
+
+-- ── Notification catalog entries ────────────────────────────────────────────
+-- #376 lifecycle surfaces for owners — mandatory transactional (cannot be
+-- turned off) because the alternative is the owner's listing silently
+-- getting stuck in "rejected" limbo.
+INSERT INTO public.notification_catalog (
+  type_key, display_name, description, category, opt_out_level,
+  default_in_app, default_email, default_sms,
+  channel_in_app_allowed, channel_email_allowed, channel_sms_allowed,
+  sort_order
+) VALUES
+  (
+    'listing_proof_rejected',
+    'Reservation Proof Rejected',
+    'Your uploaded reservation proof was rejected by the RAV team — please re-upload.',
+    'transactional', 'mandatory',
+    true, true, false,
+    true, true, false,
+    16
+  ),
+  (
+    'listing_proof_verified',
+    'Reservation Proof Verified',
+    'The RAV team confirmed your reservation — your Listing is one step closer to going live.',
+    'transactional', 'mandatory',
+    true, true, false,
+    true, true, false,
+    17
+  )
+ON CONFLICT (type_key) DO NOTHING;


### PR DESCRIPTION
## Summary

Bundled PR for **#376** (Pre-Booked reservation verification) and **#378** (Open-for-Offers indicator everywhere). Both tickets touch `ListProperty`, `OwnerListings`, and `AdminListings` in overlapping ways, so shipping once avoids sequential-rebase friction.

Scoping followed a 7-decision matrix with the user; 3 anti-scam layers agreed (owner attestation, file-hash dedup, admin phone-verification checklist). All form fields, columns, buttons, and dialogs carry short guiding help text per the newly-captured "Help Text Everywhere" durable-memory rule.

## #376 Pre-Booked reservation verification

### Schema — Migration 064
- `listing_proof_status` enum: `not_required` / `required` / `submitted` / `verified` / `rejected`
- 9 new columns on `listings`: confirmation number, proof path + SHA-256 hash, verification by/at, rejection reason, owner attestation timestamp, admin phone-verification notes
- Private `listing-proofs` storage bucket (10 MB cap, PDF/JPEG/PNG allowed-list)
- 4 RLS policies (owner rw-own, RAV-team r)
- Grandfathering backfill: existing Pre-Booked active/booked listings flipped to `verified` so the admin queue doesn't flood with legacy work
- **UNIQUE index on `confirmation_proof_hash`** enforces cross-owner proof dedup — the same reservation PDF can't be reused by another owner
- 2 new `notification_catalog` entries: `listing_proof_rejected`, `listing_proof_verified`

### Pure-logic util — `src/lib/listingProof.ts`
- `hashFile` (SHA-256 via Web Crypto + FileReader fallback for older test envs)
- `validateProofFile` (MIME + 10 MB size guard with friendly error copy)
- `buildProofStoragePath` (path-traversal sanitizer — strips `..`, `/`, `\`, non-safe chars)
- Status dictionaries: labels, badge Tailwind classes, help descriptions (capped at 18 words each)
- `isDeflected`, `isProofRequired` predicates
- **17 unit tests**

### Owner flow
- **`ListProperty` Step 2** gets a new Reservation Proof section: confirmation-number field, file upload with validation, legal-language attestation checkbox
- Client-side pre-check queries for duplicate proof hash before upload — fast friendly error if owner reuses a file
- Listing id generated client-side (`crypto.randomUUID()`) so storage path scopes before insert; on insert failure, orphan file is cleaned up
- Proof, number, and attestation fields required to proceed past Step 2
- Listing lands in `proof_status='submitted'` awaiting admin review

### Rejection recovery
- `OwnerListings` shows proof-status badges on all listing statuses
- When rejected: red alert block showing admin's reason + "Re-upload proof" button opening new **`ReuploadProofDialog`**
- Re-upload flips listing back to `proof_status='submitted'` for another admin pass

### Admin flow
- `AdminListings` new "Model" column (Direct / Bidding) + "Proof" column (color-coded badge) + column tooltips
- New **`ProofVerifyDialog`** with embedded PDF/image preview via short-lived signed URL
- Admin phone-verification notes field (anti-scam layer G: document who-you-spoke-to at the resort)
- **Approve button on Pre-Booked listings is disabled** with explanatory tooltip when `proof_status !== 'verified'`
- Verify + Reject both fire `notification-dispatcher` to the owner (fire-and-forget, non-blocking)

## #378 Open-for-Offers surfacing

- **`ListProperty` Step 2**: new bidding-config section (toggle + conditional min-bid / ends-at / reserve-price / counter-offers — all with muted subtext)
- **`OwnerListings`** + **`AdminListings`**: consistent Direct vs Bidding Open badges
- **`ListingCard`** (search results): new "Bidding Open" badge bottom-right of the image
- **`PropertyDetail`**: persistent "Open for Offers" badge next to type badge above the fold (was buried in a collapsible before)
- Consistent amber (Bidding) / emerald (Direct) color scheme across owner / admin / search

## Anti-scam layers shipping in v1 (per agreed matrix)
- **A** Confirmation number + file upload ✅
- **B** Owner attestation checkbox with legal language ✅
- **C** File-hash dedup across listings ✅
- **D** Admin manual review ✅
- **G** Admin phone-verification notes (process-based, not software) ✅

**Deferred** to v1.5 / post-launch: OCR extraction (E), brand-specific confirmation # regex (F), direct brand-API integrations (H), trust-level gating.

## Supabase free-tier guardrails

- 10 MB per file cap enforced at bucket level + client-side validation
- 2 files practical max per listing (one PDF, one screenshot) — not enforced but default UX
- Worst-case pre-launch: 100 listings × 10 MB = 1 GB (right at free-tier edge)
- If ceiling hit, fix is a plan upgrade, not a code change

## Other

- Test helper `renderWithProviders` now wraps in `TooltipProvider` (mirrors `App.tsx`) so admin-tab tests don't break on Tooltip usage
- New durable feedback memory **"Help Text Everywhere"** — every new form field, column, button, dialog gets short non-intrusive guiding text. Systematically applied across this PR

## Tests

- **+17 tests** (1291 → 1308). 140 test files.
- `src/lib/listingProof.test.ts`: `isProofRequired`, status dictionary consistency, file validation (accept/reject paths), path sanitization, SHA-256 hashing (jsdom fallback path).
- Existing `AdminListings.test.tsx` continues to pass with updated `renderWithProviders`.

## Test plan

- [ ] `npm run test` passes (1308/1308)
- [ ] `npm run build` passes
- [ ] `npx tsc --noEmit` clean
- [ ] Post-deploy smoke: Create a Pre-Booked listing through `ListProperty` → uploads proof, shows in `AdminListings` with Proof=Pending Review. Admin opens Verify dialog, approves → owner notification fires, Approve button on the listing row unlocks, listing goes active. Reject flow → owner sees red alert in OwnerListings + can re-upload via dialog.

## Scope held

- SMS alerts (blocked on A2P 10DLC)
- Trust-level gating of proof requirement (post-launch enhancement)
- OCR of reservation details + brand-format regex (v1.5)
- Direct brand-API integrations (partnership-dependent)

PROD migration deploy held per CLAUDE.md human-confirmation rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)