### PR TITLE
feat(dashboard): #381 Action Needed sections — surface time-sensitive items first

### DIFF
--- a/docs/PRIORITY-ROADMAP.md
+++ b/docs/PRIORITY-ROADMAP.md
@@ -1,6 +1,6 @@
 ---
-last_updated: "2026-04-24T18:29:19"
-change_ref: "27a34e1"
+last_updated: "2026-04-24T21:11:26"
+change_ref: "0fa0c27"
 change_type: "session-58"
 status: "active"
 ---
@@ -45,7 +45,6 @@ All unblocked follow-ups from Sessions 54-58. Pick in any order; they're indepen
 
 | Issue | Title | Est. | Why now |
 |-------|-------|------|---------|
-| **#381** | Role-relevant landing-view ordering | 6-8h | Surface most-time-sensitive items on each dashboard's Overview tab per "rooted in simplicity" principle. |
 | **#377** | Cancel-listing cascade (bulk bid rejection + booking cancellation + notifications) | 1d | Standalone, coordinates with DEC-034 wish-matched handling. New edge function + atomic cascade. |
 | **#371** | Edge function test harness | 1-2d (needs scoping) | Tech-debt follow-up from Tests-With-Features shortfalls. Enables future edge-fn work to be properly tested. |
 | **#393** | PLATFORM-INVENTORY.md — one-page mental model of everything built | 2-3h | Session 56 meta-ask: a single doc cataloging product + platform + dev-tooling + governance layers so the user can explain what they've built to investors, new collaborators, and future sessions. |
@@ -129,6 +128,7 @@ These unblock when the LLC is formed. Not code-dependent.
 
 | Date | Session | Changes |
 |------|---------|---------|
+| Apr 24, 2026 | 59 | **#381 shipped** — Action Needed sections on Traveler / Owner / Admin landing views. New `ActionNeededSection` component + `usePriorityActions` hooks (3 variants). Role-specific tiles: travelers see counter-offers + imminent check-ins; owners see proof-rejected + Wish-Matched confirmations + pending Offers + unread inquiries; admins see disputes + escrow + pending approvals + proof verifications. Empty state with role-relevant CTA. 3 new tests. |
 | Apr 24, 2026 | 59 | **#376 + #378 bundled + shipped.** Migration 064 adds `listing_proof_status` enum + 9 new columns on `listings` + `listing-proofs` private storage bucket (10 MB cap, PDF/JPEG/PNG) + 4 RLS policies + 2 notification_catalog entries. Owner gets proof step in `ListProperty` with file+number+attestation; rejected listings get alert + `ReuploadProofDialog`. Admin gets `ProofVerifyDialog` with embedded preview, phone-verification notes, and Approve-button gating. #378 ships consistent Direct / Bidding-Open badges across ListProperty / OwnerListings / AdminListings / ListingCard / PropertyDetail. 17 new tests (pure-logic util). Help-text-everywhere memory captured. |
 | Apr 22-23, 2026 | 58 | **PHASE 22 COMPLETE — 22/22 tickets shipped across 6 PRs this session.** PR #428 (C1+C4): text-chat `context:'support'` + 5 agent tools; DB-first with live Stripe reconcile. PR #429 (C2): route-based context detection + `<RavioFloatingChat />` on /my-trips, /owner-dashboard, /account. PR #430 (C5): Migration 061 `dispute_source` enum; AdminDisputes "via RAVIO" badges. PR #431 (C3): `intent-classifier.ts` + SSE `classified_context` + "Switched to X — back" chip. PR #432 (D1): Migration 062 `support_conversations` + `support_messages` + full transcript capture + escalation stamping. PR #433 (D2): Migration 063 `get_support_metrics` RPC + `AdminSupportInteractions` tab (metrics cards, filter bar, transcripts table, detail dialog) + `RavioChatRating` thumbs UI. 145 new tests total this session. |
 | Apr 21, 2026 | 57 | **Phase 22 SHIPPED Tracks A + B + E (15 of 22 tickets, 8 PRs #418-#425).** Full documentation infrastructure end-to-end on DEV: 22 markdown files in `docs/support/`, migration 060 (support_docs), `ingest-support-docs` edge fn + GitHub Action, `docs-sync-check` extension, 6 legal-blocked drafts at status:draft pending #80. Issues closed: #396-#404, #412-#417. Remaining: Track C (#405-#409 RAVIO agent code) + Track D (#410, #411 observability) — next session. PROD deploys held per CLAUDE.md. |

--- a/docs/PROJECT-HUB.md
+++ b/docs/PROJECT-HUB.md
@@ -1,6 +1,6 @@
 ---
-last_updated: "2026-04-24T18:29:19"
-change_ref: "27a34e1"
+last_updated: "2026-04-24T21:11:26"
+change_ref: "0fa0c27"
 change_type: "session-58"
 status: "active"
 ---
@@ -93,8 +93,8 @@ gh issue create --repo rent-a-vacation/rav-website --title "..." --label "..." -
 - Edge functions require `--no-verify-jwt` deployment flag
 
 ### Platform Status
-- **1308 automated tests** (140 test files, all passing), 0 type errors, 0 lint errors, build clean
-- **P0 tests:** 97 critical-path tests tagged `@p0` + 4 subscription P0s + 6 ListingTypeBadge P0s + 1 support-tool P0 + 35 detectChatContext P0s + 17 intent-classifier P0s — run with `npm run test:p0`
+- **1311 automated tests** (141 test files, all passing), 0 type errors, 0 lint errors, build clean
+- **P0 tests:** 97 critical-path tests tagged `@p0` + 4 subscription P0s + 6 ListingTypeBadge P0s + 1 support-tool P0 + 35 detectChatContext P0s + 17 intent-classifier P0s + 3 ActionNeededSection P0s — run with `npm run test:p0`
 - **CI reporting:** GitHub native via dorny/test-reporter (JUnit XML) — PR annotations on every run (Qase removed Mar 2026)
 - **Migrations created:** 001-064 (001-059 deployed to DEV + PROD; 060 + 061 + 062 + 063 + 064 deployed to DEV only — PROD held per CLAUDE.md) + 3 date-based MDM migrations
 - **Edge functions:** 35 total (27 deployed to PROD + 4 subscription functions on DEV + 3 SMS functions pending LLC/EIN + `ingest-support-docs` deployed to DEV only). `text-chat` gains a `context: 'support'` branch with 5 agent tools (Session 58, Phase 22 C1 + C4).
@@ -108,7 +108,16 @@ gh issue create --repo rent-a-vacation/rav-website --title "..." --label "..." -
 
 ### Session Handoff (Sessions 25-59)
 
-**Session 59 — Pre-Booked reservation verification + Open-for-Offers surfacing (#376 + #378, Apr 24, 2026):**
+**Session 59 — Pre-Booked reservation verification + Open-for-Offers surfacing + role-relevant dashboard landing views (#376 + #378 + #381, Apr 24, 2026):**
+
+**Second PR (#381) — Action Needed sections on Traveler / Owner / Admin landing views:**
+- New `src/components/dashboard/ActionNeededSection.tsx` — compact tile grid with urgency tones (red urgent / amber action / blue info). Friendly empty state with optional CTA.
+- New `src/hooks/usePriorityActions.ts` — 3 React Query hooks (`useTravelerPriorityActions`, `useOwnerPriorityActions`, `useAdminPriorityActions`). Each returns a `PriorityAction[]` sorted by urgency: for travelers, counter-offers / imminent check-ins / pending Wish-Matched confirmations; for owners, proof-rejected / Wish-Matched resort-confirmation / pending Offers / unread inquiries; for admins, open disputes / escrow / pending approvals / proof verifications / user approvals / owner-identity reviews.
+- Mounted at the top of `RenterDashboard` Overview, `OwnerDashboard` dashboard tab, `AdminOverview`. Each dashboard gets a role-specific empty-state CTA ("Browse Rentals" / "List another week" / silent).
+- Every tile is one click from the detail destination — no gray-tab hunts.
+- Tests: 1308 → 1311 (+3). `ActionNeededSection.test.tsx` covers loading state, empty state with CTA, and filtered-rendering.
+
+**First PR (#434) — #376 Pre-Booked reservation verification + #378 Open-for-Offers surfacing:**
 - **One bundled PR (#376 + #378)** because both touched `ListProperty`, `OwnerListings`, and `AdminListings` in overlapping ways. Scoping via the 7-decision matrix with the user: all 7 leans confirmed + 3 anti-scam layers agreed (attestation, file-hash dedup, admin phone-verification checklist).
 - **#376 Pre-Booked reservation proof.** Migration 064 adds: `listing_proof_status` enum (`not_required`/`required`/`submitted`/`verified`/`rejected`), 9 columns on `listings` (confirmation number, proof path + SHA-256 hash, verification by/at, rejection reason, owner attestation timestamp, admin phone-verification notes), `listing-proofs` private storage bucket with 10 MB cap and PDF/JPEG/PNG allowed-list, 4 RLS policies, backfill that grandfathers pre-existing Pre-Booked active/booked listings as `verified`, 2 new `notification_catalog` entries for proof_verified/rejected. UNIQUE index on `confirmation_proof_hash` enforces cross-owner proof dedup.
 - **Owner flow** in `ListProperty` Step 2: confirmation-number field + file upload (validated via `validateProofFile`) + legal-language attestation checkbox. Client-side pre-check queries for duplicate proof hash before upload so owners get a fast friendly error if they reuse a file. Listing id is generated client-side via `crypto.randomUUID()` so the storage path can be scoped before insert; on insert failure the orphan file is cleaned up. On success, listing lands in `proof_status='submitted'` awaiting admin review.

--- a/docs/testing/TESTING-STATUS.md
+++ b/docs/testing/TESTING-STATUS.md
@@ -1,6 +1,6 @@
 ---
-last_updated: "2026-04-24T18:29:19"
-change_ref: "27a34e1"
+last_updated: "2026-04-24T21:11:26"
+change_ref: "0fa0c27"
 change_type: "session-58"
 status: "active"
 ---
@@ -15,9 +15,9 @@ status: "active"
 
 | Metric | Value |
 |--------|-------|
-| **Total tests** | 1308 |
-| **Test files** | 140 |
-| **P0 critical-path tests** | 97 (tagged `@p0`) + 4 subscription P0s + 1 support-tool P0 + 35 detectChatContext P0s + 17 intent-classifier P0s |
+| **Total tests** | 1311 |
+| **Test files** | 141 |
+| **P0 critical-path tests** | 97 (tagged `@p0`) + 4 subscription P0s + 1 support-tool P0 + 35 detectChatContext P0s + 17 intent-classifier P0s + 3 ActionNeededSection P0s |
 | **E2E smoke tests** | 3 (Playwright) |
 | **Local run time** | ~2.5 min (full), ~2s (P0 only) |
 | **CI run time** | <3 min |

--- a/src/components/admin/AdminOverview.tsx
+++ b/src/components/admin/AdminOverview.tsx
@@ -1,17 +1,18 @@
 import { useEffect, useState } from "react";
 import { supabase } from "@/lib/supabase";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
-import { 
-  Building2, 
-  Calendar, 
-  DollarSign, 
+import {
+  Building2,
+  Calendar,
+  DollarSign,
   Users,
   TrendingUp,
   Clock,
-  CheckCircle2,
-  AlertCircle
+  AlertCircle,
 } from "lucide-react";
+import { ActionNeededSection } from "@/components/dashboard/ActionNeededSection";
+import { useAdminPriorityActions } from "@/hooks/usePriorityActions";
 
 interface PlatformStats {
   totalProperties: number;
@@ -40,6 +41,7 @@ const AdminOverview = () => {
     pendingPayouts: 0,
   });
   const [isLoading, setIsLoading] = useState(true);
+  const { data: priorityActions = [], isLoading: priorityActionsLoading } = useAdminPriorityActions();
 
   useEffect(() => {
     const fetchStats = async () => {
@@ -116,6 +118,15 @@ const AdminOverview = () => {
         <p className="text-muted-foreground">
           Real-time metrics across all properties and users
         </p>
+      </div>
+
+      {/* #381 — decisions that are blocking travelers, owners, or revenue move to the top */}
+      <div className="mb-8">
+        <ActionNeededSection
+          actions={priorityActions}
+          isLoading={priorityActionsLoading}
+          emptyMessage="All clear — no pending admin actions."
+        />
       </div>
 
       {/* Key Metrics */}

--- a/src/components/dashboard/ActionNeededSection.test.tsx
+++ b/src/components/dashboard/ActionNeededSection.test.tsx
@@ -1,0 +1,79 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { AlertTriangle, Gavel } from "lucide-react";
+import { ActionNeededSection, type PriorityAction } from "./ActionNeededSection";
+
+function withRouter(ui: React.ReactElement) {
+  return <MemoryRouter>{ui}</MemoryRouter>;
+}
+
+describe("ActionNeededSection @p0", () => {
+  it("renders loading skeletons when isLoading is true", () => {
+    const { container } = render(
+      withRouter(<ActionNeededSection actions={[]} isLoading />),
+    );
+    // Exactly 3 placeholder skeletons (see component)
+    const skeletons = container.querySelectorAll(".h-24");
+    expect(skeletons.length).toBeGreaterThan(0);
+  });
+
+  it("renders the empty state when no actions have count > 0", () => {
+    const actions: PriorityAction[] = [
+      {
+        id: "a",
+        label: "unused",
+        count: 0,
+        icon: Gavel,
+        linkTo: "/x",
+        tone: "action",
+        help: "h",
+      },
+    ];
+    render(
+      withRouter(
+        <ActionNeededSection
+          actions={actions}
+          emptyMessage="All clear!"
+          emptyCtaLabel="Next"
+          emptyCtaLink="/next"
+        />,
+      ),
+    );
+    expect(screen.getByText("All clear!")).toBeInTheDocument();
+    expect(screen.getByText("Next")).toBeInTheDocument();
+  });
+
+  it("renders only actions with count > 0 as tiles, in order supplied", () => {
+    const actions: PriorityAction[] = [
+      {
+        id: "hidden",
+        label: "hidden item",
+        count: 0,
+        icon: Gavel,
+        linkTo: "/hidden",
+        tone: "urgent",
+        help: "should not appear",
+      },
+      {
+        id: "shown",
+        label: "shown item",
+        count: 3,
+        icon: AlertTriangle,
+        linkTo: "/shown",
+        tone: "urgent",
+        help: "review these",
+      },
+    ];
+    render(withRouter(<ActionNeededSection actions={actions} />));
+    expect(screen.queryByText("hidden item")).not.toBeInTheDocument();
+    expect(screen.getByText("shown item")).toBeInTheDocument();
+    expect(screen.getByText("3")).toBeInTheDocument();
+    expect(screen.getByText("review these")).toBeInTheDocument();
+    // Tile is a link to the destination
+    expect(screen.getByRole("link", { name: /shown item/i })).toHaveAttribute(
+      "href",
+      "/shown",
+    );
+  });
+});

--- a/src/components/dashboard/ActionNeededSection.tsx
+++ b/src/components/dashboard/ActionNeededSection.tsx
@@ -1,0 +1,123 @@
+import { Link } from "react-router-dom";
+import { Card, CardContent } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { ArrowRight, CheckCircle2 } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { LucideIcon } from "lucide-react";
+
+/**
+ * Priority action item rendered as a compact tile on a dashboard landing view.
+ * #381 — "surface what matters first" principle. Each tile is one click from
+ * the detail destination; admins/owners/travelers shouldn't hunt through tabs.
+ */
+export interface PriorityAction {
+  id: string;
+  label: string;
+  count: number;
+  icon: LucideIcon;
+  linkTo: string;
+  /** Short muted subtext under the label — the "why this needs attention". */
+  help: string;
+  /**
+   * Visual urgency tone:
+   *   urgent   — red/orange — time-critical (e.g. expiring offer deadline)
+   *   action   — amber       — needs a decision
+   *   info     — blue        — informational but worth noticing
+   */
+  tone: "urgent" | "action" | "info";
+}
+
+interface ActionNeededSectionProps {
+  title?: string;
+  emptyMessage?: string;
+  emptyCtaLabel?: string;
+  emptyCtaLink?: string;
+  actions: PriorityAction[];
+  isLoading?: boolean;
+}
+
+const TONE_CLASSES: Record<PriorityAction["tone"], string> = {
+  urgent: "border-red-300 bg-red-50 text-red-800 hover:bg-red-100",
+  action: "border-amber-300 bg-amber-50 text-amber-900 hover:bg-amber-100",
+  info: "border-blue-300 bg-blue-50 text-blue-800 hover:bg-blue-100",
+};
+
+const TONE_ICON_BG: Record<PriorityAction["tone"], string> = {
+  urgent: "bg-red-100",
+  action: "bg-amber-100",
+  info: "bg-blue-100",
+};
+
+export function ActionNeededSection({
+  title = "Action Needed",
+  emptyMessage = "You're all caught up.",
+  emptyCtaLabel,
+  emptyCtaLink,
+  actions,
+  isLoading = false,
+}: ActionNeededSectionProps) {
+  if (isLoading) {
+    return (
+      <div className="space-y-3">
+        <h2 className="text-sm font-medium text-muted-foreground tracking-wide uppercase">{title}</h2>
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
+          {[1, 2, 3].map((i) => (
+            <Skeleton key={i} className="h-24 rounded-lg" />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  const filtered = actions.filter((a) => a.count > 0);
+
+  if (filtered.length === 0) {
+    return (
+      <Card className="bg-emerald-50/50 border-emerald-200">
+        <CardContent className="pt-6 pb-6 text-center">
+          <CheckCircle2 className="h-8 w-8 text-emerald-500 mx-auto mb-2" />
+          <p className="text-sm font-medium text-emerald-800">{emptyMessage}</p>
+          {emptyCtaLabel && emptyCtaLink && (
+            <Link
+              to={emptyCtaLink}
+              className="inline-flex items-center gap-1 mt-3 text-sm text-emerald-700 hover:text-emerald-900 underline"
+            >
+              {emptyCtaLabel}
+              <ArrowRight className="h-3.5 w-3.5" />
+            </Link>
+          )}
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      <h2 className="text-sm font-medium text-muted-foreground tracking-wide uppercase">{title}</h2>
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
+        {filtered.map((action) => (
+          <Link
+            key={action.id}
+            to={action.linkTo}
+            className={cn(
+              "group flex items-start gap-3 rounded-lg border-2 p-3 transition-colors",
+              TONE_CLASSES[action.tone],
+            )}
+          >
+            <div className={cn("h-10 w-10 rounded-lg flex items-center justify-center flex-shrink-0", TONE_ICON_BG[action.tone])}>
+              <action.icon className="h-5 w-5" />
+            </div>
+            <div className="flex-1 min-w-0">
+              <div className="flex items-baseline gap-2 mb-0.5">
+                <span className="font-bold text-lg leading-none">{action.count}</span>
+                <span className="text-sm font-medium truncate">{action.label}</span>
+              </div>
+              <p className="text-xs opacity-80 leading-snug">{action.help}</p>
+            </div>
+            <ArrowRight className="h-4 w-4 mt-1 opacity-0 group-hover:opacity-100 transition-opacity flex-shrink-0" />
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/usePriorityActions.ts
+++ b/src/hooks/usePriorityActions.ts
@@ -1,0 +1,308 @@
+import { useQuery } from "@tanstack/react-query";
+import { supabase } from "@/lib/supabase";
+import { useAuth } from "@/hooks/useAuth";
+import {
+  AlertTriangle,
+  CalendarClock,
+  Gavel,
+  MessageCircle,
+  ShieldAlert,
+  ClipboardCheck,
+  Scale,
+  DollarSign,
+  UserCheck,
+} from "lucide-react";
+import type { PriorityAction } from "@/components/dashboard/ActionNeededSection";
+
+// Window used for "imminent check-in" urgency.
+const IMMINENT_CHECKIN_DAYS = 7;
+
+function daysFromNow(isoDate: string): number {
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  const d = new Date(isoDate + "T00:00:00");
+  return Math.round((d.getTime() - today.getTime()) / 86_400_000);
+}
+
+// ── Traveler ────────────────────────────────────────────────────────────────
+
+export function useTravelerPriorityActions() {
+  const { user } = useAuth();
+  return useQuery({
+    queryKey: ["priority-actions", "traveler", user?.id],
+    enabled: !!user,
+    queryFn: async (): Promise<PriorityAction[]> => {
+      if (!user) return [];
+
+      // Listings where this traveler has a bid with owner-counter status awaiting their response.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const { count: counterOfferCount } = await (supabase as any)
+        .from("listing_bids")
+        .select("id", { count: "exact", head: true })
+        .eq("renter_id", user.id)
+        .eq("status", "counter_offered");
+
+      // Wish-Matched bookings where owner is still securing the reservation — traveler is watching.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const { data: pendingWishBookings } = await (supabase as any)
+        .from("bookings")
+        .select("id, listing:listings(check_in_date)")
+        .eq("renter_id", user.id)
+        .eq("source_type", "wish_matched")
+        .eq("status", "pending");
+
+      const wishPendingCount = (pendingWishBookings ?? []).length;
+
+      // Active bookings with check-in within IMMINENT_CHECKIN_DAYS.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const { data: confirmedBookings } = await (supabase as any)
+        .from("bookings")
+        .select("id, listing:listings(check_in_date)")
+        .eq("renter_id", user.id)
+        .in("status", ["confirmed", "active"]);
+
+      const imminent = ((confirmedBookings ?? []) as Array<{ listing: { check_in_date: string } | null }>).filter(
+        (b) => {
+          const checkIn = b.listing?.check_in_date;
+          if (!checkIn) return false;
+          const d = daysFromNow(checkIn);
+          return d >= 0 && d <= IMMINENT_CHECKIN_DAYS;
+        },
+      ).length;
+
+      const actions: PriorityAction[] = [
+        {
+          id: "counter-offers",
+          label: counterOfferCount === 1 ? "counter-offer to review" : "counter-offers to review",
+          count: counterOfferCount ?? 0,
+          icon: Gavel,
+          linkTo: "/my-trips?tab=offers",
+          tone: "urgent",
+          help: "An owner responded with a different price — review to accept or counter.",
+        },
+        {
+          id: "imminent-checkin",
+          label: imminent === 1 ? "check-in this week" : "check-ins this week",
+          count: imminent,
+          icon: CalendarClock,
+          linkTo: "/my-trips?tab=bookings",
+          tone: "action",
+          help: "Review check-in details and resort contact before you travel.",
+        },
+        {
+          id: "pending-wish-confirmations",
+          label: wishPendingCount === 1 ? "Wish-Matched stay pending confirmation" : "Wish-Matched stays pending confirmation",
+          count: wishPendingCount,
+          icon: CalendarClock,
+          linkTo: "/my-trips?tab=bookings",
+          tone: "info",
+          help: "The owner is securing the resort reservation — you'll be notified when confirmed.",
+        },
+      ];
+
+      return actions;
+    },
+    staleTime: 60_000,
+  });
+}
+
+// ── Owner ───────────────────────────────────────────────────────────────────
+
+export function useOwnerPriorityActions() {
+  const { user } = useAuth();
+  return useQuery({
+    queryKey: ["priority-actions", "owner", user?.id],
+    enabled: !!user,
+    queryFn: async (): Promise<PriorityAction[]> => {
+      if (!user) return [];
+
+      // Listings with proof_status rejected — owner needs to re-upload.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const { count: proofRejectedCount } = await (supabase as any)
+        .from("listings")
+        .select("id", { count: "exact", head: true })
+        .eq("owner_id", user.id)
+        .eq("proof_status", "rejected");
+
+      // Bids pending on owner's listings (not yet responded to).
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const { data: pendingBidsData } = await (supabase as any)
+        .from("listing_bids")
+        .select("id, listing:listings!inner(owner_id)")
+        .eq("status", "pending")
+        .eq("listing.owner_id", user.id);
+      const pendingBidsCount = (pendingBidsData ?? []).length;
+
+      // Wish-Matched bookings on owner's listings needing resort confirmation.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const { data: pendingOwnerConfirmsData } = await (supabase as any)
+        .from("booking_confirmations")
+        .select("id, booking:bookings!inner(listing:listings!inner(owner_id))")
+        .eq("owner_confirmation_status", "pending_owner")
+        .eq("booking.listing.owner_id", user.id);
+      const pendingOwnerConfirmsCount = (pendingOwnerConfirmsData ?? []).length;
+
+      // Unread inquiry messages — use conversation unread counts for the owner.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const { data: unreadConvsData } = await (supabase as any)
+        .from("conversations")
+        .select("id")
+        .eq("owner_id", user.id)
+        .gt("owner_unread_count", 0);
+      const unreadInquiryCount = (unreadConvsData ?? []).length;
+
+      const actions: PriorityAction[] = [
+        {
+          id: "proof-rejected",
+          label: proofRejectedCount === 1 ? "listing needs re-upload" : "listings need re-upload",
+          count: proofRejectedCount ?? 0,
+          icon: ShieldAlert,
+          linkTo: "/owner-dashboard?tab=my-listings",
+          tone: "urgent",
+          help: "Reservation proof was rejected — upload a corrected file to keep your listing.",
+        },
+        {
+          id: "pending-owner-confirms",
+          label: pendingOwnerConfirmsCount === 1 ? "Wish-Matched booking to confirm" : "Wish-Matched bookings to confirm",
+          count: pendingOwnerConfirmsCount,
+          icon: CalendarClock,
+          linkTo: "/owner-dashboard?tab=bookings-earnings",
+          tone: "urgent",
+          help: "A traveler accepted your Offer — secure the reservation and submit the confirmation number.",
+        },
+        {
+          id: "pending-bids",
+          label: pendingBidsCount === 1 ? "Offer awaiting your response" : "Offers awaiting your response",
+          count: pendingBidsCount,
+          icon: Gavel,
+          linkTo: "/owner-dashboard?tab=my-listings",
+          tone: "action",
+          help: "Accept, counter, or decline — every Offer has a deadline.",
+        },
+        {
+          id: "unread-inquiries",
+          label: unreadInquiryCount === 1 ? "unread traveler message" : "unread traveler messages",
+          count: unreadInquiryCount,
+          icon: MessageCircle,
+          linkTo: "/messages",
+          tone: "info",
+          help: "Travelers have questions before they book — fast replies close deals.",
+        },
+      ];
+
+      return actions;
+    },
+    staleTime: 60_000,
+  });
+}
+
+// ── Admin ───────────────────────────────────────────────────────────────────
+
+export function useAdminPriorityActions() {
+  return useQuery({
+    queryKey: ["priority-actions", "admin"],
+    queryFn: async (): Promise<PriorityAction[]> => {
+      // Pending approvals.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const { count: pendingListingsCount } = await (supabase as any)
+        .from("listings")
+        .select("id", { count: "exact", head: true })
+        .eq("status", "pending_approval");
+
+      // Proof verifications pending.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const { count: proofPendingCount } = await (supabase as any)
+        .from("listings")
+        .select("id", { count: "exact", head: true })
+        .eq("proof_status", "submitted");
+
+      // Open disputes (not resolved/closed).
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const { count: openDisputesCount } = await (supabase as any)
+        .from("disputes")
+        .select("id", { count: "exact", head: true })
+        .in("status", ["open", "investigating", "awaiting_response"]);
+
+      // Pending owner identity verifications.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const { count: ownerVerifPendingCount } = await (supabase as any)
+        .from("owner_verifications")
+        .select("id", { count: "exact", head: true })
+        .eq("status", "pending");
+
+      // User approvals pending.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const { count: userApprovalsPending } = await (supabase as any)
+        .from("profiles")
+        .select("id", { count: "exact", head: true })
+        .eq("approval_status", "pending_approval");
+
+      // Escrow awaiting release.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const { count: escrowPendingCount } = await (supabase as any)
+        .from("booking_confirmations")
+        .select("id", { count: "exact", head: true })
+        .eq("escrow_status", "confirmation_submitted");
+
+      const actions: PriorityAction[] = [
+        {
+          id: "open-disputes",
+          label: openDisputesCount === 1 ? "open dispute" : "open disputes",
+          count: openDisputesCount ?? 0,
+          icon: Scale,
+          linkTo: "/admin?tab=disputes",
+          tone: "urgent",
+          help: "Travelers or owners need a resolution — investigate and close.",
+        },
+        {
+          id: "escrow-pending",
+          label: escrowPendingCount === 1 ? "escrow to release" : "escrow releases to review",
+          count: escrowPendingCount ?? 0,
+          icon: DollarSign,
+          linkTo: "/admin?tab=escrow",
+          tone: "urgent",
+          help: "Owner submitted confirmation — verify and release funds.",
+        },
+        {
+          id: "pending-listings",
+          label: pendingListingsCount === 1 ? "listing pending approval" : "listings pending approval",
+          count: pendingListingsCount ?? 0,
+          icon: ClipboardCheck,
+          linkTo: "/admin?tab=listings",
+          tone: "action",
+          help: "New listings awaiting admin review before going active.",
+        },
+        {
+          id: "proof-pending",
+          label: proofPendingCount === 1 ? "reservation proof to verify" : "reservation proofs to verify",
+          count: proofPendingCount ?? 0,
+          icon: ShieldAlert,
+          linkTo: "/admin?tab=listings",
+          tone: "action",
+          help: "Pre-Booked Stays need proof verification before the listing can go active.",
+        },
+        {
+          id: "user-approvals",
+          label: userApprovalsPending === 1 ? "user approval pending" : "user approvals pending",
+          count: userApprovalsPending ?? 0,
+          icon: UserCheck,
+          linkTo: "/admin?tab=pending-approvals",
+          tone: "action",
+          help: "New account signups awaiting team approval.",
+        },
+        {
+          id: "owner-verif-pending",
+          label: ownerVerifPendingCount === 1 ? "owner identity review" : "owner identity reviews",
+          count: ownerVerifPendingCount ?? 0,
+          icon: AlertTriangle,
+          linkTo: "/admin?tab=verifications",
+          tone: "info",
+          help: "Owner identity documents need review to raise their trust level.",
+        },
+      ];
+
+      return actions;
+    },
+    staleTime: 60_000,
+  });
+}

--- a/src/pages/OwnerDashboard.tsx
+++ b/src/pages/OwnerDashboard.tsx
@@ -54,6 +54,8 @@ import { ReferralDashboard } from "@/components/owner/ReferralDashboard";
 import { OwnerTaxInfo } from "@/components/owner/OwnerTaxInfo";
 import { useOwnerCommission } from "@/hooks/useOwnerCommission";
 import { RavioFloatingChat } from "@/components/RavioFloatingChat";
+import { ActionNeededSection } from "@/components/dashboard/ActionNeededSection";
+import { useOwnerPriorityActions } from "@/hooks/usePriorityActions";
 import { useOwnerDashboardStats } from "@/hooks/owner/useOwnerDashboardStats";
 import { useOwnerEarnings } from "@/hooks/owner/useOwnerEarnings";
 import { useOwnerListingsData } from "@/hooks/owner/useOwnerListingsData";
@@ -120,6 +122,9 @@ const OwnerDashboard = () => {
   // Draft banner state
   const [draft, setDraft] = useState<ListPropertyDraft | null>(() => loadDraft());
   const [showDiscardConfirm, setShowDiscardConfirm] = useState(false);
+
+  // #381 priority actions for the owner landing view
+  const { data: priorityActions = [], isLoading: priorityActionsLoading } = useOwnerPriorityActions();
 
   async function handlePublishDraft() {
     if (!user || !draft) return;
@@ -361,6 +366,15 @@ const OwnerDashboard = () => {
 
           {/* ========== Dashboard Tab (Overview + Portfolio) ========== */}
           <TabsContent value="dashboard" className="mt-6 space-y-6">
+            {/* #381 — surface time-sensitive owner actions first */}
+            <ActionNeededSection
+              actions={priorityActions}
+              isLoading={priorityActionsLoading}
+              emptyMessage="All caught up — no action needed right now."
+              emptyCtaLabel="List another week"
+              emptyCtaLink="/list-property"
+            />
+
             {/* Draft publish banner */}
             {draft && draft.resortName && draft.checkInDate && (
               <div className="bg-primary/5 border border-primary/20 rounded-lg p-4">

--- a/src/pages/RenterDashboard.tsx
+++ b/src/pages/RenterDashboard.tsx
@@ -27,6 +27,8 @@ import { canAccessConcierge } from '@/lib/tierGating';
 import { ConciergeRequestDialog } from '@/components/concierge/ConciergeRequestDialog';
 import { ConciergeRequestList } from '@/components/concierge/ConciergeRequestList';
 import { RavioFloatingChat } from '@/components/RavioFloatingChat';
+import { ActionNeededSection } from '@/components/dashboard/ActionNeededSection';
+import { useTravelerPriorityActions } from '@/hooks/usePriorityActions';
 
 // Lazy-load heavy sub-pages
 const MyBookings = lazy(() => import('./MyBookings'));
@@ -38,6 +40,7 @@ type TabValue = (typeof TABS)[number];
 const RenterDashboard = () => {
   usePageMeta('My Trips', 'Manage your bookings, offers, travel requests, and favorites.');
   const { user } = useAuth();
+  const { data: priorityActions = [], isLoading: actionsLoading } = useTravelerPriorityActions();
   const [searchParams, setSearchParams] = useSearchParams();
   const activeTab = (searchParams.get('tab') as TabValue) || 'overview';
   const { data: membership } = useMyMembership();
@@ -166,6 +169,17 @@ const RenterDashboard = () => {
 
             {/* Overview Tab */}
             <TabsContent value="overview">
+              {/* #381 — surface role-relevant time-sensitive items first */}
+              <div className="mb-8">
+                <ActionNeededSection
+                  actions={priorityActions}
+                  isLoading={actionsLoading}
+                  emptyMessage="You're all caught up. Plan your next trip?"
+                  emptyCtaLabel="Browse Rentals"
+                  emptyCtaLink="/rentals"
+                />
+              </div>
+
               <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 mb-8">
                 {/* Next Trip Card */}
                 <Card className="md:col-span-2">


### PR DESCRIPTION
## Summary

Every dashboard (Traveler / Owner / Admin) now opens with a compact **Action Needed** tile grid of the decisions or actions waiting on that role. Per the QA-audit principle: *surface what matters first; don't make users hunt through gray tabs.*

Each tile is **one click from the detail destination** — admins see "3 open disputes" → click → lands on the disputes tab filtered appropriately. No tab-then-item chains.

## What shipped

### Shared primitive
- **`ActionNeededSection`** — tile grid with three urgency tones:
  - 🔴 `urgent` — time-critical (escalations, imminent deadlines)
  - 🟡 `action` — needs a decision
  - 🔵 `info` — informational but worth noticing
- Friendly empty state with optional role-relevant CTA
- Loading skeletons; zero-count tiles filtered out automatically

### Role-specific priority queries (`usePriorityActions.ts`)

| Role | Tiles surfaced |
|---|---|
| **Traveler** | Counter-offers awaiting my response · check-ins within 7 days · Wish-Matched bookings pending owner confirmation |
| **Owner** | Proof-rejected listings · Wish-Matched bookings needing resort confirmation · Offers pending my response · unread traveler inquiries |
| **Admin** | Open disputes · escrow releases · pending listing approvals · reservation proofs to verify · pending user approvals · owner-identity reviews |

### Mount points
- `RenterDashboard` Overview — empty-state CTA: "Browse Rentals"
- `OwnerDashboard` dashboard tab — above draft banner; empty CTA: "List another week"
- `AdminOverview` — above headline metrics; empty is silent

### Scope held
- **Nothing removed** from existing dashboards — this sharpens the landing view, doesn't rewrite it
- No data-model changes, no new migrations
- Non-urgent sections (Earnings Timeline, Maintenance Fee Tracker, Portfolio, Quick Actions, etc.) stay in place below

## Tests

- **+3 tests** (1308 → 1311). 141 test files.
- `ActionNeededSection.test.tsx` — loading state, empty state with CTA, filtered-rendering (zero-count items suppressed, tiles link to destination)

## Test plan

- [ ] `npm run test` passes (1311/1311)
- [ ] `npm run build` passes
- [ ] `npx tsc --noEmit` clean
- [ ] Manual: as owner with a rejected proof, top of dashboard shows red "listing needs re-upload" tile → click → lands on My Listings. Empty case (owner all caught up) shows green "All caught up — List another week" CTA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)