### PR TITLE
fix: remove inaccurate "partner resorts" language across codebase

### DIFF
--- a/docs/DEMO-WALKTHROUGH.md
+++ b/docs/DEMO-WALKTHROUGH.md
@@ -1,6 +1,6 @@
 ---
-last_updated: "2026-04-12T22:57:23"
-change_ref: "a521368"
+last_updated: "2026-04-27T19:34:52"
+change_ref: "611f7c5"
 change_type: "session-39-docs-update"
 status: "active"
 ---
@@ -80,10 +80,10 @@ Between each section, use these transition phrases to maintain narrative continu
 
 ### Platform Scale
 
-**What to show:** Scroll to the Trust Badges section showing partner resort counts.
+**What to show:** Scroll to the Trust Badges section showing resort counts.
 
 > **Talking point:**
-> "We have 117 partner resorts across 9 major vacation club brands:
+> "We have 117 resorts across 9 major vacation club brands:
 > - Hilton Grand Vacations (62 resorts)
 > - Marriott Vacation Club (40 resorts)
 > - Disney Vacation Club (15 resorts)
@@ -103,7 +103,7 @@ Between each section, use these transition phrases to maintain narrative continu
 
 ### Key Metrics to Highlight
 
-- 117 partner resorts, 9 vacation club brands
+- 117 resorts, 9 vacation club brands
 - 351 unit types across 10+ countries
 - 15% base commission rate (tiered discounts for Pro/Business)
 - 20-40% savings for renters compared to resort-direct booking
@@ -988,7 +988,7 @@ Keep these numbers handy for when stakeholders ask during the demo.
 
 | Metric | Value | Source |
 |--------|-------|--------|
-| Partner resorts | 117 | Database (62 Hilton, 40 Marriott, 15 Disney) |
+| Resorts | 117 | Database (62 Hilton, 40 Marriott, 15 Disney) |
 | Vacation club brands | 9 | calculatorLogic.ts `VACATION_CLUB_BRANDS` |
 | Unit types | 351 | Database |
 | Countries | 10+ | Database |
@@ -1054,7 +1054,7 @@ Keep these numbers handy for when stakeholders ask during the demo.
 ### Closing Statement
 
 > **Talking point:**
-> "To summarize: Rent-A-Vacation is a purpose-built marketplace for timeshare vacation rentals. We have 117 partner resorts across 9 brands, a fully functional two-sided marketplace with payments, escrow, and dispute resolution, AI-powered search with both voice and text, a public REST API for third-party integrations, the RAV Smart Suite of 5 free tools, dynamic pricing intelligence, comprehensive admin tooling, and enterprise-grade security. The platform is at v0.9.0 with 771 automated tests across 99 test files -- feature-complete for launch. We are in the final pre-launch phase, completing business formation, activating Stripe Tax, and onboarding our initial inventory of property owners."
+> "To summarize: Rent-A-Vacation is a purpose-built marketplace for timeshare vacation rentals. We have 117 resorts across 9 brands, a fully functional two-sided marketplace with payments, escrow, and dispute resolution, AI-powered search with both voice and text, a public REST API for third-party integrations, the RAV Smart Suite of 5 free tools, dynamic pricing intelligence, comprehensive admin tooling, and enterprise-grade security. The platform is at v0.9.0 with 771 automated tests across 99 test files -- feature-complete for launch. We are in the final pre-launch phase, completing business formation, activating Stripe Tax, and onboarding our initial inventory of property owners."
 
 ### Call to Action (Customize per Audience)
 

--- a/docs/api/public-api.yaml
+++ b/docs/api/public-api.yaml
@@ -315,7 +315,7 @@ paths:
       summary: Look up a RAV resort by partner system ID
       description: |
         Maps an external system's resort identifier to the RAV golden record.
-        Use this to integrate partner resort IDs (e.g. XPD, OTA aggregator codes)
+        Use this to integrate external resort IDs (e.g. XPD, OTA aggregator codes)
         without maintaining a local cross-reference table.
       security:
         - ApiKeyAuth: []

--- a/docs/brand-assets/PITCH-DECK-SCRIPT.md
+++ b/docs/brand-assets/PITCH-DECK-SCRIPT.md
@@ -1,6 +1,6 @@
 ---
-last_updated: "2026-04-15T11:10:55"
-change_ref: "bc1bafd"
+last_updated: "2026-04-27T19:34:52"
+change_ref: "611f7c5"
 change_type: "session-48-docs-refresh"
 status: "active"
 ---
@@ -445,7 +445,7 @@ ADDITIONAL REVENUE STREAMS:
 • Referral program (owner acquisition)       [BUILT]
 • Featured listing placements                [Future]
 • Premium analytics for owners               [Future]
-• Resort partnership referral fees            [Future]
+• Resort affiliate referral fees              [Future]
 ```
 
 **Labels:** Commission model and tiers are [BUILT]. Revenue streams marked "Future" are [PROJECTED].

--- a/docs/exports/RAV-roadmap-draft-02222026.md
+++ b/docs/exports/RAV-roadmap-draft-02222026.md
@@ -1,6 +1,6 @@
 ---
-last_updated: "2026-04-12T22:57:23"
-change_ref: "a521368"
+last_updated: "2026-04-27T19:34:52"
+change_ref: "611f7c5"
 change_type: "session-39-docs-update"
 status: "archived"
 ---
@@ -89,7 +89,7 @@ The platform is feature-complete for MVP across 19 completed development phases,
 |---------|-------------|--------|
 | **Voice Search (Ask RAVIO)** | Voice concierge powered by VAPI + Deepgram Nova-3 transcription. Natural language queries ("show me beachfront condos in Hawaii for next month"), 300ms endpointing, smart denoising. Tier-based daily limits with admin overrides | BUILT |
 | **Text Chat (Chat with RAVIO)** | LLM-powered text assistant (OpenRouter / Gemini 3 Flash) with SSE streaming and tool calling for property search. Context-aware across 4 page types (rentals, property detail, bidding, general) | BUILT |
-| **Resort Knowledge Base (ResortIQ)** | Database of 117 partner resorts and 351 unit types from 9 vacation club brands. Auto-populates listing specs (bedrooms, bathrooms, max guests, square footage) when owners create listings | BUILT |
+| **Resort Knowledge Base (ResortIQ)** | Database of 117 resorts and 351 unit types from 9 vacation club brands. Auto-populates listing specs (bedrooms, bathrooms, max guests, square footage) when owners create listings | BUILT |
 
 ### 2.6 Admin & Operations
 

--- a/docs/exports/generate_docx.py
+++ b/docs/exports/generate_docx.py
@@ -416,7 +416,7 @@ def generate_roadmap():
         [
             ["Voice Search (Ask RAVIO)", "Voice concierge powered by VAPI + Deepgram Nova-3. Natural language queries, 300ms endpointing, smart denoising. Tier-based daily limits with admin overrides", "BUILT"],
             ["Text Chat (Chat with RAVIO)", "LLM-powered text assistant (OpenRouter / Gemini 3 Flash) with SSE streaming and tool calling. Context-aware across 4 page types", "BUILT"],
-            ["Resort Knowledge Base (ResortIQ)", "Database of 117 partner resorts and 351 unit types from 9 vacation club brands. Auto-populates listing specs when owners create listings", "BUILT"],
+            ["Resort Knowledge Base (ResortIQ)", "Database of 117 resorts and 351 unit types from 9 vacation club brands. Auto-populates listing specs when owners create listings", "BUILT"],
         ]
     )
 

--- a/docs/features/mdm-resort-data/WS3-API-ENHANCEMENT.md
+++ b/docs/features/mdm-resort-data/WS3-API-ENHANCEMENT.md
@@ -1,6 +1,6 @@
 ---
-last_updated: "2026-04-16T01:58:25"
-change_ref: "9945546"
+last_updated: "2026-04-27T19:34:52"
+change_ref: "611f7c5"
 change_type: "manual-edit"
 status: "active"
 ---
@@ -251,7 +251,7 @@ Update **both** copies: `docs/api/public-api.yaml` AND `public/api/public-api.ya
     summary: Look up a RAV resort by partner system ID
     description: |
       Maps an external system's resort identifier to the RAV golden record.
-      Use this to integrate partner resort IDs without maintaining a local
+      Use this to integrate external resort IDs without maintaining a local
       cross-reference table.
     parameters:
       - name: system

--- a/public/api/public-api.yaml
+++ b/public/api/public-api.yaml
@@ -315,7 +315,7 @@ paths:
       summary: Look up a RAV resort by partner system ID
       description: |
         Maps an external system's resort identifier to the RAV golden record.
-        Use this to integrate partner resort IDs (e.g. XPD, OTA aggregator codes)
+        Use this to integrate external resort IDs (e.g. XPD, OTA aggregator codes)
         without maintaining a local cross-reference table.
       security:
         - ApiKeyAuth: []

--- a/src/components/TrustBadges.tsx
+++ b/src/components/TrustBadges.tsx
@@ -9,7 +9,7 @@ const badges = [
   {
     icon: Building2,
     value: "117",
-    label: "Partner Resorts",
+    label: "Resorts",
   },
   {
     icon: Gavel,

--- a/src/pages/HowItWorksPage.tsx
+++ b/src/pages/HowItWorksPage.tsx
@@ -389,7 +389,7 @@ const HowItWorksPage = () => {
             <div>
               <Home className="w-10 h-10 mx-auto mb-3 opacity-80" />
               <div className="font-display text-4xl font-bold mb-1">117</div>
-              <div className="opacity-80">Partner Resorts</div>
+              <div className="opacity-80">Resorts</div>
             </div>
             <div>
               <Users className="w-10 h-10 mx-auto mb-3 opacity-80" />

--- a/supabase/functions/api-gateway/index.ts
+++ b/supabase/functions/api-gateway/index.ts
@@ -539,7 +539,7 @@ async function handleResorts(
 
 /**
  * GET /v1/resorts/by-external-id?system=xpd&id=XPD-12345
- * Maps an external partner resort ID to the RAV golden record.
+ * Maps an external resort ID to the RAV golden record.
  */
 async function handleResortByExternalId(
   _req: Request,


### PR DESCRIPTION
## Summary

- Removes \"partner resorts\" and \"partner resort\" phrasing from user-facing UI, public API spec, demo / pitch scripts, and generated exports
- Pre-launch legal-compliance fix: 117 resorts are pre-seeded reference data (publicly available info to streamline owner listing creation), not formal partnerships
- Single clean pass driven by an audit list reviewed before any edits — all changes confirmed against the replacement table in #458

## Files changed (10)

**UI (Tier 1):**
- \`src/components/TrustBadges.tsx\` — \"Partner Resorts\" → \"Resorts\"
- \`src/pages/HowItWorksPage.tsx\` — \"Partner Resorts\" → \"Resorts\"

**Public API spec + edge fn comments (Tier 2):**
- \`docs/api/public-api.yaml\`
- \`public/api/public-api.yaml\`
- \`supabase/functions/api-gateway/index.ts\`
- \`docs/features/mdm-resort-data/WS3-API-ENHANCEMENT.md\`

**Demo / pitch (Tier 4):**
- \`docs/DEMO-WALKTHROUGH.md\` (5 occurrences)
- \`docs/brand-assets/PITCH-DECK-SCRIPT.md\` — \"Resort partnership referral fees\" → \"Resort affiliate referral fees\"

**Generated exports (Tier 5):**
- \`docs/exports/RAV-roadmap-draft-02222026.md\`
- \`docs/exports/generate_docx.py\`

## Preserved intentionally

- \`docs/COMPLETED-PHASES.md:1314\` — historical changelog entry documenting *past* TrustBadges copy. Rewriting it would falsify the audit trail
- \`docs/boardroom/sessions/**\` — historical board transcripts; one transcript actually flags this exact problem
- Tier 7 internal docs already accurate (use \"117 resorts\" without \"partner\") — no change needed

## Test plan

- [x] All 1394 tests pass (\`npm run test\` — 149 files, 0 failures)
- [x] Build clean (\`npm run build\` — 1m 29s, 0 errors)
- [x] No remaining \"partner resort\" matches except historical changelog (verified post-edit)
- [ ] Manual visual check on \`/\` and \`/how-it-works\` after preview deploy — confirm Trust Badges and Stats sections render \"Resorts\" cleanly
- [ ] Confirm public API spec at \`/developers\` still validates (Redocly)

Closes #458

🤖 Generated with [Claude Code](https://claude.com/claude-code)