### PR TITLE
docs(paysafe): cross-link spec to gap issues + DEC-038 + roadmap

### DIFF
--- a/docs/PRIORITY-ROADMAP.md
+++ b/docs/PRIORITY-ROADMAP.md
@@ -1,7 +1,7 @@
 ---
-last_updated: "2026-04-25T21:17:59"
-change_ref: "e1f3aea"
-change_type: "session-59"
+last_updated: "2026-04-28T10:04:52"
+change_ref: "dfba76b"
+change_type: "session-61"
 status: "active"
 ---
 # PRIORITY ROADMAP — Rent-A-Vacation
@@ -48,7 +48,7 @@ When `/sdlc pickup` runs next, the user has explicitly scoped the next session a
 
 **Also consider after those:** A controlled PROD deploy window for the accumulated Phase 22 + Session 59 changes (migrations 060–065, text-chat updates with support context + 5 tools + classifier, ingest-support-docs + cancel-listing edge fns, support_conversations + listing-proofs + dispute_source schemas). All currently sit on DEV per CLAUDE.md human-confirmation rule.
 
-## Current Priority Tiers (as of April 25, 2026 — Session 60)
+## Current Priority Tiers (as of April 28, 2026 — Session 61)
 
 ### Tier A: Build Next (High Impact, Code-Ready)
 
@@ -69,6 +69,11 @@ These require decisions, walkthroughs, or external dependencies before coding.
 | #322 | RAV Wishes proposal enforcement | Deferred until 30+ days of real proposal data. Post-beta. |
 | **#404** | Phase 22 B5: Legal-blocked public policy docs (privacy, booking-terms, payment-policy, trust-safety, insurance-liability, subscription-terms, refund, cancellation) | Blocked by #80 (legal consult — timeshare lawyer). 8 drafts production-ready in `docs/support/policies/`, held with `status: 'draft'` pending lawyer sign-off. Bundle into the same lawyer pass as #438. |
 | **#438** | Incorporation documentation starter kit (operating agreement, formation checklist, IP assignment, state tax notes, RAV-specific marketplace docs) | **NEXT PICKUP.** Confirmed Session 60: Delaware C-Corp via Stripe Atlas (vs Gust under boardroom review); 4 founders all Florida-based; foreign-entity registration in Florida; scope WIDE — full packet for #80 lawyer engagement. Goal: zero owners onboard before lawyer signs off. |
+| **#461** | PaySafe Gap A — wire up `confirm-checkin` server action (renter arrival button is currently a no-op) | New issue from PaySafe spec §3.2 (DEC-038). Pre-launch. Blocks #462 + #467. |
+| **#462** | PaySafe Gap B — auto-confirmation cron when renter ignores deadline | Depends on #461. Pre-launch — needed for fraud + dispute analytics. |
+| **#464** | PaySafe Gap G — enforce dispute SLAs with alerting + business-hours config | Pre-launch (operational). 2-hour triage on safety/owner-no-show categories cannot be a paper target at launch. |
+| **#465** | PaySafe Gap H — auto-mirror Stripe `charge.dispute.created` to internal disputes | Pre-launch. Chargeback evidence windows are tight; manual mirroring loses time. |
+| **#466** | PaySafe Gap I — jurisdiction field on bookings + per-state disclosure logic | Pre-launch. Linked to #80 — counsel input gates seeding the rules table. Decision A/B/C in issue body re: launch jurisdictions. |
 
 ### Tier C: Tier Feature Differentiation — ✅ COMPLETED IN SESSION 53 (PR #367)
 
@@ -120,6 +125,10 @@ Park these until after launch or until specific triggers.
 | #440 | Archive PROJECT-HUB session handoffs 25-54 to COMPLETED-PHASES | Mechanical doc migration. Pure reorganization — defer until a docs-focused session. |
 | **#443** | Edge-fn test for ingest-support-docs (admin ETL) | Low-risk admin ETL. Implementation guide posted as comment on issue (Session 60). Can be picked up anytime — ~2-3h work. |
 | **#444** | Edge-fn tests for notification stack (notification-dispatcher, sms-scheduler, twilio-webhook) | Blocked on A2P 10DLC anyway (#127 chain). Wait until SMS handles production traffic before adding tests. |
+| **#467** | PaySafe Gap C — pre-fill dispute form from check-in issue report | Post-launch UX win. Depends on #461 (Pre-launch). |
+| **#468** | PaySafe Gap D — move `HOLD_PERIOD_DAYS` to `system_settings` | Post-launch ergonomics. Currently hardcoded at 5; ops cannot tune without redeploy. |
+| **#469** | PaySafe Gap F — native split refunds, holdbacks, rebooking credits, fee waivers | Post-launch. Likely splits into a small epic — needs DEC for scope. |
+| **#463** | PaySafe Gap E — enforce per-category dispute role mapping in schema/RLS | Pre-launch (low risk). In `Security Hardening` milestone (#24). |
 
 ---
 
@@ -141,6 +150,7 @@ These unblock when the LLC is formed. Not code-dependent.
 
 | Date | Session | Changes |
 |------|---------|---------|
+| Apr 27–28, 2026 | 61 | **PaySafe Flow Specification SHIPPED (PR #460).** New `docs/payments/PAYSAFE-FLOW-SPEC.md` — authoritative internal spec for the escrow + dispute system across 11 sections. DEC-038 logged. **9 gap issues opened** (#461–#469): pre-launch (#461 confirm-checkin server action, #462 auto-confirm cron, #463 role-mapping enforcement, #464 SLA enforcement, #465 Stripe chargeback auto-mirror, #466 jurisdiction field) and post-launch (#467 issue→dispute pre-fill, #468 hold-period to system_settings, #469 split refunds/holdbacks/credits). Tier B updated with the 5 Launch-Readiness gap issues; Tier E updated with the 3 post-launch gap issues + #463 (Security Hardening). Doc-only PR — no test count change (1394), no migrations, no edge-fn changes. |
 | Apr 25, 2026 | 60 | **#442 + #445 SHIPPED (PR #446).** Stripe Connect tests + vitest coverage extension to `supabase/functions/**`. 19 new tests (1375 → 1394). Coverage now measures handler.ts files; thresholds unchanged at 25/25/30/25 — all pass with 75/78/84/75 actuals. Tier A confirmed empty. Tier audit: added #368 + #443 + #444 to Tier E with explicit triggers; clarified #233 (X/Twitter) as post-launch; expanded #404 row to mention all 8 policy drafts (was 6); reframed #438 with confirmed Atlas + 4-founder + Florida foreign-entity scope. |
 | Apr 25, 2026 | 60 | **#371 SHIPPED — edge function test harness.** DEC-037 logged: Vitest, not Deno-native. Pattern: each Stripe-touching + cancel-listing edge fn split into `handler.ts` (testable) + `index.ts` (5-line `Deno.serve` wrapper). 64 new tests across 6 files (1311 → 1375); 23 new `@p0` tags (176 → 199). Refactored: create-booking-checkout, verify-booking-payment, stripe-webhook, process-cancellation, cancel-listing. Plus extracted `text-chat/context-resolver.ts` for the pure intent-classification routing logic. New shared infra: `_shared/__tests__/{stripe-mock, edge-fn-fixtures, stripe-events}.ts`. Tier A now empty; next pickup **#438**. |
 | Apr 25, 2026 | 60 | **Session 60 pickup + doc audit.** All 4 bootstrap docs brought current: LAUNCH-READINESS rebuilt with Sessions 53-59 platform-completeness rows + updated By-the-Numbers (1311 tests / 141 files / 065 migrations / 36 edge fns); PROJECT-HUB body 'Last Updated' bumped to Session 59; PRIORITY-ROADMAP + COMPLETED-PHASES frontmatter stamped to session-59. New issue **#440** opened for the larger archival task (move PROJECT-HUB Session 25-54 handoff entries into COMPLETED-PHASES). Tier E. Doc audit cleared before pivoting to #371. |

--- a/docs/PROJECT-HUB.md
+++ b/docs/PROJECT-HUB.md
@@ -1,7 +1,7 @@
 ---
-last_updated: "2026-04-25T06:41:23"
-change_ref: "2dd6116"
-change_type: "session-59"
+last_updated: "2026-04-28T10:04:52"
+change_ref: "dfba76b"
+change_type: "session-61"
 status: "active"
 ---
 # PROJECT HUB - Rent-A-Vacation
@@ -9,7 +9,7 @@ status: "active"
 > **Architectural decisions, session context, and agent instructions**
 > **Task tracking has moved to [GitHub Issues & Milestones](https://github.com/rent-a-vacation/rav-website/issues)**
 > **Project board: [RAV Roadmap](https://github.com/orgs/rent-a-vacation/projects/1)**
-> **Last Updated:** April 24, 2026 (Session 59: proof workflow + Action Needed + cancel-listing cascade + PLATFORM-INVENTORY)
+> **Last Updated:** April 28, 2026 (Session 61: PaySafe flow specification — internal spec for escrow + dispute system, 9 gap issues filed)
 > **Repository:** https://github.com/rent-a-vacation/rav-website
 > **App Version:** v0.9.0 (build version visible in footer)
 
@@ -106,7 +106,35 @@ gh issue create --repo rent-a-vacation/rav-website --title "..." --label "..." -
 - **dev and main:** in sync after Session 59 close (PRs #434–#437 + #439). Session 60 #371 edge-fn test harness lives on dev awaiting PR.
 - **GitHub Project:** RAV Roadmap — 202 issues, all with Status/Category/Sub-Category/Type populated. Auto-add workflow enabled. PRs excluded.
 
-### Session Handoff (Sessions 25-60)
+### Session Handoff (Sessions 25-61)
+
+**Session 61 — PaySafe Flow Specification (PR #460, Apr 27–28, 2026):**
+
+Authored `docs/payments/PAYSAFE-FLOW-SPEC.md` — the authoritative internal spec for the escrow + dispute system. Single PR (#460) merged to main at `f4f7a12`, doc-only change (no code, no migrations, no test count delta).
+
+**Spec covers** (11 sections):
+- §2 six-state escrow lifecycle (`pending_confirmation` → `confirmation_submitted` → `verified` → `released` / `refunded` / `disputed`) with pre-state branches for Pre-Booked vs Wish-Matched stays (DEC-034)
+- §3 check-in confirmation trigger (target state + current Gaps A/B/C)
+- §4 auto-release eligibility (7 conditions, including `stripe_payouts_enabled` gate, hold period 5 days hardcoded — Gap D)
+- §5 dispute system: 13 categories (8 from migration 026 + 5 from migration 041) grouped by typical filer; status flow; resolution authority (`rav_admin` for safety/payment/cancellation/damage>$500; `rav_staff` for operational; `rav_owner` schema-allowed but unused — Gap E policy-only)
+- §6 SLA targets per category (2h triage on safety/owner-no-show/access — Gap G not enforced)
+- §7 regulatory landscape (FL Ch. 721, HI TAT, TN STR ordinances, CA/NY consumer-protection overrides — Gap I jurisdiction field)
+- §9 nine open gaps (A–I) with priority, suggested home, and dependency notes
+
+**Verified all code references against the implementation** — caught and fixed: migrations 006 and 023 are archived in `docs/supabase-migrations/` (Lovable starter), not in the live `supabase/migrations/` directory; `booking_confirmations` is at lines 131–162 (not 139–190); confirmation insert at `verify-booking-payment/handler.ts:236–266` (not 371); eligibility uses field `stripe_payouts_enabled` (not `payouts_enabled`).
+
+**Tightening pass** added: lifecycle diagram, owner-confirmation timer details (60min default + 2× 30min extensions, sourced from `system_settings` migration 012:133–137), Pre-Booked vs Wish-Matched distinction, complete eligibility (was 5 conditions, now 7), commission-tier note (15% default, Pro −2%, Business −5%), regulatory disclaimer at top of §7, explicit business-hours definition for §6 SLAs (09:00–18:00 ET, M–F, ex-federal-holidays).
+
+**Gaps filed** as 9 discrete GitHub issues (Apr 28 follow-up):
+- **Pre-launch / Launch Readiness:** #461 (A — confirm-checkin), #462 (B — auto-confirm cron, depends on #461), #464 (G — SLA enforcement), #465 (H — Stripe chargeback auto-mirror), #466 (I — jurisdiction field, linked to #80)
+- **Pre-launch / Security Hardening:** #463 (E — per-category role mapping in schema/RLS)
+- **Post-launch:** #467 (C — issue→dispute pre-fill, depends on #461), #468 (D — `HOLD_PERIOD_DAYS` to `system_settings`), #469 (F — split refunds + holdbacks + credits + fee waivers)
+
+**Key design decision (DEC-038)** logged: spec is the long-running source of truth for money-movement architecture. Future gap closures update the spec by removing the corresponding row from §9.
+
+**No platform changes:** test count unchanged (1394), no migrations, no edge-fn changes, dev↔main now in sync via PR #460 merge.
+
+---
 
 **Session 60 — Edge function test harness + doc audit (#371, Apr 25, 2026):**
 
@@ -1002,6 +1030,31 @@ Three workstreams shipped plus Phase 21 DoD cleanup. All backed by GitHub issues
 - #190 — Webhook delivery to partners (event notifications)
 - #191 — Chat endpoint (`/v1/chat`) via gateway
 - #192 — SDK packages for partners (npm, Python)
+
+---
+
+### DEC-038: PaySafe Flow Specification — Authoritative Internal Doc for Money Movement
+**Date:** April 27–28, 2026 (Session 61, PR #460)
+**Decision:** `docs/payments/PAYSAFE-FLOW-SPEC.md` is the **authoritative internal specification** of how money moves through the marketplace — escrow lifecycle, auto-release rules, dispute system (categories, status, authority, SLAs), check-in confirmation, and the state-specific regulatory landscape. When this spec and the code disagree, **the code wins** — open a PR to update the spec.
+
+**Rationale:**
+1. **Onboarding new contributors and counsel.** The escrow + dispute paths cross 5 edge functions, 3 migrations, 2 archived starter migrations, and a Stripe Connect destination-charge model. New engineers (and lawyer doing #80 review) need one document that wires it all together.
+2. **Gap inventory + tracking.** The spec catalogues 9 known gaps (A–I) — each filed as a discrete GitHub issue (#461–#469) with priority, dependencies, and acceptance criteria. Future PRs that close a gap update the spec to remove that row.
+3. **Regulatory pre-launch surface.** §7 captures the timeshare + state-specific rules RAV operates under (FL Ch. 721, HI TAT, TN STR ordinances, CA / NY consumer-protection overrides). Counsel reviews the spec section, not scattered code comments.
+4. **Boundary with public docs.** Internal spec ↔ public-facing policies (`docs/support/policies/payment-policy.md`, `cancellation-policy.md`) are now explicitly distinguished. The public docs stay user-readable; the spec stays implementation-grounded.
+
+**Issue tracking:**
+- **Pre-launch (Launch Readiness milestone):** #461 (Gap A — confirm-checkin server action), #462 (Gap B — auto-confirm cron), #464 (Gap G — SLA enforcement), #465 (Gap H — Stripe chargeback auto-mirror), #466 (Gap I — jurisdiction field, linked to #80)
+- **Pre-launch (Security Hardening milestone):** #463 (Gap E — per-category role mapping in schema/RLS)
+- **Post-launch:** #467 (Gap C — issue → dispute pre-fill), #468 (Gap D — HOLD_PERIOD_DAYS to system_settings), #469 (Gap F — split refunds + holdbacks + credits + fee waivers)
+
+**Cross-links:**
+- Spec at `docs/payments/PAYSAFE-FLOW-SPEC.md` — frontmatter `change_type: session-61-paysafe-spec-v1`
+- Public-facing payment policy at `docs/support/policies/payment-policy.md` (status: draft, blocked on #80)
+- Cancellation policy at `docs/support/policies/cancellation-policy.md`
+- Canonical refund-tier rules at `src/lib/cancellationPolicy.ts`
+
+**Status:** Active. Spec is the long-running source of truth. Future revisions land via PR with a revision-history row entry; closing a gap issue requires a corresponding spec update to remove the row from §9.
 
 ---
 

--- a/docs/payments/PAYSAFE-FLOW-SPEC.md
+++ b/docs/payments/PAYSAFE-FLOW-SPEC.md
@@ -1,6 +1,6 @@
 ---
-last_updated: "2026-04-27T23:23:35"
-change_ref: "ebf90fb"
+last_updated: "2026-04-28T10:04:52"
+change_ref: "dfba76b"
 change_type: "session-61-paysafe-spec-v1"
 status: "active"
 ---
@@ -298,19 +298,19 @@ The internal `disputes` row should be created automatically when a Stripe `charg
 
 ## 9. Open gaps and tracking
 
-Each gap below should become (or be linked to) a GitHub issue before launch. Tracking lives in `docs/PRIORITY-ROADMAP.md`; this doc only enumerates.
+Each gap is tracked as a discrete GitHub issue. Tier assignment and ordering live in `docs/PRIORITY-ROADMAP.md`; this doc only enumerates and links.
 
-| ID | Gap | Priority | Suggested home |
+| ID | Gap | Priority | Issue |
 |---|---|---|---|
-| A | No dedicated `confirm-checkin` server action wired up | Pre-launch | New issue (or fold into #187) |
-| B | No auto-confirmation cron when the renter ignores the deadline | Pre-launch | New issue |
-| C | Check-in issue path does not pre-fill the dispute form | Post-launch UX | New issue |
-| D | `HOLD_PERIOD_DAYS` is hardcoded; should live in `system_settings` | Post-launch | New issue |
-| E | Per-category role mapping (admin vs staff) is policy, not enforced in schema or RLS | Pre-launch (low risk) | New issue |
-| F | No native support for split refunds, holdbacks, rebooking credits, or platform-fee waivers | Post-launch | New issue |
-| G | SLAs are documented here but not enforced in code (no alerting, no business-hours definition in `system_settings`) | Pre-launch (operational) | New issue |
-| H | Stripe `charge.dispute.created` does not auto-create internal dispute row | Pre-launch | New issue |
-| I | No `jurisdiction` field on bookings; no per-state disclosure logic; no per-state cancellation-override rules | Pre-launch | Folds into #80 |
+| A | No dedicated `confirm-checkin` server action wired up | Pre-launch | [#461](https://github.com/rent-a-vacation/rav-website/issues/461) |
+| B | No auto-confirmation cron when the renter ignores the deadline | Pre-launch | [#462](https://github.com/rent-a-vacation/rav-website/issues/462) (depends on #461) |
+| C | Check-in issue path does not pre-fill the dispute form | Post-launch UX | [#467](https://github.com/rent-a-vacation/rav-website/issues/467) (depends on #461) |
+| D | `HOLD_PERIOD_DAYS` is hardcoded; should live in `system_settings` | Post-launch | [#468](https://github.com/rent-a-vacation/rav-website/issues/468) |
+| E | Per-category role mapping (admin vs staff) is policy, not enforced in schema or RLS | Pre-launch (low risk) | [#463](https://github.com/rent-a-vacation/rav-website/issues/463) |
+| F | No native support for split refunds, holdbacks, rebooking credits, or platform-fee waivers | Post-launch | [#469](https://github.com/rent-a-vacation/rav-website/issues/469) |
+| G | SLAs are documented here but not enforced in code (no alerting, no business-hours definition in `system_settings`) | Pre-launch (operational) | [#464](https://github.com/rent-a-vacation/rav-website/issues/464) |
+| H | Stripe `charge.dispute.created` does not auto-create internal dispute row | Pre-launch | [#465](https://github.com/rent-a-vacation/rav-website/issues/465) |
+| I | No `jurisdiction` field on bookings; no per-state disclosure logic; no per-state cancellation-override rules | Pre-launch | [#466](https://github.com/rent-a-vacation/rav-website/issues/466) (linked to #80) |
 
 ---
 
@@ -332,3 +332,4 @@ Each gap below should become (or be linked to) a GitHub issue before launch. Tra
 |---|---|---|
 | 2026-04-27 | Initial draft. Captures current implementation, the nine open gaps (A–I), and the regulatory landscape RAV must address before #80 lawyer pass. | Session 60+ |
 | 2026-04-27 | Tightening pass. Corrected migration paths (006 / 023 archived in `docs/supabase-migrations/`), fixed line-number citations (`booking_confirmations` 131–162; confirmation insert at handler.ts:236–266; eligibility uses `stripe_payouts_enabled`). Added six-state lifecycle diagram, owner-confirmation timer details, Pre-Booked vs Wish-Matched distinction, complete eligibility list (7 conditions), commission-tier note, restructured §5.1 dispute categories by typical filer, regulatory disclaimer at §7, business-hours definition for §6 SLAs. | Session 61 |
+| 2026-04-28 | All nine gaps filed as discrete GitHub issues #461–#469. §9 table updated with issue links + dependency notes. Spec is now self-referential — clicking any gap leads to its tracking issue. | Session 61 (follow-up) |


### PR DESCRIPTION
## Summary

Doc-only follow-up to PR #460 — wires the freshly-filed PaySafe gap issues into the spec and the roadmap docs.

- **PAYSAFE-FLOW-SPEC §9** — replaces "New issue" placeholders with #461–#469, plus dependency notes (e.g. #462 depends on #461)
- **PROJECT-HUB.md** — adds DEC-038 (PaySafe spec is the long-running internal source of truth) + Session 61 handoff entry; bumps Last Updated to Session 61
- **PRIORITY-ROADMAP.md** — adds 5 pre-launch gap issues to Tier B (#461, #462, #464, #465, #466), 3 post-launch + #463 to Tier E; Session 61 changelog entry; frontmatter bumped to session-61

No code, migrations, or test changes. Test count unchanged (1394).

## Test plan

- [ ] CI passes (`docs:audit:ci`, `docs:sync-check:ci`, build)
- [ ] Spec §9 issue links resolve to the right issues
- [ ] DEC-038 entry renders cleanly in PROJECT-HUB.md