### PR TITLE
chore(cron): migration 073 cron schedules (already deployed to PROD)

### DIFF
--- a/supabase/migrations/073_session63_cron_schedules.sql
+++ b/supabase/migrations/073_session63_cron_schedules.sql
@@ -1,0 +1,83 @@
+-- Migration 073: Cron schedules for Session 63 edge functions
+-- #462 (auto-confirm-checkins) and #464 (sla-monitor).
+--
+-- Both jobs invoke their respective edge functions hourly via pg_net.
+-- Auth uses the service-role JWT pulled from vault.decrypted_secrets
+-- under the key 'service_role_key'. If that secret is not present, the
+-- net.http_post call will receive an empty Authorization header and the
+-- edge function will reject the request — the failure mode is "cron
+-- runs every hour and gets a 401" rather than corrupted data.
+--
+-- To set the secret one-time per environment:
+--   SELECT vault.create_secret('<service_role_jwt>', 'service_role_key');
+--
+-- Project URL is environment-specific:
+--   PROD: https://xzfllqndrlmhclqfybew.supabase.co
+--   DEV:  https://oukbxqnlxnkainnligfz.supabase.co
+-- Stored in app.settings.supabase_url GUC if available; otherwise the
+-- migration falls back to hardcoded PROD URL. Override in DEV:
+--   ALTER DATABASE postgres SET app.settings.supabase_url
+--     TO 'https://oukbxqnlxnkainnligfz.supabase.co';
+
+-- ── Helper: resolve the project URL ─────────────────────────────────────────
+CREATE OR REPLACE FUNCTION public.session63_supabase_url()
+RETURNS text
+LANGUAGE sql
+STABLE
+AS $$
+  SELECT COALESCE(
+    current_setting('app.settings.supabase_url', true),
+    'https://xzfllqndrlmhclqfybew.supabase.co'  -- PROD fallback
+  );
+$$;
+
+-- ── Unschedule prior versions (idempotent re-run) ───────────────────────────
+DO $$
+BEGIN
+  PERFORM cron.unschedule('auto-confirm-checkins-hourly');
+EXCEPTION WHEN OTHERS THEN NULL;
+END $$;
+
+DO $$
+BEGIN
+  PERFORM cron.unschedule('sla-monitor-hourly');
+EXCEPTION WHEN OTHERS THEN NULL;
+END $$;
+
+-- ── auto-confirm-checkins (hourly) ──────────────────────────────────────────
+SELECT cron.schedule(
+  'auto-confirm-checkins-hourly',
+  '0 * * * *',  -- top of every hour
+  $$
+  SELECT net.http_post(
+    url := public.session63_supabase_url() || '/functions/v1/auto-confirm-checkins',
+    headers := jsonb_build_object(
+      'Content-Type', 'application/json',
+      'Authorization', 'Bearer ' || COALESCE(
+        (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name = 'service_role_key' LIMIT 1),
+        ''
+      )
+    ),
+    body := jsonb_build_object('source', 'pg_cron')
+  ) AS request_id;
+  $$
+);
+
+-- ── sla-monitor (hourly, offset by 30 min so the two cron jobs don't pile) ──
+SELECT cron.schedule(
+  'sla-monitor-hourly',
+  '30 * * * *',
+  $$
+  SELECT net.http_post(
+    url := public.session63_supabase_url() || '/functions/v1/sla-monitor',
+    headers := jsonb_build_object(
+      'Content-Type', 'application/json',
+      'Authorization', 'Bearer ' || COALESCE(
+        (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name = 'service_role_key' LIMIT 1),
+        ''
+      )
+    ),
+    body := jsonb_build_object('source', 'pg_cron')
+  ) AS request_id;
+  $$
+);


### PR DESCRIPTION
## Summary

Captures migration 073 (cron schedules for #462 + #464) in the repo. Already applied to PROD as part of the Session 63 deploy window (May 4); this PR brings the file into git history.

## What's included

- \`supabase/migrations/073_session63_cron_schedules.sql\` — schedules \`auto-confirm-checkins-hourly\` (top of every hour) and \`sla-monitor-hourly\` (:30 each hour) via pg_cron + pg_net.

## Auth note

Cron jobs read \`service_role_key\` from \`vault.decrypted_secrets\`. If the secret isn't seeded, jobs fire but get 401 — failure mode is "cron logs an error every hour" not data corruption.

To seed (one-time, per environment):

\`\`\`sql
SELECT vault.create_secret('<service_role_jwt>', 'service_role_key');
\`\`\`

## Verification

- [x] Migration applied successfully to PROD (May 4)
- [ ] Confirm cron jobs fire at the next hour boundary
- [ ] Confirm vault \`service_role_key\` is seeded on PROD (if not, jobs will 401)

🤖 Generated with [Claude Code](https://claude.com/claude-code)