### PR TITLE
feat(compliance): #485 No Timeshare Sales validation on listing creation

### DIFF
--- a/docs/testing/TESTING-STATUS.md
+++ b/docs/testing/TESTING-STATUS.md
@@ -7,7 +7,7 @@ status: "active"
 # Testing Status
 
 > Current state of the RAV test suite. Updated each session.
-> **Last Updated:** May 6, 2026 (Session 64 — #483 + #484 disclaimer registry + DisclaimerBlock + 9 placements + About page; +89 tests, +9 test files)
+> **Last Updated:** May 6, 2026 (Session 64 — #483 + #484 disclaimer registry + 9 placements + About page; #485 No Timeshare Sales validation; +134 tests, +10 test files)
 
 ---
 
@@ -15,8 +15,8 @@ status: "active"
 
 | Metric | Value |
 |--------|-------|
-| **Total tests** | 1581 |
-| **Test files** | 166 |
+| **Total tests** | 1626 |
+| **Test files** | 167 |
 | **P0 critical-path tests** | 290+ tagged `@p0` (Session 64 added @p0 on disclaimer registry, DisclaimerBlock, StateSpecificDisclaimer, Footer registry sourcing, Terms 8.3+8.6, About page, placement audit) |
 | **E2E smoke tests** | 3 (Playwright) |
 | **Local run time** | ~2.5 min (full), ~2s (P0 only) |

--- a/docs/testing/TESTING-STATUS.md
+++ b/docs/testing/TESTING-STATUS.md
@@ -7,7 +7,7 @@ status: "active"
 # Testing Status
 
 > Current state of the RAV test suite. Updated each session.
-> **Last Updated:** May 2, 2026 (Session 63 — #473 + 7 PaySafe gaps closed, +90 tests, +7 test files)
+> **Last Updated:** May 6, 2026 (Session 64 — #483 + #484 disclaimer registry + DisclaimerBlock + 9 placements + About page; +89 tests, +9 test files)
 
 ---
 
@@ -15,9 +15,9 @@ status: "active"
 
 | Metric | Value |
 |--------|-------|
-| **Total tests** | 1492 |
-| **Test files** | 157 |
-| **P0 critical-path tests** | 220+ tagged `@p0` (Session 63 added @p0 on confirm-checkin handler, auto-confirm-checkins, process-escrow-release, sla-monitor, disputeSla, checkinPhoto, sentry, ReportIssueDialog mapper) |
+| **Total tests** | 1581 |
+| **Test files** | 166 |
+| **P0 critical-path tests** | 290+ tagged `@p0` (Session 64 added @p0 on disclaimer registry, DisclaimerBlock, StateSpecificDisclaimer, Footer registry sourcing, Terms 8.3+8.6, About page, placement audit) |
 | **E2E smoke tests** | 3 (Playwright) |
 | **Local run time** | ~2.5 min (full), ~2s (P0 only) |
 | **CI run time** | <3 min |

--- a/src/lib/disclaimers/placements.test.ts
+++ b/src/lib/disclaimers/placements.test.ts
@@ -96,6 +96,14 @@ const PLACEMENTS: ReadonlyArray<Placement> = [
     ],
     notes: "Booking confirmation email must include verbatim Tax (8.4), Cancellation (8.5), Escrow (8.8) via the edge-function mirror.",
   },
+  {
+    file: "src/pages/ListProperty.tsx",
+    required: [
+      `validateListingForSaleLanguage`,
+      `saleLanguageFieldLabel`,
+    ],
+    notes: "Listing creation must call validateListingForSaleLanguage on owner-provided text fields before any insert (#485 No Timeshare Sales validation).",
+  },
 ];
 
 describe("Disclaimer placement audit — required <DisclaimerBlock /> usages per page", () => {

--- a/src/lib/listingValidation/index.ts
+++ b/src/lib/listingValidation/index.ts
@@ -1,0 +1,12 @@
+export {
+  SALE_LANGUAGE_TERMS,
+  containsSaleLanguage,
+  isListingSaleLanguageRejection,
+  saleLanguageFieldLabel,
+  validateListingForSaleLanguage,
+} from "./noSales";
+export type {
+  ListingTextFields,
+  ListingSaleLanguageResult,
+  SaleLanguageCheckResult,
+} from "./noSales";

--- a/src/lib/listingValidation/noSales.test.ts
+++ b/src/lib/listingValidation/noSales.test.ts
@@ -1,0 +1,169 @@
+// @vitest-environment jsdom
+// @p0
+/**
+ * Tests for the "No Timeshare Sales" listing validator. Compliance-critical:
+ * a regression here lets sale-language listings reach the platform.
+ *
+ * @see GitHub issue #485
+ * @see docs/legal/compliance-gap-analysis.md item I-5
+ */
+import { describe, it, expect } from "vitest";
+import {
+  SALE_LANGUAGE_TERMS,
+  containsSaleLanguage,
+  saleLanguageFieldLabel,
+  validateListingForSaleLanguage,
+} from "./noSales";
+
+describe("containsSaleLanguage — positive cases (must reject)", () => {
+  const cases: Array<[label: string, text: string, expectedTerm: string]> = [
+    ["lowercase 'for sale'", "This timeshare is for sale", "for sale"],
+    ["uppercase 'FOR SALE'", "FOR SALE: vacation week", "for sale"],
+    ["mixed case 'For Sale'", "Available For Sale immediately", "for sale"],
+    ["hyphenated 'for-sale'", "for-sale by owner", "for-sale"],
+    ["'deed transfer'", "Looking for deed transfer arrangement", "deed transfer"],
+    ["'transfer of deed'", "Transfer of deed available upon agreement", "transfer of deed"],
+    ["'transferring deed'", "We will be transferring deed at closing", "transferring deed"],
+    ["'ownership transfer'", "Ownership transfer included with sale", "ownership transfer"],
+    ["'transfer of ownership'", "Full transfer of ownership offered", "transfer of ownership"],
+    ["'buy my'", "Buy my timeshare today", "buy my"],
+    ["'selling my timeshare'", "I'm selling my timeshare points", "selling my timeshare"],
+    ["'sell my timeshare'", "Sell my timeshare for any price", "sell my timeshare"],
+    ["'sell my points'", "I'd like to sell my points fast", "sell my points"],
+    ["'selling my points'", "Selling my points at a discount", "selling my points"],
+    ["'purchase my timeshare'", "Purchase my timeshare and save", "purchase my timeshare"],
+    ["'resale'", "Resale opportunity!", "resale"],
+    ["full-width unicode 'sale'", "ｆｏｒ ｓａｌｅ", "for sale"], // NFKC normalization
+  ];
+
+  for (const [label, text, expectedTerm] of cases) {
+    it(`rejects: ${label}`, () => {
+      expect(containsSaleLanguage(text)).toEqual({ ok: false, term: expectedTerm });
+    });
+  }
+});
+
+describe("containsSaleLanguage — negative cases (must accept)", () => {
+  const cases: Array<[label: string, text: string]> = [
+    ["typical rental description", "Beautiful 2BR vacation rental at the resort"],
+    ["mentions vacation club brand", "Wonderful Marriott Vacation Club week available"],
+    ["available 'for rent'", "Available for rent during summer 2026"],
+    ["mentions 'bought' (not 'buy my')", "We bought this and now want to share with travelers"],
+    ["'selling out quickly' (not 'selling my')", "These dates sell quickly — book now"],
+    ["'family-owned' (not 'ownership transfer')", "Family-owned property since 2010"],
+    ["'deed' alone is allowed (e.g., DVC deeded contract)", "Disney Vacation Club deed property at Aulani"],
+    ["'owned' (not 'ownership transfer')", "Privately owned by responsible host"],
+    ["'transfer' alone (e.g., airport transfer)", "Free airport transfer included"],
+    ["empty string", ""],
+    ["only whitespace", "   "],
+    ["typical description with rental terminology", "Two-bedroom suite available for nightly rental during peak season"],
+    ["mentions 'sales tax'", "Includes applicable sales tax at checkout"],
+    ["typical title", "Marriott's Grande Vista — Lockoff 2BR — Apr 18-25"],
+  ];
+
+  for (const [label, text] of cases) {
+    it(`accepts: ${label}`, () => {
+      expect(containsSaleLanguage(text).ok).toBe(true);
+    });
+  }
+
+  it("accepts null", () => {
+    expect(containsSaleLanguage(null).ok).toBe(true);
+  });
+
+  it("accepts undefined", () => {
+    expect(containsSaleLanguage(undefined).ok).toBe(true);
+  });
+});
+
+describe("validateListingForSaleLanguage", () => {
+  it("returns ok when all fields are clean", () => {
+    const result = validateListingForSaleLanguage({
+      title: "Marriott Aruba Surf Club",
+      resortName: "Marriott Aruba Surf Club",
+      location: "Palm Beach, Aruba",
+      description: "Beautiful 2BR/2BA villa at the resort",
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it("flags the title field when title contains sale language", () => {
+    const result = validateListingForSaleLanguage({
+      title: "FOR SALE: Marriott Vacation Club",
+      description: "Two bedroom unit",
+    });
+    expect(result).toEqual({ ok: false, term: "for sale", field: "title" });
+  });
+
+  it("flags the description field when only description contains sale language", () => {
+    const result = validateListingForSaleLanguage({
+      title: "Beautiful resort week",
+      description: "Buy my timeshare today, asking $5000",
+    });
+    expect(result).toEqual({ ok: false, term: "buy my", field: "description" });
+  });
+
+  it("flags resortName when only resort name contains sale language", () => {
+    const result = validateListingForSaleLanguage({
+      resortName: "Resale Brokers Inc.",
+      description: "Family resort week available",
+    });
+    expect(result).toEqual({ ok: false, term: "resale", field: "resortName" });
+  });
+
+  it("flags location when only location contains sale language", () => {
+    const result = validateListingForSaleLanguage({
+      title: "Beautiful unit",
+      location: "Resale district, Orlando",
+    });
+    expect(result).toEqual({ ok: false, term: "resale", field: "location" });
+  });
+
+  it("returns the FIRST matching field, not the last", () => {
+    // Title is checked before description, so a banned term in title wins.
+    const result = validateListingForSaleLanguage({
+      title: "for sale",
+      description: "buy my timeshare",
+    });
+    expect(result).toEqual({ ok: false, term: "for sale", field: "title" });
+  });
+
+  it("handles missing fields gracefully (only validates provided ones)", () => {
+    expect(validateListingForSaleLanguage({}).ok).toBe(true);
+    expect(validateListingForSaleLanguage({ title: undefined, description: null }).ok).toBe(true);
+  });
+});
+
+describe("SALE_LANGUAGE_TERMS sanity", () => {
+  it("contains the explicit terms required by the compliance brief", () => {
+    // The compliance brief Section 3.2 sub-requirement 1 enumerates these:
+    const required = [
+      "for sale",
+      "for-sale",
+      "deed transfer",
+      "ownership transfer",
+      "buy my",
+      "selling my timeshare",
+      "sell my points",
+      "resale",
+    ];
+    for (const term of required) {
+      expect(SALE_LANGUAGE_TERMS).toContain(term);
+    }
+  });
+
+  it("every term is lowercase (normalization invariant)", () => {
+    for (const term of SALE_LANGUAGE_TERMS) {
+      expect(term).toBe(term.toLowerCase());
+    }
+  });
+});
+
+describe("saleLanguageFieldLabel", () => {
+  it("returns human-readable labels for each field", () => {
+    expect(saleLanguageFieldLabel("title")).toBe("title");
+    expect(saleLanguageFieldLabel("resortName")).toBe("resort name");
+    expect(saleLanguageFieldLabel("location")).toBe("location");
+    expect(saleLanguageFieldLabel("description")).toBe("description");
+  });
+});

--- a/src/lib/listingValidation/noSales.ts
+++ b/src/lib/listingValidation/noSales.ts
@@ -1,0 +1,131 @@
+/**
+ * "No Timeshare Sales" listing validation.
+ *
+ * RAV facilitates timeshare *rentals* only. Listings that read like sale ads
+ * (deed transfers, ownership transfers, "buy my timeshare", resale offers)
+ * undermine the platform's marketplace-facilitator legal posture and pull RAV
+ * into broker-licensing territory under FL § 721.11 and CA B&P § 11003.5.
+ * This validator is the first line of defense — it scans owner-provided text
+ * for sale-language phrases and returns the matched term so the UI can show
+ * a helpful, specific error.
+ *
+ * Staff approval (proof_status workflow on `listings`) is the second line of
+ * defense; nothing reaches renters until staff click Approve.
+ *
+ * @see docs/legal/_extracted_legal_dossier.txt § 2.3 — "No Timeshare Sales" designation
+ * @see docs/legal/_extracted_compliance_brief.txt § 3.2 sub-requirement 1
+ * @see GitHub issue #485
+ */
+
+/**
+ * Phrases that indicate a sale, transfer, or resale rather than a rental.
+ * Each phrase is matched case-insensitively as a substring (after NFKC
+ * normalization + lowercasing). Adding terms here is the right way to harden
+ * the filter — the test suite expects this list to be the single source of
+ * truth.
+ */
+export const SALE_LANGUAGE_TERMS = [
+  "for sale",
+  "for-sale",
+  "deed transfer",
+  "transfer of deed",
+  "transferring deed",
+  "ownership transfer",
+  "transfer of ownership",
+  "transferring ownership",
+  "buy my",
+  "selling my timeshare",
+  "sell my timeshare",
+  "selling my points",
+  "sell my points",
+  "purchase my timeshare",
+  "purchase my points",
+  "resale",
+] as const;
+
+export type SaleLanguageCheckResult =
+  | { ok: true }
+  | { ok: false; term: string };
+
+/**
+ * Returns `{ ok: true }` if the text is clean, or `{ ok: false, term }` with
+ * the first matched banned phrase. Empty / null / undefined input is OK.
+ */
+export function containsSaleLanguage(
+  text: string | null | undefined,
+): SaleLanguageCheckResult {
+  if (!text) return { ok: true };
+  // NFKC normalization collapses full-width / compatibility characters so a
+  // user can't bypass the filter with e.g. wide-form `ｓａｌｅ`. We do not
+  // attempt to normalize alternate dash characters (em / en) — staff review
+  // is the backstop.
+  const normalized = text.normalize("NFKC").toLowerCase();
+  for (const term of SALE_LANGUAGE_TERMS) {
+    if (normalized.includes(term)) {
+      return { ok: false, term };
+    }
+  }
+  return { ok: true };
+}
+
+export interface ListingTextFields {
+  readonly title?: string | null;
+  readonly resortName?: string | null;
+  readonly location?: string | null;
+  readonly description?: string | null;
+}
+
+export type ListingSaleLanguageResult =
+  | { ok: true }
+  | { ok: false; term: string; field: keyof ListingTextFields };
+
+/**
+ * Validate every owner-provided text field on a listing for sale language.
+ * Returns the first field that contains a banned term so the UI can highlight
+ * the right input.
+ */
+export function validateListingForSaleLanguage(
+  fields: ListingTextFields,
+): ListingSaleLanguageResult {
+  const order: ReadonlyArray<keyof ListingTextFields> = [
+    "title",
+    "resortName",
+    "location",
+    "description",
+  ];
+  for (const field of order) {
+    const text = fields[field];
+    if (!text) continue;
+    const normalized = text.normalize("NFKC").toLowerCase();
+    for (const term of SALE_LANGUAGE_TERMS) {
+      if (normalized.includes(term)) {
+        return { ok: false, term, field };
+      }
+    }
+  }
+  return { ok: true };
+}
+
+/**
+ * Type guard for ergonomic narrowing at call sites where TS does not narrow
+ * the discriminated union automatically (some `tsconfig` settings block it).
+ */
+export function isListingSaleLanguageRejection(
+  r: ListingSaleLanguageResult,
+): r is { ok: false; term: string; field: keyof ListingTextFields } {
+  return !r.ok;
+}
+
+/** Human-readable field label for use in user-facing error messages. */
+export function saleLanguageFieldLabel(field: keyof ListingTextFields): string {
+  switch (field) {
+    case "title":
+      return "title";
+    case "resortName":
+      return "resort name";
+    case "location":
+      return "location";
+    case "description":
+      return "description";
+  }
+}

--- a/src/pages/ListProperty.tsx
+++ b/src/pages/ListProperty.tsx
@@ -48,6 +48,11 @@ import { EmailVerificationBanner } from "@/components/EmailVerificationBanner";
 import { calculateNights, computeOwnerPayoutBreakdown } from "@/lib/pricing";
 import { useOwnerCommission } from "@/hooks/useOwnerCommission";
 import { trackEvent } from "@/lib/posthog";
+import {
+  isListingSaleLanguageRejection,
+  saleLanguageFieldLabel,
+  validateListingForSaleLanguage,
+} from "@/lib/listingValidation/noSales";
 
 const benefits = [
   {
@@ -362,6 +367,22 @@ const ListProperty = () => {
     // Check listing limit before creating
     if (!canCreateListing) {
       setSubmitError("You've reached your listing limit. Please upgrade your plan to create more listings.");
+      setIsSubmitting(false);
+      return;
+    }
+
+    // #485 — "No Timeshare Sales" validation. RAV facilitates rentals only;
+    // reject listings whose owner-provided text reads like a sale ad. Staff
+    // approval (proof_status workflow) is the secondary defense.
+    const saleCheck = validateListingForSaleLanguage({
+      resortName,
+      location,
+      description,
+    });
+    if (isListingSaleLanguageRejection(saleCheck)) {
+      setSubmitError(
+        `Listings cannot contain sale-related language. The ${saleLanguageFieldLabel(saleCheck.field)} contains "${saleCheck.term}". Rent-A-Vacation is a marketplace for renting timeshare periods only — see /about for details.`,
+      );
       setIsSubmitting(false);
       return;
     }


### PR DESCRIPTION
## Summary

Closes **#485** — "No Timeshare Sales" listing-creation validation.

- Pure-function validator at \`src/lib/listingValidation/noSales.ts\`. Block list of sale-language phrases (e.g. "for sale", "deed transfer", "buy my", "selling my timeshare", "resale"); case-insensitive + NFKC normalization (defeats full-width unicode bypass).
- Validates \`title\`, \`resortName\`, \`location\`, \`description\` fields and returns the first matching field so the UI can highlight the right input.
- Wired into \`ListProperty.tsx\` \`handleSubmit\` before any DB insert. Error message names the matched term + field and links to \`/about\` for context.
- Staff approval (proof_status workflow) remains the secondary defense.

## Why this matters

RAV's marketplace-facilitator legal posture depends on staying rentals only. FL § 721.11 and CA B&P § 11003.5 define "timeshare plan" broadly; a listing that reads like a sale ad pulls RAV into broker-licensing territory.

## DB-level enforcement (deferred)

The current architecture inserts listings client-side via the supabase client — no edge function in between. A determined user could bypass client validation with a direct API call. Defense-in-depth at the DB level would be a BEFORE INSERT trigger mirroring the TS block list. Deferred because (a) staff approval is still the gate before anything reaches renters, (b) drift mitigation would need its own test infrastructure.

## Test plan

- [x] \`npm run test\` — 1626 / 1626 pass (45 new: 43 validator unit + 2 placement audit)
- [x] \`npm run build\` — clean
- [x] ESLint + TypeScript clean for changed files
- [x] \`docs:sync-check\` green (test count claim bumped to 1626)

🤖 Generated with [Claude Code](https://claude.com/claude-code)