### PR TITLE
docs(session-64): retire sequential phase numbering — DEC-040 + sync-check guard

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,6 +117,26 @@ The same check runs in CI on every PR via `.github/workflows/docs-audit.yml` —
 - **In progress** → add `in-progress` label
 - **Done** → close issue with summary comment
 
+### Milestone strategy — themed, not sequential phases (DEC-040)
+
+Sequential `Phase NN` numbering ended at **Phase 22: Customer Support Foundation**. New work is tracked under **themed GitHub milestones** named for an outcome a non-engineer can read at a glance.
+
+**When to create a new themed milestone:**
+- 5+ related issues that share an outcome
+- Cross-cuts code + docs + ops
+- Has a clean "done" state when the theme is delivered
+
+**When NOT to:**
+- One-off bug → `Maintenance & Bugs`
+- Single feature → standalone issue, no milestone
+- Sequential continuation of an old phase → ❌ **never create `Phase 23` or higher.** Use a theme instead.
+
+**Examples in flight:** `Launch Readiness`, `Role-Based UX Overhaul`, `Search & Discovery Enhancement`, `Security Hardening`, `Growth & Marketing`, `Analytics & Monitoring`, `Maintenance & Bugs`. A natural next theme would be **"PaySafe Compliance Hardening"** wrapping #461–#468 + #80 + #438.
+
+Standard answer to "what phase are we on?": *"Phase 22 was the last numbered phase; current work is tracked under the Launch Readiness milestone."*
+
+`scripts/docs-sync-check.ts` enforces this — any new `Phase 23+` reference in `docs/**/*.md` fails CI (with an allowlist for the historical archive and DEC-040 itself).
+
 ### Creating issues during a session
 ```bash
 # Bug discovered
@@ -125,11 +145,11 @@ gh issue create --repo rent-a-vacation/rav-website \
   --label "bug,platform" \
   --body "[What's broken, steps to reproduce, expected vs actual]"
 
-# Enhancement identified
+# Enhancement identified — milestone is THEMED, not Phase NN
 gh issue create --repo rent-a-vacation/rav-website \
   --title "[Feature name]" \
   --label "enhancement,pre-launch,marketplace" \
-  --milestone "Phase 20: Accounting & Tax" \
+  --milestone "Launch Readiness" \
   --body "[What needs to be built and why]"
 ```
 
@@ -514,3 +534,4 @@ All admin actions that modify data MUST have appropriate confirmation dialogs:
 - ❌ Never skip updating seed manager when adding tables (see Seed Manager Convention)
 - ❌ Never use placeholder content or fake statistics
 - ❌ Never modify production Supabase (xzfllqndrlmhclqfybew) without explicit human confirmation
+- ❌ Never propose `Phase 23` or higher — sequential phase numbering ended at Phase 22 (DEC-040). Use themed milestones for new work.

--- a/docs/PRIORITY-ROADMAP.md
+++ b/docs/PRIORITY-ROADMAP.md
@@ -1,7 +1,7 @@
 ---
 last_updated: "2026-04-28T10:04:52"
 change_ref: "dfba76b"
-change_type: "session-63"
+change_type: "session-64"
 status: "active"
 ---
 # PRIORITY ROADMAP — Rent-A-Vacation
@@ -48,7 +48,7 @@ When `/sdlc pickup` runs next, the user has explicitly scoped the next session a
 
 **Also consider after those:** A controlled PROD deploy window for the accumulated Phase 22 + Session 59 changes (migrations 060–065, text-chat updates with support context + 5 tools + classifier, ingest-support-docs + cancel-listing edge fns, support_conversations + listing-proofs + dispute_source schemas). All currently sit on DEV per CLAUDE.md human-confirmation rule.
 
-## Current Priority Tiers (as of May 2, 2026 — Session 63)
+## Current Priority Tiers (as of May 6, 2026 — Session 64)
 
 ### Tier A: Build Next (High Impact, Code-Ready)
 
@@ -151,6 +151,7 @@ These unblock when the LLC is formed. Not code-dependent.
 
 | Date | Session | Changes |
 |------|---------|---------|
+| May 6, 2026 | 64 | **DEC-040 logged — sequential Phase numbering retired.** Phase 22 was the last numbered phase; new work (5+ related issues sharing an outcome) goes into themed milestones (`Launch Readiness`, `Security Hardening`, `Role-Based UX Overhaul`, etc.). PROJECT-HUB.md, this file, and `CLAUDE.md` updated with the new convention. `scripts/docs-sync-check.ts` extended with `checkPhaseNumbering()` rule that fails CI on any new "Phase 23+" reference outside the allowlist. Auto-memory saved. **No tier changes.** Doc-only Session 64. |
 | May 2, 2026 | 63 | **#473 SHIPPED (PR #474)** — PostHog session recording disabled + Sentry `beforeSend` filter for EvalError/CSP events; resolves 16-user CSP block on /signup. **PaySafe Compliance doc created** (`docs/payments/PAYSAFE-COMPLIANCE.md`) — captures marketplace + Stripe Connect compliance posture, gap closure register, placeholder for incoming counsel references; DEC-039 logged. **PaySafe gaps C (#467), D (#468) promoted Tier E → Tier B**, and #463 (Gap E) consolidated under Tier B per user stance "minimal post-launch deferral." Session 63 working scope: 7 of 9 PaySafe gaps (A, B, C, D, E, G, H) + #473. F deferred (user confirmed); I gated on #80 lawyer pass. |
 | Apr 27–28, 2026 | 61 | **PaySafe Flow Specification SHIPPED (PR #460).** New `docs/payments/PAYSAFE-FLOW-SPEC.md` — authoritative internal spec for the escrow + dispute system across 11 sections. DEC-038 logged. **9 gap issues opened** (#461–#469): pre-launch (#461 confirm-checkin server action, #462 auto-confirm cron, #463 role-mapping enforcement, #464 SLA enforcement, #465 Stripe chargeback auto-mirror, #466 jurisdiction field) and post-launch (#467 issue→dispute pre-fill, #468 hold-period to system_settings, #469 split refunds/holdbacks/credits). Tier B updated with the 5 Launch-Readiness gap issues; Tier E updated with the 3 post-launch gap issues + #463 (Security Hardening). Doc-only PR — no test count change (1394), no migrations, no edge-fn changes. |
 | Apr 25, 2026 | 60 | **#442 + #445 SHIPPED (PR #446).** Stripe Connect tests + vitest coverage extension to `supabase/functions/**`. 19 new tests (1375 → 1394). Coverage now measures handler.ts files; thresholds unchanged at 25/25/30/25 — all pass with 75/78/84/75 actuals. Tier A confirmed empty. Tier audit: added #368 + #443 + #444 to Tier E with explicit triggers; clarified #233 (X/Twitter) as post-launch; expanded #404 row to mention all 8 policy drafts (was 6); reframed #438 with confirmed Atlas + 4-founder + Florida foreign-entity scope. |

--- a/docs/PROJECT-HUB.md
+++ b/docs/PROJECT-HUB.md
@@ -1,7 +1,7 @@
 ---
 last_updated: "2026-05-01T02:17:14"
 change_ref: "8a06e90"
-change_type: "session-63"
+change_type: "session-64"
 status: "active"
 ---
 # PROJECT HUB - Rent-A-Vacation
@@ -9,7 +9,7 @@ status: "active"
 > **Architectural decisions, session context, and agent instructions**
 > **Task tracking has moved to [GitHub Issues & Milestones](https://github.com/rent-a-vacation/rav-website/issues)**
 > **Project board: [RAV Roadmap](https://github.com/orgs/rent-a-vacation/projects/1)**
-> **Last Updated:** May 2, 2026 (Session 63: #473 CSP fix shipped; PaySafe gap sweep A/B/C/D/E/G/H + compliance doc — DEC-039 logged)
+> **Last Updated:** May 6, 2026 (Session 64: DEC-040 — sequential Phase numbering retired; new work uses themed milestones)
 > **Repository:** https://github.com/rent-a-vacation/rav-website
 > **App Version:** v0.9.0 (build version visible in footer)
 
@@ -106,7 +106,21 @@ gh issue create --repo rent-a-vacation/rav-website --title "..." --label "..." -
 - **dev and main:** Session 63 8-PR sweep (PR #474) sits on `dev` awaiting `dev → main` merge (1492 tests, 7 new migrations, 3 new edge fns, 1 refactored).
 - **GitHub Project:** RAV Roadmap — 202 issues, all with Status/Category/Sub-Category/Type populated. Auto-add workflow enabled. PRs excluded.
 
-### Session Handoff (Sessions 25-63)
+### Session Handoff (Sessions 25-64)
+
+**Session 64 — Phase numbering retired; themed milestones formalized (May 6, 2026):**
+
+Doc-only checkpoint. User asked how many phases were complete and whether Phase 23 was the next. Walked through GitHub Milestones (authoritative source per CLAUDE.md) vs PROJECT-HUB.md vs COMPLETED-PHASES.md and confirmed: **18 phase milestones closed; Phase 21 + Phase 22 effectively complete; Phase 20 partial (pre-launch shipped, post-launch deferred); Phase 12 deferred per DEC-011; Phase 3 / Phase 21-Partial-Week are placeholders.** No Phase 23 anywhere.
+
+**DEC-040 logged:** Sequential Phase numbering ended at Phase 22. New work (5+ related issues sharing an outcome) is tracked under themed GitHub milestones (`Launch Readiness`, `Security Hardening`, `Role-Based UX Overhaul`, etc.). Standard answer to "what phase are we on?": *"Phase 22 was the last numbered phase; current work is tracked under the Launch Readiness milestone."* Auto-memory `feedback_themed_milestones_for_new_work.md` saved so future sessions default to this.
+
+**SDLC hardening (so this doesn't drift):**
+- `CLAUDE.md` — added a "Milestone strategy" subsection under Project Management that codifies themed-only for new work; updated the issue-creation example to use a themed milestone instead of `Phase 20`; added "Never propose Phase 23+" to What NOT to Do.
+- `scripts/docs-sync-check.ts` — extended with a new `checkPhaseNumbering()` rule that scans `docs/**/*.md` for new "Phase 23"/"Phase 24" references and fails CI if found (allowlist for the historical archive in COMPLETED-PHASES.md and the DEC-040 entry itself).
+
+**No code, no migrations, no test count delta.** PRs touched: PROJECT-HUB, PRIORITY-ROADMAP, CLAUDE.md, docs-sync-check.ts. 1492 tests unchanged.
+
+---
 
 **Session 63 — #473 + PaySafe gap sweep + compliance doc (May 2, 2026):**
 
@@ -1078,6 +1092,36 @@ Three workstreams shipped plus Phase 21 DoD cleanup. All backed by GitHub issues
 - #190 — Webhook delivery to partners (event notifications)
 - #191 — Chat endpoint (`/v1/chat`) via gateway
 - #192 — SDK packages for partners (npm, Python)
+
+---
+
+### DEC-040: Themed Milestones for New Work (Sequential Phase Numbering Retired)
+**Date:** May 6, 2026 (Session 64)
+**Decision:** New work is tracked under **themed GitHub milestones** (named for an outcome), not new sequential Phase numbers. Phase numbering effectively ended at **Phase 22: Customer Support Foundation** (Sessions 57–58). There is no "Phase 23" and there will not be one.
+
+**Trigger to create a new themed milestone:**
+- 5+ related issues that share an outcome a non-engineer can read at a glance
+- A clean "done" state — the milestone closes when the theme is delivered
+- The work cross-cuts code + docs + ops (themes hold all of it; phase numbers historically only held code)
+
+**Counter-cases (do NOT create a new milestone):**
+- One-off bugs → file under existing `Maintenance & Bugs`
+- Single feature with no siblings → standalone issue, no milestone
+
+**Examples of the pattern in flight today:** `Launch Readiness`, `Role-Based UX Overhaul`, `Search & Discovery Enhancement`, `Security Hardening`, `Growth & Marketing`, `Analytics & Monitoring`, `Maintenance & Bugs`. A natural next theme would be **"PaySafe Compliance Hardening"** wrapping #461–#468 + #80 + #438, instead of relabelling that work as Phase 23.
+
+**Rationale:**
+1. **Phase numbers stopped communicating anything by ~Phase 20.** Sequence-by-happenstance, not sequence-by-dependency. New collaborators couldn't infer scope from the number.
+2. **Themes survive scope changes.** Issues can be added to `Launch Readiness` without renumbering anything; you can't add issues to a "Phase" without negotiating what that phase means.
+3. **Stakeholder-readable.** A milestone called "Security Hardening" tells founder, counsel, and marketing what's happening; "Phase 23" tells them nothing.
+4. **Authoritative source clarified.** GitHub Milestones is the source of truth (per CLAUDE.md priority #1). PROJECT-HUB.md and COMPLETED-PHASES.md are derivative — they describe past phases but do not define future ones.
+
+**What changes:**
+- Going forward, no PR or issue should reference a "Phase 23" or higher
+- When asked "what phase are we on?", the standard answer is: *"Phase 22 was the last numbered phase. Current work is tracked under the Launch Readiness milestone (plus themed sub-milestones for cross-cutting work)."*
+- Auto-memory `feedback_themed_milestones_for_new_work.md` saved so future Claude Code sessions default to this approach
+
+**Status:** Active. Supersedes the implicit assumption that Phase numbering would continue.
 
 ---
 

--- a/scripts/docs-sync-check.ts
+++ b/scripts/docs-sync-check.ts
@@ -12,6 +12,10 @@
  * Also validates docs/support/**\/*.md frontmatter + legal-review freshness
  * (Phase 22 — DEC-036).
  *
+ * Also enforces DEC-040 (themed milestones, not sequential phases): any
+ * "Phase 23+" reference in docs/**\/*.md fails the check unless it appears
+ * in the allowlist (the historical archive and the DEC-040 entry itself).
+ *
  * Complements scripts/docs-audit.ts (which checks frontmatter + orphans).
  *
  * Usage:
@@ -51,6 +55,15 @@ const ROADMAP_MAX_DRIFT = 1;
 const TEST_COUNT_DRIFT_PCT = 0.05;
 // LAUNCH-READINESS change_type must have been bumped within the last N sessions
 const LAUNCH_MAX_SESSION_DRIFT = 3;
+
+// DEC-040 — Phase numbering is retired at Phase 22.
+// New "Phase 23"/"Phase 24"/… references in docs are blocked unless they
+// appear in this allowlist (historical archive + the DEC-040 entry itself).
+const PHASE_NUMBERING_MAX = 22;
+const PHASE_NUMBERING_ALLOWLIST = [
+  'docs/COMPLETED-PHASES.md', // historical archive — keeps old phase mentions intact
+  'docs/exports/',            // pre-DEC-040 exported snapshots
+] as const;
 
 // Support docs (Phase 22)
 const SUPPORT_DOCS_ROOT = 'docs/support';
@@ -379,6 +392,88 @@ function checkSupportDocs(): CheckResult[] {
   ];
 }
 
+function isDec040MetaReference(lines: string[], idx: number): boolean {
+  // A Phase 23+ mention is allowed if it's a meta-reference to DEC-040.
+  // Two ways that's true:
+  //   1. Inside the DEC-040 section (walk upward to nearest `### DEC-NNN`)
+  //   2. Within ±10 lines of any "DEC-040" mention (covers handoff entries,
+  //      revision-history rows, and inline rule citations)
+  for (let i = idx; i >= 0; i--) {
+    const line = lines[i];
+    const decMatch = line.match(/^###\s+DEC-(\d+)/);
+    if (decMatch) {
+      if (decMatch[1] === '040') return true;
+      break; // hit a different DEC heading — stop section-walk
+    }
+    if (/^##\s+/.test(line)) break;
+  }
+  const start = Math.max(0, idx - 10);
+  const end = Math.min(lines.length, idx + 10);
+  for (let i = start; i < end; i++) {
+    if (/DEC-040/.test(lines[i])) return true;
+  }
+  return false;
+}
+
+function checkPhaseNumbering(): CheckResult[] {
+  // DEC-040 guard: any "Phase 23"/"Phase 24"/… in docs/**/*.md fails CI.
+  // Allowlist covers the historical archive and exported snapshots.
+  const docsRoot = 'docs';
+  if (!existsSync(docsRoot)) {
+    return [{ doc: 'docs', status: 'ok', message: 'docs/ folder absent — skipping' }];
+  }
+
+  const files = walkMarkdown(docsRoot);
+  const offenders: { file: string; line: number; phase: number; text: string }[] = [];
+
+  for (const file of files) {
+    if (PHASE_NUMBERING_ALLOWLIST.some((prefix) => file.startsWith(prefix))) continue;
+
+    const content = readFileSync(file, 'utf-8');
+    const lines = content.split(/\r?\n/);
+
+    lines.forEach((line, idx) => {
+      // Match "Phase NN" where NN is 23+. Captures both bare "Phase 23"
+      // and milestone-shaped "Phase 23: …" / "phase-23".
+      for (const m of line.matchAll(/\bPhase[\s-](\d{2,3})\b/gi)) {
+        const n = parseInt(m[1], 10);
+        if (n > PHASE_NUMBERING_MAX) {
+          // Skip the DEC-040 entry itself — it explicitly cites "Phase 23"
+          // as the thing not to do. Walk upward to the nearest section
+          // heading; if it's DEC-040, the mention is intentional.
+          if (isDec040MetaReference(lines, idx)) continue;
+          offenders.push({ file, line: idx + 1, phase: n, text: line.trim() });
+        }
+      }
+    });
+  }
+
+  if (offenders.length === 0) {
+    return [
+      {
+        doc: 'docs/**/*.md (Phase numbering)',
+        status: 'ok',
+        message: `No Phase ${PHASE_NUMBERING_MAX + 1}+ references — DEC-040 themed-milestone convention holds`,
+      },
+    ];
+  }
+
+  return [
+    {
+      doc: 'docs/**/*.md (Phase numbering)',
+      status: 'error',
+      message:
+        `Found ${offenders.length} reference(s) to Phase ${PHASE_NUMBERING_MAX + 1}+ — DEC-040 retired sequential phase numbering. ` +
+        `Use a themed milestone instead. Offenders:\n` +
+        offenders
+          .slice(0, 10)
+          .map((o) => `       • ${o.file}:${o.line} — "Phase ${o.phase}" in: ${o.text.slice(0, 100)}`)
+          .join('\n') +
+        (offenders.length > 10 ? `\n       … and ${offenders.length - 10} more` : ''),
+    },
+  ];
+}
+
 function walkMarkdown(root: string): string[] {
   const out: string[] = [];
   const stack = [root];
@@ -413,6 +508,7 @@ function main(): void {
     checkTestingStatus(),
     checkLaunchReadiness(latestSession),
     ...checkSupportDocs(),
+    ...checkPhaseNumbering(),
   ];
 
   const errors = results.filter((r) => r.status === 'error');


### PR DESCRIPTION
## Summary

- **DEC-040 logged** — Sequential `Phase NN` numbering ended at Phase 22. New work goes into themed GitHub milestones (`Launch Readiness`, `Security Hardening`, `Role-Based UX Overhaul`, etc.). Standard answer to "what phase are we on?": *"Phase 22 was the last numbered phase; current work is tracked under the Launch Readiness milestone."*
- **CLAUDE.md hardened** — New "Milestone strategy" subsection codifying themed-only for new work; issue-creation example switched from `Phase 20` to `Launch Readiness`; "Never propose Phase 23+" added to What NOT to Do.
- **`docs-sync-check.ts` extended** — New `checkPhaseNumbering()` rule scans `docs/**/*.md` for `Phase 23+` references and fails CI. Allowlist covers `COMPLETED-PHASES.md` (historical archive), pre-DEC-040 exports, and DEC-040 meta-references (within ±10 lines of any "DEC-040" mention or inside the DEC-040 section). The CI workflow `.github/workflows/docs-audit.yml` already runs `docs:sync-check --ci`, so this is enforced on every future PR with no additional wiring.

Doc-only Session 64. No code, no migrations, no test count change (1492).

## Files changed

- `docs/PROJECT-HUB.md` — DEC-040 entry; Session 64 handoff entry; frontmatter `change_type` → `session-64`; "Last Updated" + Session Handoff header bumped.
- `docs/PRIORITY-ROADMAP.md` — Revision history row; "as of … Session 64" header; frontmatter → `session-64`.
- `CLAUDE.md` — Milestone strategy subsection + What NOT to Do entry + issue-creation example update.
- `scripts/docs-sync-check.ts` — `checkPhaseNumbering()` + `isDec040MetaReference()` helper + wiring into main.

## Test plan

- [x] `npm run docs:sync-check` → 6 ok, 0 warn, 0 error
- [x] Inject fake `Phase 25` reference → guard fires, exit 1 in `--ci` mode
- [x] Restore → exit 0 in `--ci` mode
- [x] No code changes; no test runs needed (test count unchanged at 1492)
- [ ] CI green on this PR (verifies the `docs-audit.yml` workflow picks up the new rule end-to-end)

🤖 Generated with [Claude Code](https://claude.com/claude-code)