### PR TITLE
chore: gitignore confidential docs + Zoho Sign + Phase-numbering retirement + 063 reserved-word fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,17 @@ docs/incorporation/signed/
 
 # Office app temp/lock files
 ~$*
+
+# Confidential strategy & legal source documents — the rent-a-vacation/rav-website
+# repo is PUBLIC. Files matched here must never be committed (or re-committed if
+# they are already tracked). Note: patterns below preventively block future
+# additions; legal dossier + compliance brief PDFs that are already tracked
+# require a separate git-history scrub to fully remove (deferred — see
+# project_legal_dossier_scrub_pending.md memory).
+docs/legal/Legal_Dossier_*.pdf
+docs/legal/RAV_Compliance_Brief_*.pdf
+docs/features/rami/
+docs/competitive-intelligence/
+**/competitor-analysis/
+RAMI-Agent-Build-Prompt-*.docx
+RAV-Competitive-Intelligence-*.docx

--- a/supabase/migrations/063_support_metrics_rpc.sql
+++ b/supabase/migrations/063_support_metrics_rpc.sql
@@ -36,7 +36,7 @@ BEGIN
   END IF;
 
   RETURN QUERY
-  WITH window AS (
+  WITH metrics_window AS (
     SELECT *
     FROM public.support_conversations
     WHERE started_at >= date_from
@@ -52,36 +52,36 @@ BEGIN
       ON prev.conversation_id = m.conversation_id
      AND prev.turn_index      = m.turn_index - 1
      AND prev.turn_type       = 'user'
-    JOIN window w ON w.id = m.conversation_id
+    JOIN metrics_window w ON w.id = m.conversation_id
     WHERE m.turn_type = 'assistant'
   )
   SELECT
-    (SELECT COUNT(*) FROM window)                                          AS total_conversations,
-    (SELECT COUNT(*) FROM window WHERE ended_at IS NOT NULL)               AS ended_conversations,
-    (SELECT COUNT(*) FROM window
+    (SELECT COUNT(*) FROM metrics_window)                                          AS total_conversations,
+    (SELECT COUNT(*) FROM metrics_window WHERE ended_at IS NOT NULL)               AS ended_conversations,
+    (SELECT COUNT(*) FROM metrics_window
        WHERE ended_at IS NOT NULL AND escalated_at IS NULL)                AS deflected_count,
-    (SELECT COUNT(*) FROM window WHERE escalated_at IS NOT NULL)           AS escalated_count,
+    (SELECT COUNT(*) FROM metrics_window WHERE escalated_at IS NOT NULL)           AS escalated_count,
     CASE
-      WHEN (SELECT COUNT(*) FROM window WHERE ended_at IS NOT NULL) = 0 THEN NULL
+      WHEN (SELECT COUNT(*) FROM metrics_window WHERE ended_at IS NOT NULL) = 0 THEN NULL
       ELSE ROUND(
-        100.0 * (SELECT COUNT(*) FROM window
+        100.0 * (SELECT COUNT(*) FROM metrics_window
                    WHERE ended_at IS NOT NULL AND escalated_at IS NULL)
-             / (SELECT COUNT(*) FROM window WHERE ended_at IS NOT NULL),
+             / (SELECT COUNT(*) FROM metrics_window WHERE ended_at IS NOT NULL),
         1
       )
     END                                                                    AS deflection_pct,
     CASE
-      WHEN (SELECT COUNT(*) FROM window) = 0 THEN NULL
+      WHEN (SELECT COUNT(*) FROM metrics_window) = 0 THEN NULL
       ELSE ROUND(
-        100.0 * (SELECT COUNT(*) FROM window WHERE escalated_at IS NOT NULL)
-             / (SELECT COUNT(*) FROM window),
+        100.0 * (SELECT COUNT(*) FROM metrics_window WHERE escalated_at IS NOT NULL)
+             / (SELECT COUNT(*) FROM metrics_window),
         1
       )
     END                                                                    AS escalation_pct,
     (SELECT percentile_cont(0.5) WITHIN GROUP (ORDER BY gap_ms) FROM response_gaps) AS median_response_ms,
-    (SELECT COUNT(*) FROM window WHERE user_rating IS NOT NULL)            AS rated_count,
-    (SELECT COUNT(*) FROM window WHERE user_rating = 1)                    AS positive_rating_count,
-    (SELECT COUNT(*) FROM window WHERE user_rating = -1)                   AS negative_rating_count;
+    (SELECT COUNT(*) FROM metrics_window WHERE user_rating IS NOT NULL)            AS rated_count,
+    (SELECT COUNT(*) FROM metrics_window WHERE user_rating = 1)                    AS positive_rating_count,
+    (SELECT COUNT(*) FROM metrics_window WHERE user_rating = -1)                   AS negative_rating_count;
 END;
 $$;
 


### PR DESCRIPTION
## Summary

Bundle of dev-branch chores that accumulated between #497 and now. Promoting to main so dev and main stay aligned.

### 1e84b6a — operating model + brand assets + gh-issues export + legal PDFs
Reference materials added to the repo. ⚠️ Note: this commit added the source PDFs of the legal dossier + compliance brief; the next commit closes the door on future copies but those files remain in repo history.

### 7167edd — gitignore confidential strategy + legal sources
Adds preventive `.gitignore` patterns for `docs/legal/Legal_Dossier_*.pdf`, `docs/legal/RAV_Compliance_Brief_*.pdf`, `docs/features/rami/`, `docs/competitive-intelligence/`, `**/competitor-analysis/`, RAMI .docx files, and competitive-intel .docx files. **Only blocks future commits** — full scrub of historical objects (via `git filter-repo`) is deferred to a focused pre-launch session per user direction.

### d8cd8d1 — Zoho Sign incorporation flow + md-to-pdf utility
Switches incorporation signing flow to Zoho Sign; adds `scripts/md-to-pdf.py` (which I used to render the attorney dossier PDFs in #495).

### 68609d7 — DEC-040 + docs:sync-check session-64 guard
Retires sequential `Phase NN` numbering at Phase 22; new work uses themed milestones (`Launch Readiness`, `Role-Based UX Overhaul`, etc.). Hardens `scripts/docs-sync-check.ts` so future PRs claiming session-N+1 actually update the docs.

### 77aa9f0 — fix(migrations): rename CTE 'window' → 'metrics_window' in 063
PostgreSQL reserves WINDOW; using it as a CTE name is a parse error. Migration 063 worked when applied originally via Studio SQL editor in Session 63, but `supabase db push` fails to parse it. Renamed all 14 occurrences. Function uses `CREATE OR REPLACE` so re-running on DEV (where it may already exist) is idempotent.

**Outcome on DEV (this evening):** With this fix in place, `supabase db push` successfully applied the full Session-63 backlog plus 074 to DEV — 11 migrations (063, 064, 065, 066, 068–074). `supabase migration list --linked` now shows Local + Remote columns matching for all rows. Backfill of `listings.state` from `resort.location->>'state'` ran inside Migration 074's transaction.

## Operations note for PROD

PROD has the same Studio-vs-CLI drift on these migrations. After this PR merges, run `supabase db push` against PROD (after re-linking) to apply the same backlog with the 063 fix in place. Pre-launch hygiene rationale: zero-tech-debt at launch.

## Test plan

- [x] `git status` clean post-commit
- [x] `.gitignore` syntax verified by git (no warnings)
- [x] `npm run docs:sync-check` green at session-64
- [x] DEV migrations 063–074 applied successfully via CLI push
- [ ] CI green on this PR