### PR TITLE
feat(financials): port financial model to TypeScript + exceljs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,15 @@ docs/incorporation/signed/
 # Office app temp/lock files
 ~$*
 
+# Confidential financial model — the .gs source (in docs/financials/) is safe
+# to commit because it contains only structure + formulas. The generated
+# .xlsx artifacts contain real revenue projections, funding ask numbers,
+# and founder context, and MUST NEVER be committed. The artifact lives in
+# the user's OneDrive and is shared with co-founders directly.
+docs/financials/*.xlsx
+docs/financials/*.xls
+docs/financials/*.csv
+
 # Confidential strategy & legal source documents — the rent-a-vacation/rav-website
 # repo is PUBLIC. Files matched here must never be committed (or re-committed if
 # they are already tracked). Note: patterns below preventively block future

--- a/package-lock.json
+++ b/package-lock.json
@@ -82,6 +82,7 @@
         "eslint": "^9.32.0",
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-react-refresh": "^0.4.20",
+        "exceljs": "^4.4.0",
         "globals": "^15.15.0",
         "gray-matter": "^4.0.3",
         "husky": "^9.1.7",
@@ -2396,6 +2397,51 @@
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
+    },
+    "node_modules/@fast-csv/format": {
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/@fast-csv/format/-/format-4.3.5.tgz",
+      "integrity": "sha512-8iRn6QF3I8Ak78lNAa+Gdl5MJJBM5vRHivFtMRUWINdevNo00K7OXxS2PshawLKTejVwieIlPmK5YlLu6w4u8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^14.0.1",
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isequal": "^4.5.0",
+        "lodash.isfunction": "^3.0.9",
+        "lodash.isnil": "^4.0.0"
+      }
+    },
+    "node_modules/@fast-csv/format/node_modules/@types/node": {
+      "version": "14.18.63",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
+      "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@fast-csv/parse": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/@fast-csv/parse/-/parse-4.3.6.tgz",
+      "integrity": "sha512-uRsLYksqpbDmWaSmzvJcuApSEe38+6NQZBUsuAyMZKqHxH0g1wcJgsKUvN3WC8tewaqFjBMMGrkHmC+T7k8LvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^14.0.1",
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.groupby": "^4.6.0",
+        "lodash.isfunction": "^3.0.9",
+        "lodash.isnil": "^4.0.0",
+        "lodash.isundefined": "^3.0.1",
+        "lodash.uniq": "^4.5.0"
+      }
+    },
+    "node_modules/@fast-csv/parse/node_modules/@types/node": {
+      "version": "14.18.63",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
+      "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@floating-ui/core": {
       "version": "1.7.2",
@@ -7344,6 +7390,126 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/archiver": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-5.3.2.tgz",
+      "integrity": "sha512-+25nxyyznAXF7Nef3y0EbBeqmGZgeN/BxHX29Rs39djAfaFalmQ89SE6CWyDCHzGL0yt/ycBtNOmGTW0FyGWNw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "archiver-utils": "^2.1.0",
+        "async": "^3.2.4",
+        "buffer-crc32": "^0.2.1",
+        "readable-stream": "^3.6.0",
+        "readdir-glob": "^1.1.2",
+        "tar-stream": "^2.2.0",
+        "zip-stream": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/archiver-utils": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-2.1.0.tgz",
+      "integrity": "sha512-bEL/yUb/fNNiNTuUz979Z0Yg5L+LzLxGJz8x79lYmR54fmTIb6ob/hNQgkQnIUDWIFjZVQwl9Xs356I6BAMHfw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "glob": "^7.1.4",
+        "graceful-fs": "^4.2.0",
+        "lazystream": "^1.0.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.difference": "^4.5.0",
+        "lodash.flatten": "^4.4.0",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.union": "^4.6.0",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/archiver-utils/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/archiver-utils/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/archiver/node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/arg": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
@@ -7720,6 +7886,27 @@
         "bare-path": "^3.0.0"
       }
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.9.19",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.19.tgz",
@@ -7740,6 +7927,30 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/big-integer": {
+      "version": "1.6.52",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
+      "integrity": "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==",
+      "dev": true,
+      "license": "Unlicense",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/binary": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
+      "integrity": "sha512-D4H1y5KYwpJgK8wk1Cue5LLPgmwHKYSChkbspQg5JtVuR5ulGckxfR62H3AE9UDkdMC8yyXlqYihuz3Aqg2XZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffers": "~0.1.1",
+        "chainsaw": "~0.1.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -7751,6 +7962,25 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/bluebird": {
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
+      "integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/body-parser": {
       "version": "1.20.4",
@@ -7870,6 +8100,31 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
     "node_modules/buffer-crc32": {
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
@@ -7886,6 +8141,25 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/buffer-indexof-polyfill": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz",
+      "integrity": "sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/buffers": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
+      "integrity": "sha512-9q/rDEGSb/Qsvv2qvzIzdluL5k7AaJOTrw23z9reQthrbF7is4CtlT0DXyO1oei2DCp4uojjzQ7igaSHp1kAEQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.2.0"
+      }
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -8022,6 +8296,19 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/chainsaw": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
+      "integrity": "sha512-75kWfWt6MEKNC8xYXIdRpDehRYY/tNSgwKaJq+dbbDcxORuVrrQ+SEHoWsniVn9XPYfP4gmdWIeDk/4YNp1rNQ==",
+      "dev": true,
+      "license": "MIT/X11",
+      "dependencies": {
+        "traverse": ">=0.3.0 <0.4"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/chalk": {
@@ -8384,6 +8671,22 @@
         "node": ">=4.0.0"
       }
     },
+    "node_modules/compress-commons": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-4.1.2.tgz",
+      "integrity": "sha512-D3uMHtGc/fcO1Gt1/L7i1e33VOvD4A9hfQLP+6ewd+BvG/gQ84Yh4oftEhAdjSMgBgwGL+jsppT7JYNpo6MHHg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "^0.2.13",
+        "crc32-stream": "^4.0.2",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/compressible": {
       "version": "2.0.18",
       "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
@@ -8562,6 +8865,13 @@
         "url": "https://opencollective.com/core-js"
       }
     },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cose-base": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-1.0.3.tgz",
@@ -8596,6 +8906,33 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/crc32-stream": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-4.0.3.tgz",
+      "integrity": "sha512-NT7w2JVU7DFroFdYkeq8cywxrgjPHWkdX1wjpRQXPX5Asews3tA+Ght6lddQO5Mkumffp3X7GEqku3epj2toIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "readable-stream": "^3.4.0"
+      },
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/cross-spawn": {
@@ -9567,6 +9904,56 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/duplexer2": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+      "integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "readable-stream": "^2.0.2"
+      }
+    },
+    "node_modules/duplexer2/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/duplexer2/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/duplexer2/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/duplexer2/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -10201,6 +10588,50 @@
         "bare-events": "^2.7.0"
       }
     },
+    "node_modules/exceljs": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/exceljs/-/exceljs-4.4.0.tgz",
+      "integrity": "sha512-XctvKaEMaj1Ii9oDOqbW/6e1gXknSY4g/aLCDicOXqBE4M0nRWkUu0PTp++UPNzoFY12BNHMfs/VadKIS6llvg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "archiver": "^5.0.0",
+        "dayjs": "^1.8.34",
+        "fast-csv": "^4.3.1",
+        "jszip": "^3.10.1",
+        "readable-stream": "^3.6.0",
+        "saxes": "^5.0.1",
+        "tmp": "^0.2.0",
+        "unzipper": "^0.10.11",
+        "uuid": "^8.3.0"
+      },
+      "engines": {
+        "node": ">=8.3.0"
+      }
+    },
+    "node_modules/exceljs/node_modules/saxes": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-5.0.1.tgz",
+      "integrity": "sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/exceljs/node_modules/tmp": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -10355,6 +10786,20 @@
       },
       "optionalDependencies": {
         "@types/yauzl": "^2.9.1"
+      }
+    },
+    "node_modules/fast-csv": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/fast-csv/-/fast-csv-4.3.6.tgz",
+      "integrity": "sha512-2RNSpuwwsJGP0frGsOmTb9oUF+VkFSM4SyLTDgwf2ciHWTarN0lQTC+F2f/t5J9QjW+c65VFIAAu85GsvMIusw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@fast-csv/format": "4.3.5",
+        "@fast-csv/parse": "4.3.6"
+      },
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -10720,6 +11165,13 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fs-extra": {
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
@@ -10765,6 +11217,59 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/fstream": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
+      "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
+      "deprecated": "This package is no longer supported.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "inherits": "~2.0.0",
+        "mkdirp": ">=0.5 0",
+        "rimraf": "2"
+      },
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/fstream/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/fstream/node_modules/rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
       }
     },
     "node_modules/function-bind": {
@@ -11329,6 +11834,27 @@
       "integrity": "sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/ignore": {
       "version": "5.3.2",
@@ -12471,6 +12997,76 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "dev": true,
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
+    "node_modules/jszip/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jszip/node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
+      }
+    },
+    "node_modules/jszip/node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "dev": true,
+      "license": "(MIT AND Zlib)"
+    },
+    "node_modules/jszip/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/jszip/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jszip/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/katex": {
       "version": "0.16.28",
       "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.28.tgz",
@@ -12542,6 +13138,59 @@
       "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-1.0.2.tgz",
       "integrity": "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==",
       "license": "MIT"
+    },
+    "node_modules/lazystream": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.1.tgz",
+      "integrity": "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.6.3"
+      }
+    },
+    "node_modules/lazystream/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lazystream/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/lazystream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lazystream/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
     },
     "node_modules/legacy-javascript": {
       "version": "0.0.1",
@@ -12914,6 +13563,13 @@
         "node": ">=20"
       }
     },
+    "node_modules/listenercount": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/listenercount/-/listenercount-1.0.1.tgz",
+      "integrity": "sha512-3mk/Zag0+IJxeDrxSgaDPy4zZ3w05PRZeJNnlWhzFz5OkX49J4krc+A8X2d2M69vGMBEX0uyl8M+W+8gH+kBqQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/listr2": {
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/listr2/-/listr2-9.0.5.tgz",
@@ -13046,11 +13702,82 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.difference": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
+      "integrity": "sha512-dS2j+W26TQ7taQBGN8Lbbq04ssV3emRw4NY58WErlTO29pIqS0HmoT5aJ9+TUQ1N3G+JOZSji4eugsWwGp9yPA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.escaperegexp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+      "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.flatten": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+      "integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.groupby": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.groupby/-/lodash.groupby-4.6.0.tgz",
+      "integrity": "sha512-5dcWxm23+VAoz+awKmBaiBvzox8+RqMgFhi7UvX9DHZr2HdxHXM/Wrf8cfKpsW37RNrvtPn6hSwNqurSILbmJw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isfunction": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz",
+      "integrity": "sha512-AirXNj15uRIMMPihnkInB4i3NHeb4iBtNg9WRWuK2o31S+ePwwNmDPaTL3o7dTJ+VXNZim7rFs4rxN4YU1oUJw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnil": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.isnil/-/lodash.isnil-4.0.0.tgz",
+      "integrity": "sha512-up2Mzq3545mwVnMhTDMdfoG1OurpA/s5t88JmQX809eH3C8491iu2sfKhTfhQtKY78oPNhiaHJUpT/dUDAAtng==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lodash.isplainobject": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
       "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
       "dev": true
+    },
+    "node_modules/lodash.isundefined": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isundefined/-/lodash.isundefined-3.0.1.tgz",
+      "integrity": "sha512-MXB1is3s899/cD8jheYYE2V9qTHwKvt+npCwpD+1Sxm3Q3cECXCiYHjeHWXNwr6Q0SOBPrYUDxendrO6goVTEA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -13063,6 +13790,20 @@
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
       "integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.union": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
+      "integrity": "sha512-c4pB2CdGrGdjMKYLA+XiRDO7Y0PRQbm/Gzg8qMj+QH+pFVAoTp5sBpO0odL3FjoPCGjK96p6qsP+yQoiLoOBcw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.uniq": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+      "integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -15036,6 +15777,13 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/progress": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
@@ -15554,6 +16302,54 @@
       "license": "MIT",
       "dependencies": {
         "pify": "^2.3.0"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/readdir-glob": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.3.tgz",
+      "integrity": "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "minimatch": "^5.1.0"
+      }
+    },
+    "node_modules/readdir-glob/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/readdir-glob/node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/readdirp": {
@@ -16247,6 +17043,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
@@ -16595,6 +17398,16 @@
         "events-universal": "^1.0.0",
         "fast-fifo": "^1.3.2",
         "text-decoder": "^1.1.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/string-argv": {
@@ -17406,6 +18219,16 @@
         "node": ">=12"
       }
     },
+    "node_modules/traverse": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
+      "integrity": "sha512-iawgk0hLP3SxGKDfnDJf8wTz4p2qImnyihM5Hh/sGvQ3K37dPi/w8sRhdNIxYA1TwFwc5mDhIJq+O0RsvXBKdQ==",
+      "dev": true,
+      "license": "MIT/X11",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/tree-kill": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
@@ -17729,6 +18552,65 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/unzipper": {
+      "version": "0.10.14",
+      "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.10.14.tgz",
+      "integrity": "sha512-ti4wZj+0bQTiX2KmKWuwj7lhV+2n//uXEotUmGuQqrbVZSEGFMbI68+c6JCQ8aAmUWYvtHEz2A8K6wXvueR/6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "big-integer": "^1.6.17",
+        "binary": "~0.3.0",
+        "bluebird": "~3.4.1",
+        "buffer-indexof-polyfill": "~1.0.0",
+        "duplexer2": "~0.1.4",
+        "fstream": "^1.0.12",
+        "graceful-fs": "^4.2.2",
+        "listenercount": "~1.0.1",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "~1.0.4"
+      }
+    },
+    "node_modules/unzipper/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unzipper/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/unzipper/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unzipper/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/upath": {
@@ -19269,6 +20151,65 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zip-stream": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-4.1.1.tgz",
+      "integrity": "sha512-9qv4rlDiopXg4E69k+vMHjNN63YFMe9sZMrdlvKnCjlCRWeCBswPPMPUfx+ipsAWq1LXHe70RcbaHdJJpS6hyQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "archiver-utils": "^3.0.4",
+        "compress-commons": "^4.1.2",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/zip-stream/node_modules/archiver-utils": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-3.0.4.tgz",
+      "integrity": "sha512-KVgf4XQVrTjhyWmx6cte4RxonPLR9onExufI1jhvw/MQ4BB6IsZD5gT8Lq+u/+pRkWna/6JoHpiQioaqFP5Rzw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "glob": "^7.2.3",
+        "graceful-fs": "^4.2.0",
+        "lazystream": "^1.0.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.difference": "^4.5.0",
+        "lodash.flatten": "^4.4.0",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.union": "^4.6.0",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/zip-stream/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/zod": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "docs:sync-check": "npx tsx scripts/docs-sync-check.ts",
     "docs:sync-check:ci": "npx tsx scripts/docs-sync-check.ts --ci",
     "docs:stamp": "bash scripts/docs-stamp.sh",
-    "docs:migrate": "npx tsx scripts/docs-migrate-frontmatter.ts"
+    "docs:migrate": "npx tsx scripts/docs-migrate-frontmatter.ts",
+    "financials:build": "npx tsx scripts/financial-model/build.ts"
   },
   "lint-staged": {
     "*.{ts,tsx}": [
@@ -107,6 +108,7 @@
     "eslint": "^9.32.0",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.20",
+    "exceljs": "^4.4.0",
     "globals": "^15.15.0",
     "gray-matter": "^4.0.3",
     "husky": "^9.1.7",

--- a/scripts/financial-model/build.ts
+++ b/scripts/financial-model/build.ts
@@ -1,0 +1,63 @@
+/**
+ * RAV Financial Model — Excel generator.
+ *
+ * Run via: npm run financials:build
+ *
+ * Produces: docs/financials/RAV_Financial_Model_YYYY-MM-DD.xlsx
+ *
+ * The output .xlsx is CONFIDENTIAL and gitignored. The .ts sources here are
+ * the single source of truth — both for this generator and (eventually) for
+ * the Phase 2 web tool on /executive-dashboard.
+ */
+import ExcelJS from 'exceljs';
+import path from 'node:path';
+import { mkdirSync, existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+import { buildCoverTab }        from './tabs/cover.ts';
+import { buildInputsTab }       from './tabs/inputs.ts';
+import { buildExpensesTab }     from './tabs/expenses.ts';
+import { buildRevenueTab }      from './tabs/revenue.ts';
+import { buildBreakevenTab }    from './tabs/breakeven.ts';
+import { buildFundingAskTab }   from './tabs/funding.ts';
+import { buildInstructionsTab } from './tabs/instructions.ts';
+
+async function main(): Promise<void> {
+  const wb = new ExcelJS.Workbook();
+  wb.creator = 'RAV Financial Model Generator';
+  wb.company = 'Rent-A-Vacation, Inc.';
+  wb.created = new Date();
+  wb.modified = new Date();
+
+  // Filename includes HH-MM so a same-day rerun produces a new file instead
+  // of silently overwriting. Excel files are gitignored — disk cost is trivial,
+  // and the timestamp creates a natural audit trail.
+  const iso = wb.created.toISOString();
+  const dateLabel = iso.slice(0, 10);                          // 2026-05-11
+  const timeLabel = iso.slice(11, 16).replace(':', '');        // 1432
+  const stampLabel = `${dateLabel}_${timeLabel}`;              // 2026-05-11_1432
+  const longLabel = wb.created.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: '2-digit' });
+
+  buildCoverTab(wb, longLabel);
+  buildInputsTab(wb);
+  buildExpensesTab(wb);
+  buildRevenueTab(wb);
+  buildBreakevenTab(wb);
+  buildFundingAskTab(wb);
+  buildInstructionsTab(wb);
+
+  const __dirname = path.dirname(fileURLToPath(import.meta.url));
+  const outDir = path.resolve(__dirname, '..', '..', 'docs', 'financials');
+  if (!existsSync(outDir)) mkdirSync(outDir, { recursive: true });
+  const outPath = path.join(outDir, `RAV_Financial_Model_${stampLabel}.xlsx`);
+
+  await wb.xlsx.writeFile(outPath);
+  // eslint-disable-next-line no-console
+  console.log(`✓ Wrote ${outPath}`);
+}
+
+main().catch((err) => {
+  // eslint-disable-next-line no-console
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/financial-model/colors.ts
+++ b/scripts/financial-model/colors.ts
@@ -1,0 +1,29 @@
+/**
+ * RAV brand colors — ARGB hex strings for exceljs (FF = full opacity).
+ * Sourced from BRAND-STYLE-GUIDE.md + BRAND-LOCK.md.
+ */
+export const ARGB = (hex: string) => 'FF' + hex.replace('#', '').toUpperCase();
+
+export const C = {
+  DEEP_TEAL:    ARGB('#1C7268'),
+  CORAL:        ARGB('#E8703A'),
+  CREAM:        ARGB('#F8F6F3'),
+  NAVY:         ARGB('#1D2E38'),
+  SAND:         ARGB('#F0EBE3'),
+  WARM_GRAY:    ARGB('#EAE8E4'),
+  SLATE:        ARGB('#6B7B85'),
+  EMERALD:      ARGB('#1FA66E'),
+  AMBER:        ARGB('#F59E0B'),
+  RED:          ARGB('#E53E3E'),
+  WHITE:        ARGB('#FFFFFF'),
+  TEAL_LIGHT:   ARGB('#E8F4F2'),
+  TEAL_MID:     ARGB('#C5DDD9'),
+  CORAL_LIGHT:  ARGB('#FDF0EA'),
+  EMERALD_LITE: ARGB('#E6F6EE'),
+  AMBER_LIGHT:  ARGB('#FEF3C7'),
+  RED_LIGHT:    ARGB('#FDECEA'),
+  NAVY_MID:     ARGB('#243848'),
+  NAVY_LIGHT:   ARGB('#2D4455'),
+} as const;
+
+export type RavColor = (typeof C)[keyof typeof C];

--- a/scripts/financial-model/data.ts
+++ b/scripts/financial-model/data.ts
@@ -1,0 +1,201 @@
+/**
+ * Single source of truth for all data in the RAV Financial Model.
+ *
+ * When the Phase 2 web tool is built at /executive-dashboard, it will import
+ * from this module — the same inputs / expenses / scenarios feed both the
+ * Excel generator and the React UI. Calculation logic lives in calc.ts.
+ */
+
+// ─── Input rows ──────────────────────────────────────────────────────────────
+// Each input row produces one editable cell (amber) with a label, value,
+// number format, named range, and a tooltip-style note shown to the right.
+
+export type InputRow = {
+  label: string;
+  value: string | number;
+  fmt: string;
+  name: string;
+  note: string;
+};
+
+// Section A — Platform Parameters
+export const PLATFORM: InputRow[] = [
+  { label: 'Base Commission Rate',          value: 0.15,  fmt: '0.00%',  name: 'pCommBase',    note: 'RAV charges owners this % per booking (system_settings.platform_commission_rate). Editable — adjust as pricing strategy evolves.' },
+  { label: 'Owner Pro Discount',            value: 0.02,  fmt: '0.00%',  name: 'pProDisc',     note: 'Pro tier effective rate = Base − Pro Discount.' },
+  { label: 'Owner Business Discount',       value: 0.05,  fmt: '0.00%',  name: 'pBizDisc',     note: 'Business tier effective rate = Base − Business Discount.' },
+  { label: 'Average Booking Value ($)',     value: 2000,  fmt: '$#,##0', name: 'pAvgBooking',  note: 'Typical timeshare week rental price.' },
+  { label: 'Average Nights Per Booking',    value: 7,     fmt: '0',      name: 'pAvgNights',   note: 'Most timeshare listings are fixed 7-night weeks.' },
+  { label: 'Stripe Processing Fee (%)',     value: 0.029, fmt: '0.000%', name: 'pStripePct',   note: '~2.9% per transaction — absorbed by RAV, baked into margin.' },
+  { label: 'Stripe Fixed Fee Per Txn ($)',  value: 0.30,  fmt: '$0.00',  name: 'pStripeFixed', note: '$0.30 flat fee per transaction — absorbed by RAV.' },
+];
+
+// Section B — Subscription Pricing
+export const SUBSCRIPTIONS: InputRow[] = [
+  { label: 'Traveler Plus ($/mo)',     value: 5,  fmt: '$#,##0', name: 'sTravPlus', note: 'Stripe: prod_UHBglcbzfRvApy' },
+  { label: 'Traveler Premium ($/mo)',  value: 15, fmt: '$#,##0', name: 'sTravPrem', note: 'Stripe: prod_UHCMIZLyOj2Eqb' },
+  { label: 'Owner Pro ($/mo)',         value: 10, fmt: '$#,##0', name: 'sOwnerPro', note: 'Stripe: prod_UHCUFTZBBYMTrz' },
+  { label: 'Owner Business ($/mo)',    value: 25, fmt: '$#,##0', name: 'sOwnerBiz', note: 'Stripe: prod_UHCZxftwwwd87K' },
+];
+
+// Section C — Growth Assumptions
+export const GROWTH: InputRow[] = [
+  { label: 'Launch Month (1 = first model month)', value: 5,    fmt: '0',     name: 'gLaunchMo',   note: 'Before this month, revenue = $0. Editable as you refine the launch date.' },
+  { label: 'Starting Active Owners at Launch',     value: 3,    fmt: '0',     name: 'gStartOwn',   note: 'Seed owners: co-founders + invited pilot owners.' },
+  { label: 'Starting Active Travelers at Launch',  value: 10,   fmt: '0',     name: 'gStartTrav',  note: 'Seed travelers: friends, family, pilot group.' },
+  { label: 'Monthly Owner Growth Rate (%)',        value: 0.20, fmt: '0.00%', name: 'gOwnGrowth',  note: 'Month-over-month % increase in active owners (net of churn).' },
+  { label: 'Monthly Traveler Growth Rate (%)',     value: 0.30, fmt: '0.00%', name: 'gTravGrowth', note: 'Month-over-month % increase in active travelers (net of churn).' },
+  { label: 'Bookings per Active Owner/mo',         value: 0.30, fmt: '0.00',  name: 'gBookPerOwn', note: '0.30 = roughly one booking per owner every ~3 months at launch.' },
+  { label: '% Owners — Free Tier',                 value: 0.70, fmt: '0.00%', name: 'gOwn0',       note: 'Must sum to 100% with Pro + Business below.' },
+  { label: '% Owners — Pro Tier',                  value: 0.20, fmt: '0.00%', name: 'gOwn1',       note: '% on $10/mo Pro plan.' },
+  { label: '% Owners — Business Tier',             value: 0.10, fmt: '0.00%', name: 'gOwn2',       note: '% on $25/mo Business plan.' },
+  { label: '% Travelers — Free Tier',              value: 0.80, fmt: '0.00%', name: 'gTrav0',      note: '% on free plan.' },
+  { label: '% Travelers — Plus Tier',              value: 0.15, fmt: '0.00%', name: 'gTrav1',      note: '% on $5/mo Plus plan.' },
+  { label: '% Travelers — Premium Tier',           value: 0.05, fmt: '0.00%', name: 'gTrav2',      note: '% on $15/mo Premium plan.' },
+  { label: 'Booking Mix — Free Owner %',           value: 0.65, fmt: '0.00%', name: 'gMix0',       note: 'Of all bookings, % from free-tier owners.' },
+  { label: 'Booking Mix — Pro Owner %',            value: 0.25, fmt: '0.00%', name: 'gMix1',       note: '% from Pro-tier owners.' },
+  { label: 'Booking Mix — Business Owner %',       value: 0.10, fmt: '0.00%', name: 'gMix2',       note: '% from Business owners (all three must sum to 100%).' },
+];
+
+// Section D — Scenario Multipliers
+export const SCENARIOS: InputRow[] = [
+  { label: 'Conservative — Booking Volume x', value: 0.5, fmt: '0.00"x"', name: 'scConBook',  note: '50% of base booking volume.' },
+  { label: 'Conservative — Growth Rate x',    value: 0.6, fmt: '0.00"x"', name: 'scConGrow',  note: 'Growth rates at 60% of base.' },
+  { label: 'Base — Booking Volume x',         value: 1.0, fmt: '0.00"x"', name: 'scBaseBook', note: '100% — matches all base assumptions.' },
+  { label: 'Base — Growth Rate x',            value: 1.0, fmt: '0.00"x"', name: 'scBaseGrow', note: '100% growth rates.' },
+  { label: 'Optimistic — Booking Volume x',   value: 1.8, fmt: '0.00"x"', name: 'scOptBook',  note: '180% of base booking volume.' },
+  { label: 'Optimistic — Growth Rate x',      value: 1.5, fmt: '0.00"x"', name: 'scOptGrow',  note: 'Growth rates at 150% of base.' },
+];
+
+// Section E — Planning Horizon
+export const HORIZON: InputRow[] = [
+  { label: 'Model Horizon (months)', value: 24,         fmt: '0', name: 'gHorizon',    note: '12 or 24 recommended.' },
+  { label: 'Model Start Label',      value: 'May 2026', fmt: '@', name: 'gStartLabel', note: 'Cosmetic label for Month 1.' },
+];
+
+// Section F — Tax, Cash & Reserves (new in v3.1)
+export const RESERVES: InputRow[] = [
+  { label: 'Subscription Churn (monthly %)', value: 0.03, fmt: '0.00%',  name: 'gChurn',     note: 'Monthly subscriber attrition. Industry: 2-5% early-stage SaaS. v3.x interprets the tier % inputs as steady-state post-churn; cohort-decay wiring is Phase 1b.' },
+  { label: 'Starting Cash on Hand ($)',      value: 0,    fmt: '$#,##0', name: 'gStartCash', note: 'Cash in Mercury at Month 1. Pre-funding = $0 or founder loan. Post-funding = your seed raise.' },
+  { label: 'Funding Inflow — Month',         value: 0,    fmt: '0',      name: 'gFundMonth', note: 'Month number when seed funding hits the bank. 0 = not raising yet.' },
+  { label: 'Funding Inflow — Amount ($)',    value: 0,    fmt: '$#,##0', name: 'gFundAmt',   note: 'Seed round size. Adds to cash in the month above.' },
+  { label: 'Founder Comp — $/founder/month', value: 0,    fmt: '$#,##0', name: 'gFndComp',   note: 'Post-funding monthly salary per founder. $3-8K typical seed-stage.' },
+  { label: 'Number of Salaried Founders',    value: 0,    fmt: '0',      name: 'gFndCount',  note: 'How many founders draw salary post-funding.' },
+  { label: 'Funded? (1=yes, 0=no)',          value: 0,    fmt: '0',      name: 'gFunded',    note: 'Toggle gating founder comp activation.' },
+];
+
+// ─── Expense rows ────────────────────────────────────────────────────────────
+export type ExpenseRow = {
+  category: string;
+  item: string;
+  type: 'One-Time' | 'Recurring';
+  amount: number;
+  frequency: 'Once' | 'Monthly' | 'Annual' | 'Quarterly';
+  startMo: number;
+  endMo: number;
+  notes: string;
+};
+
+export const EXPENSE_CATEGORIES = [
+  'Legal & Formation',
+  'Operations & Tools',
+  'Marketing & Launch',
+  'Compliance & Tax',
+  'People & Admin',
+] as const;
+export type ExpenseCategory = (typeof EXPENSE_CATEGORIES)[number];
+
+export const CATEGORY_PALETTE: Record<ExpenseCategory, { bg: string; fg: string }> = {
+  'Legal & Formation':   { bg: 'NAVY',      fg: 'WHITE' },
+  'Operations & Tools':  { bg: 'DEEP_TEAL', fg: 'WHITE' },
+  'Marketing & Launch':  { bg: 'CORAL',     fg: 'WHITE' },
+  'Compliance & Tax':    { bg: 'SLATE',     fg: 'WHITE' },
+  'People & Admin':      { bg: 'EMERALD',   fg: 'WHITE' },
+};
+
+export const EXPENSES: ExpenseRow[] = [
+  // Legal & Formation
+  { category: 'Legal & Formation',  item: 'Delaware C-Corp via Stripe Atlas',         type: 'One-Time',  amount: 500,  frequency: 'Once',    startMo: 1,  endMo: 1,  notes: 'Stripe Atlas all-in $500 covers DE C-Corp formation, EIN, registered agent (year 1), Stripe + Mercury referral, stock issuance, 83(b) e-filing.' },
+  { category: 'Legal & Formation',  item: 'Registered Agent (years 2+, annual)',      type: 'Recurring', amount: 150,  frequency: 'Annual',  startMo: 13, endMo: 24, notes: 'Stripe Atlas covers year 1. From year 2 onward, ~$150/yr (Atlas renewal) or ~$50-100/yr (Northwest, Harbor).' },
+  { category: 'Legal & Formation',  item: 'Startup Attorney — initial consultation', type: 'One-Time',  amount: 800,  frequency: 'Once',    startMo: 1,  endMo: 1,  notes: 'IP assignments, founder agreements, OBA disclosure review (4 founders).' },
+  { category: 'Legal & Formation',  item: 'Timeshare Attorney — consultation',       type: 'One-Time',  amount: 1200, frequency: 'Once',    startMo: 1,  endMo: 2,  notes: 'ARDA compliance, marketplace facilitator review, listing T&C. Specialist outside Atlas network.' },
+  { category: 'Legal & Formation',  item: 'IP Assignment Agreements (all 4 founders)', type: 'One-Time', amount: 600, frequency: 'Once',    startMo: 1,  endMo: 1,  notes: 'Critical: signed before any code is assigned to the entity. Templates via Atlas; attorney review extra.' },
+  { category: 'Legal & Formation',  item: 'Terms of Service & Privacy — legal review', type: 'One-Time', amount: 500, frequency: 'Once',    startMo: 2,  endMo: 2,  notes: 'Issue #80 in RAV GitHub — required before public launch.' },
+  { category: 'Legal & Formation',  item: 'Trademark — "Rent-A-Vacation" wordmark',  type: 'One-Time',  amount: 350,  frequency: 'Once',    startMo: 3,  endMo: 3,  notes: 'USPTO TEAS Plus $250 + attorney $100. Class 39 (travel services).' },
+  { category: 'Legal & Formation',  item: 'Trademark — "Pay Safe"',                  type: 'One-Time',  amount: 350,  frequency: 'Once',    startMo: 3,  endMo: 3,  notes: 'Escrow service mark. Class 36 (financial services).' },
+  { category: 'Legal & Formation',  item: 'Trademark — "TrustShield"',               type: 'One-Time',  amount: 350,  frequency: 'Once',    startMo: 3,  endMo: 3,  notes: 'Owner verification mark. Class 35 (business services).' },
+
+  // Operations & Tools
+  { category: 'Operations & Tools', item: 'Claude Max subscription',             type: 'Recurring', amount: 100, frequency: 'Monthly', startMo: 1, endMo: 24, notes: 'Primary AI development tool.' },
+  { category: 'Operations & Tools', item: 'Vercel Pro (frontend hosting)',       type: 'Recurring', amount: 20,  frequency: 'Monthly', startMo: 1, endMo: 24, notes: 'Production and preview deployments.' },
+  { category: 'Operations & Tools', item: 'Supabase (free -> Pro)',              type: 'Recurring', amount: 25,  frequency: 'Monthly', startMo: 4, endMo: 24, notes: 'Free pre-launch; Pro ~$25/mo when usage grows.' },
+  { category: 'Operations & Tools', item: 'VAPI — voice AI (Ask RAVIO)',         type: 'Recurring', amount: 50,  frequency: 'Monthly', startMo: 5, endMo: 24, notes: 'Per-usage. Est. $50/mo at launch. Scales with adoption.' },
+  { category: 'Operations & Tools', item: 'OpenRouter — text chat (Chat with RAVIO)', type: 'Recurring', amount: 15, frequency: 'Monthly', startMo: 5, endMo: 24, notes: '10-100x cheaper than VAPI per interaction.' },
+  { category: 'Operations & Tools', item: 'Twilio — A2P 10DLC registration',     type: 'One-Time',  amount: 19,  frequency: 'Once',    startMo: 2, endMo: 2,  notes: '$19 one-time. Blocked on LLC/EIN. ~1-2 week approval.' },
+  { category: 'Operations & Tools', item: 'Twilio — monthly SMS usage',          type: 'Recurring', amount: 20,  frequency: 'Monthly', startMo: 3, endMo: 24, notes: 'Estimated SMS volume. SMS_TEST_MODE=true until launch.' },
+  { category: 'Operations & Tools', item: 'Resend (transactional email)',        type: 'Recurring', amount: 0,   frequency: 'Monthly', startMo: 1, endMo: 24, notes: 'Free tier: 3K emails/mo.' },
+  { category: 'Operations & Tools', item: 'Sentry (error monitoring)',           type: 'Recurring', amount: 0,   frequency: 'Monthly', startMo: 1, endMo: 24, notes: 'Free tier pre-launch.' },
+  { category: 'Operations & Tools', item: 'PostHog (analytics)',                 type: 'Recurring', amount: 0,   frequency: 'Monthly', startMo: 1, endMo: 24, notes: 'Free <1M events/mo.' },
+  { category: 'Operations & Tools', item: 'GitHub Team Plan',                    type: 'Recurring', amount: 4,   frequency: 'Monthly', startMo: 1, endMo: 24, notes: '$4/user/mo — branch protection for private repo.' },
+  { category: 'Operations & Tools', item: 'Antigravity IDE',                     type: 'Recurring', amount: 20,  frequency: 'Monthly', startMo: 1, endMo: 24, notes: 'Development IDE subscription.' },
+  { category: 'Operations & Tools', item: 'Cursor / Windsurf IDE',               type: 'Recurring', amount: 20,  frequency: 'Monthly', startMo: 1, endMo: 24, notes: 'Additional AI-assisted coding environment.' },
+  { category: 'Operations & Tools', item: 'Domain & DNS (Cloudflare)',           type: 'Recurring', amount: 15,  frequency: 'Annual',  startMo: 1, endMo: 24, notes: 'rent-a-vacation.com + Techsilon venture domains.' },
+  { category: 'Operations & Tools', item: 'Canva Pro',                           type: 'Recurring', amount: 13,  frequency: 'Monthly', startMo: 1, endMo: 24, notes: 'Marketing design — social graphics, pitch materials.' },
+  { category: 'Operations & Tools', item: 'Gamma.app (presentations)',           type: 'Recurring', amount: 8,   frequency: 'Monthly', startMo: 1, endMo: 24, notes: 'Investor pitch deck and stakeholder presentations.' },
+
+  // Marketing & Launch
+  { category: 'Marketing & Launch', item: 'Marketing materials (print + digital)', type: 'One-Time',  amount: 500,  frequency: 'Once',    startMo: 4, endMo: 4,  notes: 'One-pagers, brochures, owner acquisition kit.' },
+  { category: 'Marketing & Launch', item: 'Conference registration (1 event)',     type: 'One-Time',  amount: 1500, frequency: 'Once',    startMo: 6, endMo: 6,  notes: 'ARDA World, VacationExpo, or equivalent.' },
+  { category: 'Marketing & Launch', item: 'Conference travel & accommodation',     type: 'One-Time',  amount: 1000, frequency: 'Once',    startMo: 6, endMo: 6,  notes: 'Flights + hotel for conference.' },
+  { category: 'Marketing & Launch', item: 'Conference exhibitor / booth fee',      type: 'One-Time',  amount: 2500, frequency: 'Once',    startMo: 6, endMo: 6,  notes: 'Exhibitor stall — direct owner acquisition.' },
+  { category: 'Marketing & Launch', item: 'Social ads — launch month (FB/IG)',     type: 'One-Time',  amount: 500,  frequency: 'Once',    startMo: 5, endMo: 5,  notes: 'Targeted launch-month ads to timeshare owner groups.' },
+  { category: 'Marketing & Launch', item: 'Social ads — ongoing (FB/IG)',          type: 'Recurring', amount: 200,  frequency: 'Monthly', startMo: 6, endMo: 24, notes: 'Sustained social media ads post-launch.' },
+  { category: 'Marketing & Launch', item: 'Google Ads (keyword targeting)',        type: 'Recurring', amount: 150,  frequency: 'Monthly', startMo: 6, endMo: 24, notes: 'timeshare rental + related keywords.' },
+  { category: 'Marketing & Launch', item: 'Apollo.io (owner lead generation)',     type: 'Recurring', amount: 0,    frequency: 'Monthly', startMo: 1, endMo: 24, notes: 'Free tier now; upgrade in growth phase.' },
+
+  // Compliance & Tax
+  { category: 'Compliance & Tax', item: 'EIN application (IRS)',                   type: 'One-Time',  amount: 0,    frequency: 'Once',    startMo: 1,  endMo: 1,  notes: 'Free — handled by Stripe Atlas as part of incorporation package.' },
+  { category: 'Compliance & Tax', item: 'Business bank account (Mercury)',         type: 'One-Time',  amount: 0,    frequency: 'Once',    startMo: 2,  endMo: 2,  notes: 'Mercury startup banking — no fees, no minimums. Stripe Atlas referral.' },
+  { category: 'Compliance & Tax', item: 'Puzzle.io accounting (free tier)',        type: 'Recurring', amount: 0,    frequency: 'Monthly', startMo: 3,  endMo: 24, notes: 'Free <$20K/mo transactions. Graduates to $25 then $50/mo as volume grows.' },
+  { category: 'Compliance & Tax', item: 'Stripe Tax activation',                   type: 'Recurring', amount: 0,    frequency: 'Monthly', startMo: 3,  endMo: 24, notes: '0.5% of transactions — scales with revenue, not a flat fee.' },
+  { category: 'Compliance & Tax', item: 'CPA — annual tax filing (Form 1120 + DE)', type: 'Recurring', amount: 2000, frequency: 'Annual', startMo: 12, endMo: 24, notes: 'Realistic range $1,500-3,000/yr for C-Corp. Federal Form 1120 + DE franchise + home-state return. Editable — confirm exact price during first engagement.' },
+  { category: 'Compliance & Tax', item: 'Delaware franchise tax + annual report',  type: 'Recurring', amount: 450,  frequency: 'Annual',  startMo: 3,  endMo: 24, notes: 'MANDATORY for every DE C-Corp regardless of revenue. ~$400 min + $50 annual report. Due March 1 each year.' },
+  { category: 'Compliance & Tax', item: 'Home-state foreign qualification + franchise', type: 'Recurring', amount: 200, frequency: 'Annual', startMo: 3, endMo: 24, notes: 'Required if operating outside DE. FL ~$150/yr. CA ~$800/yr min. Adjust per actual operating state.' },
+  { category: 'Compliance & Tax', item: 'R&D Tax Credit prep (Mainstreet/Fondo)',  type: 'Recurring', amount: 0,    frequency: 'Annual',  startMo: 12, endMo: 24, notes: 'NET POSITIVE — specialist takes 20% of credit captured. Typically returns $3K-15K/yr offset against employer payroll tax for software-heavy startups.' },
+  { category: 'Compliance & Tax', item: 'D&O Insurance (Directors & Officers)',    type: 'Recurring', amount: 1800, frequency: 'Annual',  startMo: 6,  endMo: 24, notes: '~$1,500-3,000/yr early-stage. Often required by investors. Vouch / Embroker for startup rates.' },
+  { category: 'Compliance & Tax', item: 'Tech E&O / Cyber Liability insurance',    type: 'Recurring', amount: 2400, frequency: 'Annual',  startMo: 6,  endMo: 24, notes: '~$2K-4K/yr SaaS marketplace pre-revenue. Often required by enterprise customers.' },
+  { category: 'Compliance & Tax', item: 'General Liability insurance',             type: 'Recurring', amount: 600,  frequency: 'Annual',  startMo: 6,  endMo: 24, notes: '~$500-800/yr baseline. Required by some venues for conference exhibit space.' },
+
+  // People & Admin
+  { category: 'People & Admin', item: 'Co-founder stipends',                       type: 'Recurring', amount: 0, frequency: 'Monthly', startMo: 1, endMo: 24, notes: '$0 until funded. Post-funding: see INPUTS Section F (Founder Comp).' },
+  { category: 'People & Admin', item: 'Founder reimbursements (pre-incorp)',       type: 'One-Time',  amount: 0, frequency: 'Once',    startMo: 1, endMo: 1,  notes: 'Placeholder — fill in actual out-of-pocket pre-incorporation costs once tallied.' },
+  { category: 'People & Admin', item: 'Contractor / freelancer (if needed)',       type: 'One-Time',  amount: 0, frequency: 'Once',    startMo: 1, endMo: 1,  notes: 'Placeholder. Common: designer ($500-2K), copywriter, specialist developer.' },
+  { category: 'People & Admin', item: 'Qase.io / test management',                 type: 'Recurring', amount: 0, frequency: 'Monthly', startMo: 1, endMo: 24, notes: 'Free tier — 837 test cases imported. Upgrade ($30/mo) only if 4+ active testers.' },
+];
+
+// ─── Platform facts (Funding Ask tab) ─────────────────────────────────────────
+export const PLATFORM_FACTS: [string, string][] = [
+  ['Product Status',   'Built and live at rent-a-vacation.com. Staff Only Mode enabled — not yet public.'],
+  ['Tech Stack',       'React 18 · TypeScript · Supabase (PostgreSQL) · Stripe · VAPI · Vercel'],
+  ['Test Coverage',    '1,090 automated tests · 0 type errors · 0 lint errors · Clean build'],
+  ['Database',         '46 SQL migrations deployed to production. 30 edge functions.'],
+  ['Resort Directory', '117 resorts · 351 unit types · 9 brands (Hilton, Marriott, Disney, Wyndham, and more)'],
+  ['Marketplace',      'Listings · Wishes · Offers — two-sided negotiation with Name Your Price + Offer mechanic'],
+  ['AI Features',      'Ask RAVIO (voice search via VAPI) · Chat with RAVIO (text AI via OpenRouter)'],
+  ['Revenue Ready',    'Stripe Connect · PaySafe escrow · cancellation policies · subscription billing built'],
+  ['Verification',     'TrustShield owner identity + ownership verification system built'],
+  ['Key Blockers',     'Delaware C-Corp (#127) · Legal review ToS/Privacy (#80) · A2P 10DLC SMS'],
+  ['Savings Claim',    'Save 20-40% vs resort-direct booking [ARDA industry data — BRAND-LOCK.md approved]'],
+  ['Market Size',      '$10.5B vacation ownership industry · 9.9M U.S. households own timeshares [ARDA 2024]'],
+];
+
+// ─── Funding timeline milestones ──────────────────────────────────────────────
+export const MILESTONES: [string, string, string][] = [
+  ['Months 1-2',  'Legal',       'Delaware C-Corp formed. IP Assignments signed (all 4 founders). OBA disclosures filed. Timeshare attorney consulted.'],
+  ['Months 2-3',  'Tech',        'Stripe Tax activated. A2P 10DLC registered. Puzzle.io live. All production blockers cleared.'],
+  ['Month 4',     'Pre-Launch',  'Beta owner recruitment (invite-only). TrustShield documented. ToS legally reviewed (#80).'],
+  ['Month 5',     'Launch',      'Platform opens. First Listings and Wishes live. First Offers submitted. First Stripe payouts.'],
+  ['Month 6',     'Marketing',   'First industry conference (ARDA). Exhibitor booth. Direct owner acquisition. First 50+ users.'],
+  ['Months 8-10', 'Growth',      '10+ active owners. 50+ completed transactions. First subscription revenue. Referral program active.'],
+  ['Month 12',    'Metrics',     'First investor-ready deck: GMV, take rate, Offer acceptance rate, LTV/CAC.'],
+  ['Months 18-24','Profitability','Break-even or Series A raise. Possible acquisition conversation with hospitality tech buyer.'],
+];

--- a/scripts/financial-model/style.ts
+++ b/scripts/financial-model/style.ts
@@ -1,0 +1,183 @@
+import type { Cell, Worksheet, Workbook, BorderStyle } from 'exceljs';
+import { C, type RavColor } from './colors.ts';
+
+type HAlign = 'left' | 'center' | 'right';
+
+/**
+ * Apply RAV brand styling to a cell (or merged range — caller passes the
+ * top-left cell after merging). Equivalent of rav() helper in the .gs.
+ */
+export function styleCell(
+  cell: Cell,
+  bg: RavColor,
+  fg: RavColor,
+  size = 10,
+  bold = false,
+  align: HAlign = 'left',
+  wrap = false,
+): Cell {
+  cell.fill = { type: 'pattern', pattern: 'solid', fgColor: { argb: bg } };
+  cell.font = { name: 'Calibri', size, bold, color: { argb: fg } };
+  cell.alignment = { horizontal: align, vertical: 'middle', wrapText: wrap };
+  return cell;
+}
+
+/**
+ * Style every cell in a merged range. exceljs merge() doesn't propagate
+ * styles automatically, so we walk the range.
+ */
+export function styleRange(
+  ws: Worksheet,
+  r1: number, c1: number, r2: number, c2: number,
+  bg: RavColor, fg: RavColor,
+  size = 10, bold = false, align: HAlign = 'left', wrap = false,
+): void {
+  for (let r = r1; r <= r2; r++) {
+    for (let c = c1; c <= c2; c++) {
+      styleCell(ws.getCell(r, c), bg, fg, size, bold, align, wrap);
+    }
+  }
+}
+
+/**
+ * Merged banner cell with text + style. Returns the top-left cell.
+ */
+export function banner(
+  ws: Worksheet,
+  row: number, col: number, span: number,
+  text: string, bg: RavColor, fg: RavColor,
+  size = 12, bold = true,
+): Cell {
+  ws.mergeCells(row, col, row, col + span - 1);
+  styleRange(ws, row, col, row, col + span - 1, bg, fg, size, bold, 'center', false);
+  const cell = ws.getCell(row, col);
+  cell.value = text;
+  return cell;
+}
+
+/**
+ * Section header — left-aligned navy-mid bar with white text.
+ */
+export function secHead(
+  ws: Worksheet, row: number, col: number, span: number, text: string,
+): Cell {
+  ws.mergeCells(row, col, row, col + span - 1);
+  styleRange(ws, row, col, row, col + span - 1, C.NAVY_MID, C.WHITE, 10, true, 'left', false);
+  const cell = ws.getCell(row, col);
+  cell.value = '  ' + text;
+  ws.getRow(row).height = 26;
+  return cell;
+}
+
+/**
+ * Label cell — sand background, navy text.
+ */
+export function lbl(ws: Worksheet, row: number, col: number, text: string): Cell {
+  const cell = ws.getCell(row, col);
+  styleCell(cell, C.SAND, C.NAVY, 10, false, 'left', false);
+  cell.value = text;
+  return cell;
+}
+
+/**
+ * Editable input cell — amber-light background, amber border, named range optional.
+ * The named range becomes a workbook-level defined name usable in formulas.
+ */
+export function inp(
+  wb: Workbook, ws: Worksheet,
+  row: number, col: number,
+  value: string | number,
+  fmt?: string, name?: string,
+): Cell {
+  const cell = ws.getCell(row, col);
+  styleCell(cell, C.AMBER_LIGHT, C.NAVY, 10, true, 'right', false);
+  cell.value = value;
+  cell.border = {
+    top:    { style: 'thin' as BorderStyle, color: { argb: C.AMBER } },
+    left:   { style: 'thin' as BorderStyle, color: { argb: C.AMBER } },
+    bottom: { style: 'thin' as BorderStyle, color: { argb: C.AMBER } },
+    right:  { style: 'thin' as BorderStyle, color: { argb: C.AMBER } },
+  };
+  if (fmt) cell.numFmt = fmt;
+  if (name) {
+    // exceljs supports per-cell names that auto-register as workbook defined names
+    cell.name = name;
+  }
+  return cell;
+}
+
+/**
+ * Calculated cell — teal-light background, navy text, holds a formula.
+ */
+export function calc(
+  ws: Worksheet, row: number, col: number,
+  formula: string, fmt?: string,
+): Cell {
+  const cell = ws.getCell(row, col);
+  styleCell(cell, C.TEAL_LIGHT, C.NAVY, 10, false, 'right', false);
+  // exceljs takes formula without leading '='
+  cell.value = { formula: formula.replace(/^=/, '') } as never;
+  if (fmt) cell.numFmt = fmt;
+  return cell;
+}
+
+/**
+ * Info note row — italic amber on amber-light.
+ */
+export function note(
+  ws: Worksheet, row: number, col: number, span: number, text: string,
+): Cell {
+  ws.mergeCells(row, col, row, col + span - 1);
+  styleRange(ws, row, col, row, col + span - 1, C.AMBER_LIGHT, C.AMBER, 9, false, 'left', false);
+  const cell = ws.getCell(row, col);
+  cell.value = 'i  ' + text;
+  cell.font = { ...(cell.font ?? {}), italic: true };
+  ws.getRow(row).height = 22;
+  return cell;
+}
+
+/**
+ * Dropdown / list data validation.
+ */
+export function drop(cell: Cell, opts: string[]): void {
+  cell.dataValidation = {
+    type: 'list',
+    allowBlank: false,
+    formulae: [`"${opts.join(',')}"`],
+    showErrorMessage: true,
+    errorStyle: 'stop',
+    error: 'Select one of: ' + opts.join(', '),
+  };
+}
+
+/**
+ * Convenience: write a cell with a formula (handles leading '=').
+ */
+export function formula(cell: Cell, f: string, fmt?: string): Cell {
+  cell.value = { formula: f.replace(/^=/, '') } as never;
+  if (fmt) cell.numFmt = fmt;
+  return cell;
+}
+
+/**
+ * Convert column number (1-based) to letter (1=A, 27=AA).
+ */
+export function colLtr(n: number): string {
+  let s = '';
+  while (n > 0) {
+    const m = (n - 1) % 26;
+    s = String.fromCharCode(65 + m) + s;
+    n = Math.floor((n - 1) / 26);
+  }
+  return s;
+}
+
+/**
+ * Set column widths from an array of pixel widths.
+ * exceljs width units are roughly pixels / 7 for the default font.
+ */
+export function setColumnPixelWidths(ws: Worksheet, widths: number[]): void {
+  widths.forEach((px, i) => {
+    ws.getColumn(i + 1).width = px / 7;
+  });
+}

--- a/scripts/financial-model/tabs/breakeven.ts
+++ b/scripts/financial-model/tabs/breakeven.ts
@@ -1,0 +1,134 @@
+import type { Workbook } from 'exceljs';
+import { C } from '../colors.ts';
+import { banner, styleCell, secHead, setColumnPixelWidths } from '../style.ts';
+
+const MONTHS = 24;
+
+export function buildBreakevenTab(wb: Workbook): void {
+  const ws = wb.addWorksheet('BREAK-EVEN', { properties: { tabColor: { argb: C.AMBER } } });
+
+  setColumnPixelWidths(ws, [20, 30, 200, 150, 150, 150, 150, 160]);
+  ws.views = [{ state: 'frozen', ySplit: 6 }];
+
+  ws.getRow(1).height = 52;
+  banner(ws, 1, 2, 7, 'RAV BREAK-EVEN & RUNWAY ANALYSIS', C.NAVY, C.AMBER, 16, true);
+  ws.getRow(2).height = 22;
+  banner(ws, 2, 2, 7, 'Shows the month when cumulative cash position first turns positive. Feeds your Funding Ask.', C.AMBER_LIGHT, C.AMBER, 9, false);
+  ws.getRow(3).height = 8;
+
+  // KPI headers
+  ws.getRow(4).height = 28;
+  const kpis = ['Total One-Time Costs', 'Monthly Burn (steady)', 'Break-Even Month', '6-Mo Funding Need', '12-Mo Funding Need'];
+  kpis.forEach((k, i) => {
+    const cell = ws.getCell(4, i + 3);
+    styleCell(cell, C.NAVY, C.WHITE, 9, true, 'center');
+    cell.value = k;
+  });
+
+  // KPI values
+  ws.getRow(5).height = 40;
+  const oneTime = ws.getCell(5, 3);
+  styleCell(oneTime, C.CORAL_LIGHT, C.CORAL, 14, true, 'center');
+  oneTime.value = { formula: 'SUMIF(EXPENSES!E7:E500,"One-Time",EXPENSES!F7:F500)' } as never;
+  oneTime.numFmt = '$#,##0';
+
+  const burn = ws.getCell(5, 4);
+  styleCell(burn, C.RED_LIGHT, C.RED, 14, true, 'center');
+  burn.value = { formula: 'SUMIF(EXPENSES!E7:E500,"Recurring",EXPENSES!J7:J500)' } as never;
+  burn.numFmt = '$#,##0';
+
+  const breakeven = ws.getCell(5, 5);
+  styleCell(breakeven, C.TEAL_LIGHT, C.DEEP_TEAL, 14, true, 'center');
+  // Find the first month (col D=Mo1..AA=Mo24 on this sheet, rows 9..32) where Cumulative Cash > 0
+  breakeven.value = { formula: `IFERROR(MATCH(TRUE,G9:G${8 + MONTHS}>0,0),"Not in 24mo")` } as never;
+  breakeven.numFmt = '0';
+
+  const sixMo = ws.getCell(5, 6);
+  styleCell(sixMo, C.AMBER_LIGHT, C.AMBER, 14, true, 'center');
+  sixMo.value = { formula: 'C5+D5*6' } as never;
+  sixMo.numFmt = '$#,##0';
+
+  const twelveMo = ws.getCell(5, 7);
+  styleCell(twelveMo, C.AMBER_LIGHT, C.AMBER, 14, true, 'center');
+  twelveMo.value = { formula: 'C5+D5*12' } as never;
+  twelveMo.numFmt = '$#,##0';
+
+  ws.getRow(6).height = 8;
+
+  let row = 7;
+  secHead(ws, row++, 2, 7, '  Month-by-Month: Revenue vs Costs vs Cumulative Cash Position');
+
+  const thdrs = ['Month', 'Monthly Revenue', 'Monthly Costs', 'Net (Rev − Cost)', 'Cumulative Cash', 'Runway Signal'];
+  thdrs.forEach((h, i) => {
+    const cell = ws.getCell(row, i + 3);
+    styleCell(cell, C.NAVY_MID, C.WHITE, 10, true, 'center');
+    cell.value = h;
+  });
+  ws.getRow(row).height = 26;
+  row++;
+
+  for (let m = 1; m <= MONTHS; m++) {
+    ws.getRow(row).height = 24;
+    const alt = m % 2 === 0 ? C.CREAM : C.WHITE;
+    // Revenue Model month m is column D + (m-1) = D for m=1, E for m=2, ... AA for m=24
+    // In a1, that's columns 4..27 → letters D..AA
+    const cL = String.fromCharCode(64 + 3 + m); // crude — works up to col 26 (Z); for AA we need colLtr
+    // Use the colLtr helper for correctness
+    const colLetter = (() => {
+      const n = 3 + m;
+      let s = ''; let nn = n;
+      while (nn > 0) { const k = (nn - 1) % 26; s = String.fromCharCode(65 + k) + s; nn = Math.floor((nn - 1) / 26); }
+      return s;
+    })();
+
+    const monthCell = ws.getCell(row, 3);
+    styleCell(monthCell, alt, C.NAVY, 10, false, 'center');
+    monthCell.value = `Month ${m}`;
+
+    const revCell = ws.getCell(row, 4);
+    styleCell(revCell, C.EMERALD_LITE, C.EMERALD, 10, false, 'right');
+    revCell.value = { formula: `IFERROR(INDEX('REVENUE MODEL'!${colLetter}:${colLetter},MATCH("TOTAL MONTHLY REVENUE",'REVENUE MODEL'!C:C,0)),0)` } as never;
+    revCell.numFmt = '$#,##0';
+
+    const costCell = ws.getCell(row, 5);
+    styleCell(costCell, C.RED_LIGHT, C.RED, 10, false, 'right');
+    costCell.value = { formula: `IFERROR(INDEX('REVENUE MODEL'!${colLetter}:${colLetter},MATCH("TOTAL MONTHLY COSTS",'REVENUE MODEL'!C:C,0)),0)` } as never;
+    costCell.numFmt = '$#,##0';
+
+    const netCell = ws.getCell(row, 6);
+    styleCell(netCell, alt, C.NAVY, 10, true, 'right');
+    netCell.value = { formula: `D${row}-E${row}` } as never;
+    netCell.numFmt = '$#,##0';
+
+    const cumCell = ws.getCell(row, 7);
+    styleCell(cumCell, alt, C.NAVY, 10, false, 'right');
+    if (m === 1) {
+      cumCell.value = { formula: `gStartCash+IF(gFundMonth=1,gFundAmt,0)+F${row}` } as never;
+    } else {
+      cumCell.value = { formula: `G${row - 1}+IF(gFundMonth=${m},gFundAmt,0)+F${row}` } as never;
+    }
+    cumCell.numFmt = '$#,##0';
+
+    const sigCell = ws.getCell(row, 8);
+    styleCell(sigCell, alt, C.NAVY, 10, false, 'center');
+    sigCell.value = { formula: `IF(G${row}>0,"Profitable","Burning Cash")` } as never;
+
+    row++;
+  }
+
+  // Totals row
+  ws.getRow(row).height = 32;
+  banner(ws, row, 3, 1, '24-MONTH TOTALS', C.NAVY, C.WHITE, 10, true).alignment = { horizontal: 'center', vertical: 'middle' };
+  const totRev = ws.getCell(row, 4);
+  styleCell(totRev, C.EMERALD, C.WHITE, 12, true, 'right');
+  totRev.value = { formula: `SUM(D${row - MONTHS}:D${row - 1})` } as never;
+  totRev.numFmt = '$#,##0';
+  const totCost = ws.getCell(row, 5);
+  styleCell(totCost, C.RED, C.WHITE, 12, true, 'right');
+  totCost.value = { formula: `SUM(E${row - MONTHS}:E${row - 1})` } as never;
+  totCost.numFmt = '$#,##0';
+  const totNet = ws.getCell(row, 6);
+  styleCell(totNet, C.NAVY, C.CORAL, 12, true, 'right');
+  totNet.value = { formula: `D${row}-E${row}` } as never;
+  totNet.numFmt = '$#,##0';
+}

--- a/scripts/financial-model/tabs/cover.ts
+++ b/scripts/financial-model/tabs/cover.ts
@@ -1,0 +1,74 @@
+import type { Workbook } from 'exceljs';
+import { C } from '../colors.ts';
+import { banner, styleCell, styleRange, setColumnPixelWidths } from '../style.ts';
+
+export function buildCoverTab(wb: Workbook, createdLabel: string): void {
+  const ws = wb.addWorksheet('Cover', { properties: { tabColor: { argb: C.DEEP_TEAL } } });
+
+  setColumnPixelWidths(ws, [30, 50, 320, 240, 200]);
+
+  ws.getRow(1).height = 16;
+  ws.getRow(2).height = 70;
+  banner(ws, 2, 2, 4, 'RENT-A-VACATION', C.NAVY, C.CORAL, 38, true);
+
+  ws.getRow(3).height = 32;
+  banner(ws, 3, 2, 4, 'Name Your Price. Book Your Paradise.', C.NAVY, C.AMBER, 14, false);
+
+  ws.getRow(4).height = 42;
+  banner(ws, 4, 2, 4, 'FINANCIAL MODEL & FUNDING PLANNER', C.DEEP_TEAL, C.WHITE, 17, true);
+
+  ws.getRow(5).height = 12;
+  ws.mergeCells(5, 2, 5, 5);
+  styleRange(ws, 5, 2, 5, 5, C.CORAL, C.CORAL, 10, false, 'left');
+
+  ws.getRow(6).height = 10;
+
+  const meta: [string, string][] = [
+    ['Document',     'Financial Model & Funding Planner — v3.1 (Phase 1a)'],
+    ['Created',      createdLabel],
+    ['Company',      'Rent-A-Vacation, Inc. (RAV)'],
+    ['Parent Entity','Techsilon.com'],
+    ['Website',      'rent-a-vacation.com'],
+    ['Stage',        'Pre-Revenue · Pre-Incorporation · Product Built'],
+    ['Horizon',      '24-Month Projection'],
+    ['Status',       'CONFIDENTIAL — Not for external distribution'],
+  ];
+  let r = 7;
+  meta.forEach((m, i) => {
+    ws.getRow(r).height = 26;
+    const lblCell = ws.getCell(r, 3);
+    styleCell(lblCell, i % 2 === 0 ? C.NAVY : C.NAVY_MID, C.WHITE, 10, true, 'left');
+    lblCell.value = m[0];
+    ws.mergeCells(r, 4, r, 5);
+    styleRange(ws, r, 4, r, 5, i % 2 === 0 ? C.SAND : C.CREAM, C.NAVY, 10, false, 'left');
+    ws.getCell(r, 4).value = m[1];
+    r++;
+  });
+
+  r += 2;
+  banner(ws, r, 2, 4, '  SPREADSHEET NAVIGATION', C.NAVY, C.WHITE, 11, true);
+  r++;
+
+  const tabs: [string, string, string][] = [
+    ['INPUTS',        C.DEEP_TEAL, 'Configure all parameters — commission rates, pricing, growth assumptions, tax & reserve inputs'],
+    ['EXPENSES',      C.CORAL,     'Add and manage all one-time and recurring costs by category'],
+    ['REVENUE MODEL', C.EMERALD,   '24-month projection — Conservative / Base / Optimistic scenario toggle'],
+    ['BREAK-EVEN',    C.AMBER,     'Month-by-month cumulative cash position — break-even month auto-highlighted'],
+    ['FUNDING ASK',   C.NAVY,      'One-page investor summary — auto-populated from your inputs and expenses'],
+    ['INSTRUCTIONS',  C.SLATE,     'How to use this model, glossary of key terms'],
+  ];
+  tabs.forEach((t) => {
+    ws.getRow(r).height = 28;
+    const lblCell = ws.getCell(r, 3);
+    styleCell(lblCell, t[1] as never, C.WHITE, 10, true, 'left');
+    lblCell.value = t[0];
+    ws.mergeCells(r, 4, r, 5);
+    styleRange(ws, r, 4, r, 5, C.CREAM, C.NAVY, 10, false, 'left');
+    ws.getCell(r, 4).value = t[2];
+    r++;
+  });
+
+  r += 2;
+  ws.getRow(r).height = 22;
+  banner(ws, r, 2, 4, 'All projections are forward-looking estimates. Actual results will vary.', C.RED_LIGHT, C.RED, 9, false);
+}

--- a/scripts/financial-model/tabs/expenses.ts
+++ b/scripts/financial-model/tabs/expenses.ts
@@ -1,0 +1,169 @@
+import type { Workbook, BorderStyle } from 'exceljs';
+import { C } from '../colors.ts';
+import { banner, styleCell, secHead, drop, setColumnPixelWidths } from '../style.ts';
+import { EXPENSES, EXPENSE_CATEGORIES, type ExpenseCategory } from '../data.ts';
+
+const CAT_BG: Record<string, string> = {
+  'Legal & Formation':  C.NAVY,
+  'Operations & Tools': C.DEEP_TEAL,
+  'Marketing & Launch': C.CORAL,
+  'Compliance & Tax':   C.SLATE,
+  'People & Admin':     C.EMERALD,
+};
+
+export function buildExpensesTab(wb: Workbook): void {
+  const ws = wb.addWorksheet('EXPENSES', { properties: { tabColor: { argb: C.CORAL } } });
+
+  setColumnPixelWidths(ws, [20, 30, 190, 200, 100, 105, 105, 90, 95, 120, 240]);
+  ws.views = [{ state: 'frozen', ySplit: 6 }];
+
+  ws.getRow(1).height = 52;
+  banner(ws, 1, 2, 10, 'RAV EXPENSE TRACKER — One-Time & Recurring Costs', C.NAVY, C.CORAL, 16, true);
+  ws.getRow(2).height = 22;
+  banner(ws, 2, 2, 10, 'Amber = editable. Add rows in the green section below. Totals auto-calculate.', C.CORAL_LIGHT, C.CORAL, 9, false);
+  ws.getRow(3).height = 8;
+  ws.getRow(4).height = 10;
+
+  ws.getRow(5).height = 30;
+  const headers = ['#', 'Category', 'Expense Item', 'Type', 'Amount ($)', 'Frequency', 'Start Mo.', 'End Mo.', 'Monthly $', 'Notes'];
+  headers.forEach((h, i) => {
+    const cell = ws.getCell(5, i + 2);
+    styleCell(cell, C.NAVY, C.WHITE, 10, true, 'center');
+    cell.value = h;
+  });
+  ws.getRow(6).height = 6;
+
+  let row = 7;
+  EXPENSES.forEach((e, idx) => {
+    ws.getRow(row).height = 24;
+    const alt = idx % 2 === 0 ? C.WHITE : C.CREAM;
+    const catBg = CAT_BG[e.category] ?? C.WARM_GRAY;
+
+    const idxCell = ws.getCell(row, 2);
+    styleCell(idxCell, alt, C.SLATE, 9, false, 'center');
+    idxCell.value = idx + 1;
+
+    const catCell = ws.getCell(row, 3);
+    styleCell(catCell, catBg as never, C.WHITE, 9, true, 'left');
+    catCell.value = e.category;
+
+    const itemCell = ws.getCell(row, 4);
+    styleCell(itemCell, alt, C.NAVY, 10, false, 'left', true);
+    itemCell.value = e.item;
+
+    const typeCell = ws.getCell(row, 5);
+    styleCell(typeCell, alt, C.NAVY, 10, false, 'left');
+    typeCell.value = e.type;
+    drop(typeCell, ['One-Time', 'Recurring']);
+
+    const amtCell = ws.getCell(row, 6);
+    styleCell(amtCell, C.AMBER_LIGHT, C.NAVY, 10, true, 'right');
+    amtCell.value = e.amount;
+    amtCell.numFmt = '$#,##0.00';
+    amtCell.border = {
+      top: { style: 'thin' as BorderStyle, color: { argb: C.AMBER } },
+      left: { style: 'thin' as BorderStyle, color: { argb: C.AMBER } },
+      bottom: { style: 'thin' as BorderStyle, color: { argb: C.AMBER } },
+      right: { style: 'thin' as BorderStyle, color: { argb: C.AMBER } },
+    };
+
+    const freqCell = ws.getCell(row, 7);
+    styleCell(freqCell, alt, C.NAVY, 10, false, 'left');
+    freqCell.value = e.frequency;
+    drop(freqCell, ['Once', 'Monthly', 'Annual', 'Quarterly']);
+
+    const startCell = ws.getCell(row, 8);
+    styleCell(startCell, C.AMBER_LIGHT, C.NAVY, 10, true, 'center');
+    startCell.value = e.startMo;
+    startCell.border = amtCell.border;
+
+    const endCell = ws.getCell(row, 9);
+    styleCell(endCell, C.AMBER_LIGHT, C.NAVY, 10, true, 'center');
+    endCell.value = e.endMo;
+    endCell.border = amtCell.border;
+
+    const monthlyCell = ws.getCell(row, 10);
+    styleCell(monthlyCell, C.TEAL_LIGHT, C.NAVY, 10, false, 'right');
+    monthlyCell.value = {
+      formula: `IF(E${row}="One-Time",F${row},IF(G${row}="Monthly",F${row},IF(G${row}="Annual",F${row}/12,IF(G${row}="Quarterly",F${row}/3,0))))`,
+    } as never;
+    monthlyCell.numFmt = '$#,##0.00';
+
+    const notesCell = ws.getCell(row, 11);
+    styleCell(notesCell, alt, C.SLATE, 9, false, 'left', true);
+    notesCell.value = e.notes;
+
+    row++;
+  });
+
+  // Buffer rows for additions
+  ws.getRow(row).height = 8;
+  row++;
+  secHead(ws, row++, 2, 10, '  + ADD NEW EXPENSES BELOW — copy format from rows above');
+  for (let i = 0; i < 25; i++) {
+    ws.getRow(row).height = 24;
+    const idxCell = ws.getCell(row, 2);
+    styleCell(idxCell, C.EMERALD_LITE, C.SLATE, 9, false, 'center');
+    idxCell.value = EXPENSES.length + i + 1;
+    [3, 4].forEach((c) => { ws.getCell(row, c).fill = { type: 'pattern', pattern: 'solid', fgColor: { argb: C.EMERALD_LITE } }; });
+    const tCell = ws.getCell(row, 5);
+    tCell.fill = { type: 'pattern', pattern: 'solid', fgColor: { argb: C.EMERALD_LITE } };
+    drop(tCell, ['One-Time', 'Recurring']);
+    const amtCell = ws.getCell(row, 6);
+    amtCell.fill = { type: 'pattern', pattern: 'solid', fgColor: { argb: C.AMBER_LIGHT } };
+    amtCell.numFmt = '$#,##0.00';
+    amtCell.border = {
+      top: { style: 'thin' as BorderStyle, color: { argb: C.AMBER } },
+      left: { style: 'thin' as BorderStyle, color: { argb: C.AMBER } },
+      bottom: { style: 'thin' as BorderStyle, color: { argb: C.AMBER } },
+      right: { style: 'thin' as BorderStyle, color: { argb: C.AMBER } },
+    };
+    const fCell = ws.getCell(row, 7);
+    fCell.fill = { type: 'pattern', pattern: 'solid', fgColor: { argb: C.EMERALD_LITE } };
+    drop(fCell, ['Once', 'Monthly', 'Annual', 'Quarterly']);
+    [8, 9].forEach((c) => {
+      const cell = ws.getCell(row, c);
+      cell.fill = { type: 'pattern', pattern: 'solid', fgColor: { argb: C.AMBER_LIGHT } };
+      cell.border = amtCell.border;
+    });
+    const mCell = ws.getCell(row, 10);
+    styleCell(mCell, C.TEAL_LIGHT, C.NAVY, 10, false, 'right');
+    mCell.value = {
+      formula: `IF(E${row}="One-Time",F${row},IF(G${row}="Monthly",F${row},IF(G${row}="Annual",F${row}/12,IF(G${row}="Quarterly",F${row}/3,0))))`,
+    } as never;
+    mCell.numFmt = '$#,##0.00';
+    ws.getCell(row, 11).fill = { type: 'pattern', pattern: 'solid', fgColor: { argb: C.EMERALD_LITE } };
+    row++;
+  }
+
+  // Summary
+  row += 2;
+  secHead(ws, row++, 2, 10, '  EXPENSE SUMMARY BY CATEGORY');
+  EXPENSE_CATEGORIES.forEach((cat: ExpenseCategory) => {
+    ws.getRow(row).height = 26;
+    ws.mergeCells(row, 3, row, 5);
+    const catCell = ws.getCell(row, 3);
+    styleCell(catCell, (CAT_BG[cat] ?? C.WARM_GRAY) as never, C.WHITE, 10, true, 'left');
+    catCell.value = cat;
+    const sumCell = ws.getCell(row, 10);
+    styleCell(sumCell, C.TEAL_LIGHT, C.NAVY, 10, true, 'right');
+    sumCell.value = { formula: `SUMIF(C7:C500,"${cat}",J7:J500)` } as never;
+    sumCell.numFmt = '$#,##0.00';
+    row++;
+  });
+
+  ws.getRow(row).height = 32;
+  banner(ws, row, 3, 3, 'TOTAL MONTHLY BURN (steady-state)', C.NAVY, C.WHITE, 11, true).alignment = { horizontal: 'left', vertical: 'middle' };
+  const burnCell = ws.getCell(row, 10);
+  styleCell(burnCell, C.NAVY, C.CORAL, 13, true, 'right');
+  burnCell.value = { formula: 'SUM(J7:J500)' } as never;
+  burnCell.numFmt = '$#,##0.00';
+  row++;
+
+  ws.getRow(row).height = 26;
+  banner(ws, row, 3, 3, 'TOTAL ONE-TIME COSTS', C.NAVY_MID, C.WHITE, 10, true).alignment = { horizontal: 'left', vertical: 'middle' };
+  const oneTimeCell = ws.getCell(row, 10);
+  styleCell(oneTimeCell, C.NAVY_MID, C.AMBER, 11, true, 'right');
+  oneTimeCell.value = { formula: 'SUMIF(E7:E500,"One-Time",F7:F500)' } as never;
+  oneTimeCell.numFmt = '$#,##0.00';
+}

--- a/scripts/financial-model/tabs/funding.ts
+++ b/scripts/financial-model/tabs/funding.ts
@@ -1,0 +1,135 @@
+import type { Workbook } from 'exceljs';
+import { C } from '../colors.ts';
+import { banner, styleCell, secHead, note, setColumnPixelWidths } from '../style.ts';
+import { PLATFORM_FACTS, MILESTONES } from '../data.ts';
+
+export function buildFundingAskTab(wb: Workbook): void {
+  const ws = wb.addWorksheet('FUNDING ASK', { properties: { tabColor: { argb: C.NAVY } } });
+
+  setColumnPixelWidths(ws, [20, 30, 220, 200, 140, 200]);
+
+  ws.getRow(1).height = 60;
+  banner(ws, 1, 2, 5, 'RENT-A-VACATION — FUNDING OVERVIEW', C.NAVY, C.CORAL, 20, true);
+  ws.getRow(2).height = 30;
+  banner(ws, 2, 2, 5, '"Name Your Price. Book Your Paradise."  ·  rent-a-vacation.com  ·  CONFIDENTIAL', C.NAVY_MID, C.AMBER, 11, false);
+  ws.getRow(3).height = 8;
+
+  let r = 4;
+
+  // THE ASK
+  secHead(ws, r++, 2, 5, '  THE ASK');
+
+  // v3.1 — fixed: formulas reference data column D, not label column C
+  // r=5 maps to D5 = 6-Mo Runway, r=6→D6 = 12-Mo Runway, r=7→D7 = contingency, r=8→D8 = total ask
+  const asks: [string, string, string][] = [
+    ['6-Month Runway (minimum viable)',  "='BREAK-EVEN'!F5", 'Incorporation, legal, tools, initial marketing to beta launch'],
+    ['12-Month Runway (target)',          "='BREAK-EVEN'!G5", 'Beta launch, growth, first conference, first Offers and Wishes'],
+    ['Contingency Buffer (15%)',          '=D6*0.15',          '15% buffer on 12-month runway for unknowns'],
+    ['RECOMMENDED SEED ASK',             '=D6+D7',            'Total: 12-month runway + contingency buffer'],
+  ];
+  asks.forEach((a, i) => {
+    const isTotal = i === 3;
+    ws.getRow(r).height = isTotal ? 40 : 28;
+    const lblCell = ws.getCell(r, 3);
+    styleCell(lblCell, isTotal ? C.NAVY : C.SAND, isTotal ? C.WHITE : C.NAVY, isTotal ? 13 : 10, true, 'left');
+    lblCell.value = a[0];
+
+    const valCell = ws.getCell(r, 4);
+    styleCell(valCell, isTotal ? C.CORAL : C.TEAL_LIGHT, isTotal ? C.WHITE : C.NAVY, isTotal ? 20 : 13, true, 'right');
+    valCell.value = { formula: a[1].replace(/^=/, '') } as never;
+    valCell.numFmt = '$#,##0';
+
+    ws.mergeCells(r, 5, r, 6);
+    const noteCell = ws.getCell(r, 5);
+    styleCell(noteCell, isTotal ? C.NAVY_MID : C.CREAM, isTotal ? C.TEAL_LIGHT : C.SLATE, 9, false, 'left');
+    noteCell.value = a[2];
+    r++;
+  });
+  r++;
+
+  // USE OF FUNDS
+  secHead(ws, r++, 2, 5, '  USE OF FUNDS');
+  ['Category', 'Amount', '% of Ask', 'Notes'].forEach((h, i) => {
+    const cell = ws.getCell(r, i + 3);
+    styleCell(cell, C.NAVY_MID, C.WHITE, 10, true, i === 1 ? 'right' : i === 2 ? 'center' : 'left');
+    cell.value = h;
+  });
+  ws.getRow(r).height = 26;
+  r++;
+
+  // % of Ask divides by $D$8 (the recommended ask), not C8 (label) — fixed in v3.1
+  const funds: [string, string, string][] = [
+    ['Legal & Formation',   'SUMIF(EXPENSES!C7:C500,"Legal & Formation",EXPENSES!F7:F500)',                                                                          'Incorporation, IP assignments, attorney review, trademark filings'],
+    ['Operations & Tools',  'SUMIF(EXPENSES!C7:C500,"Operations & Tools",EXPENSES!J7:J500)*12',                                                                       'SaaS stack × 12 months'],
+    ['Marketing & Launch',  'SUMIF(EXPENSES!C7:C500,"Marketing & Launch",EXPENSES!F7:F500)+SUMIF(EXPENSES!C7:C500,"Marketing & Launch",EXPENSES!J7:J500)*12',         'Conference, booth, social ads × 12 months'],
+    ['Compliance & Tax',    'SUMIF(EXPENSES!C7:C500,"Compliance & Tax",EXPENSES!F7:F500)+SUMIF(EXPENSES!C7:C500,"Compliance & Tax",EXPENSES!J7:J500)*12',             'EIN, bank, accounting, CPA, franchise tax, insurance'],
+    ['People',              'SUMIF(EXPENSES!C7:C500,"People & Admin",EXPENSES!F7:F500)+SUMIF(EXPENSES!C7:C500,"People & Admin",EXPENSES!J7:J500)*12',                 'Founder stipends, contractors, test management'],
+    ['Contingency Buffer',  'D7',                                                                                                                                       'From The Ask above — 15% buffer on 12-month runway'],
+  ];
+  funds.forEach((f, i) => {
+    ws.getRow(r).height = 26;
+    const labelCell = ws.getCell(r, 3);
+    styleCell(labelCell, i % 2 === 0 ? C.SAND : C.CREAM, C.NAVY, 10, false, 'left');
+    labelCell.value = f[0];
+
+    const amtCell = ws.getCell(r, 4);
+    styleCell(amtCell, C.TEAL_LIGHT, C.NAVY, 10, false, 'right');
+    amtCell.value = { formula: f[1] } as never;
+    amtCell.numFmt = '$#,##0';
+
+    const pctCell = ws.getCell(r, 5);
+    styleCell(pctCell, i % 2 === 0 ? C.WHITE : C.CREAM, C.SLATE, 10, false, 'center');
+    pctCell.value = { formula: `D${r}/$D$8` } as never;
+    pctCell.numFmt = '0.0%';
+
+    const notesCell = ws.getCell(r, 6);
+    styleCell(notesCell, i % 2 === 0 ? C.WHITE : C.CREAM, C.SLATE, 9, false, 'left', true);
+    notesCell.value = f[2];
+    r++;
+  });
+  r++;
+
+  // PLATFORM FACTS
+  secHead(ws, r++, 2, 5, '  PLATFORM FACTS  (what is already built)');
+  PLATFORM_FACTS.forEach((f, i) => {
+    ws.getRow(r).height = 28;
+    const lblCell = ws.getCell(r, 3);
+    styleCell(lblCell, i % 2 === 0 ? C.NAVY : C.NAVY_MID, C.WHITE, 10, true, 'left');
+    lblCell.value = f[0];
+    ws.mergeCells(r, 4, r, 6);
+    const valCell = ws.getCell(r, 4);
+    styleCell(valCell, i % 2 === 0 ? C.SAND : C.CREAM, C.NAVY, 10, false, 'left', true);
+    valCell.value = f[1];
+    r++;
+  });
+  r++;
+
+  // MILESTONES
+  secHead(ws, r++, 2, 5, '  KEY MILESTONES — Use of Funding Timeline');
+  ['Timeline', 'Area', 'Milestone'].forEach((h, i) => {
+    const cell = ws.getCell(r, i + 3);
+    styleCell(cell, C.NAVY_MID, C.WHITE, 10, true, 'left');
+    cell.value = h;
+  });
+  ws.getRow(r).height = 26;
+  r++;
+
+  MILESTONES.forEach((m, i) => {
+    ws.getRow(r).height = 32;
+    const tlCell = ws.getCell(r, 3);
+    styleCell(tlCell, i % 2 === 0 ? C.DEEP_TEAL : C.NAVY_MID, C.WHITE, 10, true, 'center');
+    tlCell.value = m[0];
+
+    const areaCell = ws.getCell(r, 4);
+    styleCell(areaCell, i % 2 === 0 ? C.TEAL_LIGHT : C.SAND, C.DEEP_TEAL, 10, true, 'left');
+    areaCell.value = m[1];
+
+    ws.mergeCells(r, 5, r, 6);
+    const msCell = ws.getCell(r, 5);
+    styleCell(msCell, i % 2 === 0 ? C.CREAM : C.WHITE, C.NAVY, 10, false, 'left', true);
+    msCell.value = m[2];
+    r++;
+  });
+  r += 2;
+  note(ws, r, 2, 5, 'Auto-populated from INPUTS and EXPENSES. Before investor meetings: verify claims against BRAND-LOCK.md Section 5.');
+}

--- a/scripts/financial-model/tabs/inputs.ts
+++ b/scripts/financial-model/tabs/inputs.ts
@@ -1,0 +1,105 @@
+import type { Workbook, Worksheet } from 'exceljs';
+import { C } from '../colors.ts';
+import { banner, styleCell, styleRange, secHead, lbl, inp, calc, note, setColumnPixelWidths } from '../style.ts';
+import { PLATFORM, SUBSCRIPTIONS, GROWTH, SCENARIOS, HORIZON, RESERVES, type InputRow } from '../data.ts';
+
+function writeInputRow(wb: Workbook, ws: Worksheet, row: number, def: InputRow): void {
+  ws.getRow(row).height = 26;
+  lbl(ws, row, 3, def.label);
+  inp(wb, ws, row, 4, def.value, def.fmt, def.name);
+  const noteCell = ws.getCell(row, 6);
+  styleCell(noteCell, C.WHITE, C.SLATE, 9, false, 'left', true);
+  noteCell.value = def.note;
+}
+
+export function buildInputsTab(wb: Workbook): void {
+  const ws = wb.addWorksheet('INPUTS', { properties: { tabColor: { argb: C.AMBER } } });
+
+  setColumnPixelWidths(ws, [20, 30, 290, 160, 50, 350]);
+  ws.views = [{ state: 'frozen', ySplit: 4 }];
+
+  ws.getRow(1).height = 52;
+  banner(ws, 1, 2, 5, 'RAV FINANCIAL MODEL — INPUTS & PARAMETERS', C.NAVY, C.CORAL, 17, true);
+  ws.getRow(2).height = 22;
+  banner(ws, 2, 2, 5, 'Amber cells = your inputs   ·   Teal cells = calculated   ·   All tabs update automatically', C.AMBER_LIGHT, C.AMBER, 9, false);
+  ws.getRow(3).height = 8;
+  ws.getRow(4).height = 14;
+
+  let r = 5;
+
+  // ── Section A ──
+  secHead(ws, r++, 2, 5, 'A.  PLATFORM PARAMETERS  —  from RAV codebase (src/lib/pricing.ts · system_settings)');
+  PLATFORM.forEach((p) => writeInputRow(wb, ws, r++, p));
+
+  ws.getRow(r++).height = 10;
+  secHead(ws, r++, 3, 4, '  Effective Commission Rates by Owner Tier  (auto-calculated)');
+  const tierRows: [string, string, string][] = [
+    ['Free Owner  (no subscription)', 'pCommBase',          'No discount — base rate'],
+    ['Pro Owner  ($10/mo)',           'pCommBase-pProDisc', 'Base − Pro Discount'],
+    ['Business Owner  ($25/mo)',      'pCommBase-pBizDisc', 'Base − Business Discount'],
+  ];
+  tierRows.forEach((t) => {
+    ws.getRow(r).height = 24;
+    const labelCell = ws.getCell(r, 3);
+    styleCell(labelCell, C.TEAL_MID, C.NAVY, 10, true, 'left');
+    labelCell.value = '      ' + t[0];
+    calc(ws, r, 4, t[1], '0.00%');
+    const noteCell = ws.getCell(r, 6);
+    styleCell(noteCell, C.WHITE, C.SLATE, 9, false, 'left', false);
+    noteCell.value = t[2];
+    r++;
+  });
+  r += 2;
+
+  // ── Section B ──
+  secHead(ws, r++, 2, 5, 'B.  SUBSCRIPTION PRICING  —  from Stripe sandbox config (migrations 047-048)');
+  SUBSCRIPTIONS.forEach((s) => writeInputRow(wb, ws, r++, s));
+  r += 2;
+
+  // ── Section C ──
+  secHead(ws, r++, 2, 5, 'C.  GROWTH ASSUMPTIONS  —  Base Case');
+  note(ws, r++, 3, 4, 'Base Case estimates. Section D multipliers apply for Conservative and Optimistic scenarios.');
+  GROWTH.forEach((g) => writeInputRow(wb, ws, r++, g));
+
+  // Mix validation row
+  ws.getRow(r).height = 24;
+  const mixLbl = ws.getCell(r, 3);
+  styleCell(mixLbl, C.CREAM, C.SLATE, 9, false, 'left');
+  mixLbl.value = '      v Owner Tier Mix (must = 100%)';
+  const mixCell = ws.getCell(r, 4);
+  styleCell(mixCell, C.TEAL_LIGHT, C.NAVY, 10, true, 'right');
+  mixCell.value = { formula: 'gOwn0+gOwn1+gOwn2' } as never;
+  mixCell.numFmt = '0.00%';
+  const mixNote = ws.getCell(r, 6);
+  styleCell(mixNote, C.WHITE, C.SLATE, 9, false, 'left');
+  mixNote.value = 'Green = correct. Red = adjust percentages above.';
+
+  // Conditional format on the mix cell — green when ~100%, red otherwise
+  ws.addConditionalFormatting({
+    ref: mixCell.address,
+    rules: [
+      { type: 'cellIs', operator: 'between', formulae: ['0.999', '1.001'], priority: 1,
+        style: { fill: { type: 'pattern', pattern: 'solid', fgColor: { argb: C.EMERALD_LITE } }, font: { color: { argb: C.EMERALD } } } } as never,
+      { type: 'cellIs', operator: 'notBetween', formulae: ['0.999', '1.001'], priority: 2,
+        style: { fill: { type: 'pattern', pattern: 'solid', fgColor: { argb: C.RED_LIGHT } }, font: { color: { argb: C.RED } } } } as never,
+    ],
+  });
+  r += 2;
+
+  // ── Section D ──
+  secHead(ws, r++, 2, 5, 'D.  SCENARIO MULTIPLIERS  —  Applied to Base Case when scenario is selected');
+  SCENARIOS.forEach((s) => writeInputRow(wb, ws, r++, s));
+  r += 2;
+
+  // ── Section E ──
+  secHead(ws, r++, 2, 5, 'E.  PLANNING HORIZON');
+  HORIZON.forEach((h) => writeInputRow(wb, ws, r++, h));
+  r += 2;
+
+  // ── Section F (new in v3.1) ──
+  secHead(ws, r++, 2, 5, 'F.  TAX, CASH & RESERVE INPUTS  —  Drives cumulative cash, churn, founder comp');
+  RESERVES.forEach((res) => writeInputRow(wb, ws, r++, res));
+
+  r++;
+  note(ws, r, 2, 5, 'Change any amber cell — Revenue Model, Break-Even, and Funding Ask tabs all update automatically.');
+}

--- a/scripts/financial-model/tabs/instructions.ts
+++ b/scripts/financial-model/tabs/instructions.ts
@@ -1,0 +1,111 @@
+import type { Workbook } from 'exceljs';
+import { C } from '../colors.ts';
+import { banner, styleCell, setColumnPixelWidths } from '../style.ts';
+
+export function buildInstructionsTab(wb: Workbook): void {
+  const ws = wb.addWorksheet('INSTRUCTIONS', { properties: { tabColor: { argb: C.SLATE } } });
+
+  setColumnPixelWidths(ws, [20, 30, 190, 480]);
+
+  ws.getRow(1).height = 52;
+  banner(ws, 1, 2, 3, 'HOW TO USE — RAV FINANCIAL MODEL', C.NAVY, C.WHITE, 15, true);
+  ws.getRow(2).height = 8;
+
+  type Section = { title: string; color: string; items: [string, string][] };
+  const sections: Section[] = [
+    {
+      title: '1.  INPUTS TAB — START HERE', color: C.DEEP_TEAL, items: [
+        ['INPUTS',           'Your control panel. Every amber cell is editable. Change any value and the entire model updates.'],
+        ['Section A',        'Platform parameters — pre-loaded from RAV codebase. Commission rates, Stripe fees, avg booking value.'],
+        ['Section B',        'Subscription prices — from Stripe sandbox config. Update when production prices are set.'],
+        ['Section C',        'Growth assumptions — your best estimates. Includes Launch Month (drives when revenue turns on).'],
+        ['Section D',        'Scenario multipliers — how Conservative and Optimistic differ from Base.'],
+        ['Section E',        'Planning horizon and model start date label.'],
+        ['Section F',        'Tax, Cash & Reserves — churn, starting cash, funding inflow (month + amount), founder comp post-funding. Drives cumulative cash position.'],
+      ],
+    },
+    {
+      title: '2.  ADDING EXPENSES', color: C.CORAL, items: [
+        ['EXPENSES',         'Pre-populated with 47 known RAV costs. Scroll to green section to add new rows.'],
+        ['Amber cells',      'Amount, Start Month, End Month are editable per row.'],
+        ['Type dropdown',    'One-Time = appears in Start Month only. Recurring = every month between Start and End.'],
+        ['Frequency',        'Monthly / Annual / Quarterly / Once. Annual and Quarterly auto-divide for monthly calc.'],
+        ['Monthly $ column', 'Auto-calculated. Do not edit directly.'],
+      ],
+    },
+    {
+      title: '3.  REVENUE MODEL', color: C.EMERALD, items: [
+        ['REVENUE MODEL',    'Do NOT edit here — all cells pull from INPUTS. Change inputs, this updates.'],
+        ['Scenario dropdown','Cell D4. Switch between Conservative / Base / Optimistic.'],
+        ['Section 2',        'Monthly Bookings = Offers that convert. GBV = bookings × avg booking value.'],
+        ['Section 3',        'Gross Commission = GBV × blended rate. Stripe Fees subtracted (2.9% + $0.30 on whole txn). Net Commission flows to Total Revenue.'],
+        ['Section 4',        'Subscription revenue across Owner Pro/Business + Traveler Plus/Premium.'],
+        ['Section 5',        'Revenue (green), Costs (red, live from Expenses tab), Net P&L, Cumulative Cash (seeded with Starting Cash + Funding Inflow from INPUTS F).'],
+      ],
+    },
+    {
+      title: '4.  BREAK-EVEN', color: C.AMBER, items: [
+        ['BREAK-EVEN',       'Month-by-month cumulative cash. Green = profitable, Red = burning cash.'],
+        ['KPI row (row 5)',  'One-time costs, monthly burn, break-even month, 6-mo and 12-mo funding needs.'],
+        ['Break-even month', 'First month cumulative cash turns positive. "Not in 24mo" if not achieved.'],
+      ],
+    },
+    {
+      title: '5.  FUNDING ASK', color: C.NAVY, items: [
+        ['FUNDING ASK',      'One-page summary. All dollar figures auto-populate from INPUTS and EXPENSES.'],
+        ['THE ASK rows',     'D5 = 6-Month Runway. D6 = 12-Month Runway. D7 = 15% contingency on D6. D8 = D6 + D7 = recommended ask. v3.1 fixed circular refs that previously self-referenced label cells.'],
+        ['Use of Funds',     'SUMIFs against EXPENSES categories. % of Ask divides each by D8 (recommended ask).'],
+        ['Platform facts',   'Pre-loaded from the RAV codebase. Update as the product evolves.'],
+        ['Before meetings',  'Check BRAND-LOCK.md Section 5 (Numerical Claims Registry) before investor conversations.'],
+      ],
+    },
+    {
+      title: '6.  BRAND TERMINOLOGY (BRAND-LOCK.md)', color: C.CORAL, items: [
+        ['Marketplace',     'Two-sided negotiation platform. Single nav link. Tabs inside = Listings + Wishes.'],
+        ['Listing',         'Owner property + dates posted for rent. DB: listings table.'],
+        ['Wish',            'Traveler open call — destination, dates, budget. DB: travel_requests. Never "RAV Wish" in UI.'],
+        ['Offer',           'Proposed deal at a price. Both directions. DB: listing_bids OR travel_proposals. Never "Bid"/"Proposal" in UI.'],
+        ['My Rentals',      'Owner dashboard nav label. Formerly Owner Edge / RAV Edge.'],
+        ['RAV Insights',    'Executive dashboard. Formerly RAV Command.'],
+        ['RAV Ops',         'Admin operations dashboard. Formerly Admin Dashboard.'],
+        ['Savings claim',   'Save 20-40% vs resort-direct [ARDA data]. Never say 50-70% or up to 70%.'],
+      ],
+    },
+    {
+      title: '7.  GLOSSARY', color: C.SLATE, items: [
+        ['GMV / GBV',       'Gross Merchandise/Booking Value — total dollar value of all bookings.'],
+        ['Take Rate',       'RAV commission as % of GBV. Currently ~15% blended.'],
+        ['Blended Rate',    'Weighted commission across Free (15%), Pro (13%), Business (10%) tiers.'],
+        ['Offer Rate',      'Proportion of Offers submitted that result in confirmed bookings.'],
+        ['CAC',             'Customer Acquisition Cost — marketing spend ÷ new users acquired.'],
+        ['LTV',             'Lifetime Value — average revenue per user over their platform lifecycle.'],
+        ['Runway',          'Months the business can operate before running out of cash.'],
+        ['Break-Even',      'Month when monthly revenue first exceeds monthly costs.'],
+        ['One-Time Cost',   'Paid once. Appears only in its Start Month.'],
+        ['Recurring Cost',  'Paid regularly. Appears every month between Start and End Month.'],
+      ],
+    },
+  ];
+
+  let r = 3;
+  sections.forEach((sec) => {
+    ws.getRow(r).height = 30;
+    const bn = banner(ws, r, 2, 3, sec.title, sec.color as never, C.WHITE, 11, true);
+    bn.alignment = { horizontal: 'left', vertical: 'middle' };
+    r++;
+    sec.items.forEach((item) => {
+      ws.getRow(r).height = 30;
+      const lblCell = ws.getCell(r, 3);
+      styleCell(lblCell, C.TEAL_LIGHT, C.DEEP_TEAL, 10, true, 'left');
+      lblCell.value = item[0];
+      const valCell = ws.getCell(r, 4);
+      styleCell(valCell, C.CREAM, C.NAVY, 10, false, 'left', true);
+      valCell.value = item[1];
+      r++;
+    });
+    ws.getRow(r++).height = 10;
+  });
+
+  ws.getRow(r).height = 24;
+  banner(ws, r, 2, 3, 'Projections are estimates. Not financial or legal advice. Consult qualified advisors.', C.RED_LIGHT, C.RED, 9, false).alignment = { horizontal: 'left', vertical: 'middle' };
+}

--- a/scripts/financial-model/tabs/revenue.ts
+++ b/scripts/financial-model/tabs/revenue.ts
@@ -1,0 +1,301 @@
+import type { Workbook, BorderStyle } from 'exceljs';
+import { C } from '../colors.ts';
+import { banner, styleCell, secHead, lbl, drop, colLtr, setColumnPixelWidths } from '../style.ts';
+
+const MONTHS = 24;
+
+export function buildRevenueTab(wb: Workbook): void {
+  const ws = wb.addWorksheet('REVENUE MODEL', { properties: { tabColor: { argb: C.DEEP_TEAL } } });
+
+  const widths = [20, 30, 250];
+  for (let c = 4; c <= 28; c++) widths.push(82);
+  setColumnPixelWidths(ws, widths);
+
+  ws.views = [{ state: 'frozen', xSplit: 3, ySplit: 7 }];
+
+  ws.getRow(1).height = 52;
+  banner(ws, 1, 2, 26, 'RAV REVENUE MODEL — 24-Month Projection', C.NAVY, C.CORAL, 16, true);
+  ws.getRow(2).height = 22;
+  banner(ws, 2, 2, 26, 'All values pull from INPUTS. Change inputs there — this tab updates automatically.', C.TEAL_LIGHT, C.DEEP_TEAL, 9, false);
+  ws.getRow(3).height = 8;
+
+  // Scenario selector
+  ws.getRow(4).height = 34;
+  banner(ws, 4, 2, 2, 'ACTIVE SCENARIO >', C.NAVY, C.WHITE, 11, true);
+  const scCell = ws.getCell(4, 4);
+  styleCell(scCell, C.AMBER_LIGHT, C.NAVY, 13, true, 'left');
+  scCell.value = 'Base';
+  scCell.border = {
+    top: { style: 'thin' as BorderStyle, color: { argb: C.AMBER } },
+    left: { style: 'thin' as BorderStyle, color: { argb: C.AMBER } },
+    bottom: { style: 'thin' as BorderStyle, color: { argb: C.AMBER } },
+    right: { style: 'thin' as BorderStyle, color: { argb: C.AMBER } },
+  };
+  drop(scCell, ['Conservative', 'Base', 'Optimistic']);
+  scCell.name = 'Scenario';
+  ws.mergeCells(4, 5, 4, 9);
+  styleCell(ws.getCell(4, 5), C.AMBER_LIGHT, C.AMBER, 9, false, 'left');
+  ws.getCell(4, 5).value = '< Change to switch between Conservative / Base / Optimistic';
+  ws.getCell(4, 5).font = { ...(ws.getCell(4, 5).font ?? {}), italic: true };
+  ws.getRow(5).height = 8;
+
+  // Month headers
+  ws.getRow(6).height = 28;
+  const metricHdr = ws.getCell(6, 3);
+  styleCell(metricHdr, C.NAVY, C.WHITE, 10, true, 'left');
+  metricHdr.value = 'METRIC';
+  for (let m = 1; m <= MONTHS; m++) {
+    const cell = ws.getCell(6, m + 3);
+    styleCell(cell, m % 2 === 0 ? C.NAVY_MID : C.NAVY, C.WHITE, 9, true, 'center');
+    cell.value = `Mo ${m}`;
+  }
+  ws.getRow(7).height = 6;
+
+  const sBook = 'IF(Scenario="Conservative",scConBook,IF(Scenario="Optimistic",scOptBook,scBaseBook))';
+  const sGrow = 'IF(Scenario="Conservative",scConGrow,IF(Scenario="Optimistic",scOptGrow,scBaseGrow))';
+  const blend = '(gMix0*pCommBase+gMix1*(pCommBase-pProDisc)+gMix2*(pCommBase-pBizDisc))';
+
+  let row = 8;
+
+  // 1. USER GROWTH
+  secHead(ws, row++, 2, 27, '  1.  USER GROWTH');
+
+  lbl(ws, row, 3, 'Active Owners');
+  for (let m = 1; m <= MONTHS; m++) {
+    const col = m + 3;
+    const cell = ws.getCell(row, col);
+    if (m === 1) {
+      styleCell(cell, C.TEAL_LIGHT, C.NAVY, 10, false, 'right');
+      cell.value = { formula: 'IF(1>=gLaunchMo,gStartOwn,0)' } as never;
+    } else {
+      styleCell(cell, m % 2 === 0 ? C.WHITE : C.CREAM, C.NAVY, 10, false, 'right');
+      cell.value = { formula: `IF(${m}>=gLaunchMo,${colLtr(col - 1)}${row}*(1+gOwnGrowth*${sGrow}),0)` } as never;
+    }
+    cell.numFmt = '#,##0';
+  }
+  const ownRow = row++;
+
+  lbl(ws, row, 3, 'Active Travelers');
+  for (let m = 1; m <= MONTHS; m++) {
+    const col = m + 3;
+    const cell = ws.getCell(row, col);
+    if (m === 1) {
+      styleCell(cell, C.TEAL_LIGHT, C.NAVY, 10, false, 'right');
+      cell.value = { formula: 'IF(1>=gLaunchMo,gStartTrav,0)' } as never;
+    } else {
+      styleCell(cell, m % 2 === 0 ? C.WHITE : C.CREAM, C.NAVY, 10, false, 'right');
+      cell.value = { formula: `IF(${m}>=gLaunchMo,${colLtr(col - 1)}${row}*(1+gTravGrowth*${sGrow}),0)` } as never;
+    }
+    cell.numFmt = '#,##0';
+  }
+  const travRow = row;
+  row += 2;
+
+  // 2. MARKETPLACE ACTIVITY
+  secHead(ws, row++, 2, 27, '  2.  MARKETPLACE ACTIVITY  (Listings · Offers · Bookings)');
+
+  lbl(ws, row, 3, 'Monthly Bookings (confirmed)');
+  for (let m = 1; m <= MONTHS; m++) {
+    const col = m + 3;
+    const cell = ws.getCell(row, col);
+    styleCell(cell, m % 2 === 0 ? C.WHITE : C.CREAM, C.NAVY, 10, false, 'right');
+    cell.value = { formula: `IF(${m}>=gLaunchMo,${colLtr(col)}${ownRow}*gBookPerOwn*${sBook},0)` } as never;
+    cell.numFmt = '#,##0.0';
+  }
+  const bookRow = row++;
+
+  lbl(ws, row, 3, '    Cumulative Bookings');
+  const firstCum = ws.getCell(row, 4);
+  styleCell(firstCum, C.TEAL_LIGHT, C.NAVY, 10, false, 'right');
+  firstCum.value = { formula: `D${bookRow}` } as never;
+  firstCum.numFmt = '#,##0';
+  for (let m = 2; m <= MONTHS; m++) {
+    const col = m + 3;
+    const cell = ws.getCell(row, col);
+    styleCell(cell, C.TEAL_LIGHT, C.NAVY, 10, false, 'right');
+    cell.value = { formula: `${colLtr(col - 1)}${row}+${colLtr(col)}${bookRow}` } as never;
+    cell.numFmt = '#,##0';
+  }
+  row++;
+
+  lbl(ws, row, 3, '    Gross Booking Value (GBV)');
+  for (let m = 1; m <= MONTHS; m++) {
+    const col = m + 3;
+    const cell = ws.getCell(row, col);
+    styleCell(cell, m % 2 === 0 ? C.EMERALD_LITE : C.TEAL_LIGHT, C.NAVY, 10, false, 'right');
+    cell.value = { formula: `${colLtr(col)}${bookRow}*pAvgBooking` } as never;
+    cell.numFmt = '$#,##0';
+  }
+  const gbvRow = row;
+  row += 2;
+
+  // 3. COMMISSION REVENUE
+  secHead(ws, row++, 2, 27, '  3.  COMMISSION REVENUE  (blended across Free / Pro / Business owner tiers)');
+
+  lbl(ws, row, 3, '    Blended Commission Rate');
+  for (let m = 1; m <= MONTHS; m++) {
+    const col = m + 3;
+    const cell = ws.getCell(row, col);
+    styleCell(cell, m % 2 === 0 ? C.WHITE : C.CREAM, C.NAVY, 10, false, 'right');
+    cell.value = { formula: blend } as never;
+    cell.numFmt = '0.00%';
+  }
+  row++;
+
+  ws.getRow(row).height = 30;
+  const grossLbl = ws.getCell(row, 3);
+  styleCell(grossLbl, C.DEEP_TEAL, C.WHITE, 11, true, 'left');
+  grossLbl.value = 'Gross Commission Revenue';
+  for (let m = 1; m <= MONTHS; m++) {
+    const col = m + 3;
+    const cell = ws.getCell(row, col);
+    styleCell(cell, C.DEEP_TEAL, C.WHITE, 11, true, 'right');
+    cell.value = { formula: `${colLtr(col)}${gbvRow}*${blend}` } as never;
+    cell.numFmt = '$#,##0';
+  }
+  const grossCommRow = row++;
+
+  // Stripe Fees row (subtractive)
+  lbl(ws, row, 3, '    Stripe Processing Fees (absorbed by RAV)');
+  for (let m = 1; m <= MONTHS; m++) {
+    const col = m + 3;
+    const cL = colLtr(col);
+    const cell = ws.getCell(row, col);
+    styleCell(cell, m % 2 === 0 ? C.RED_LIGHT : C.WHITE, C.RED, 10, false, 'right');
+    cell.value = { formula: `-(${cL}${gbvRow}*(1+${blend})*pStripePct + ${cL}${bookRow}*pStripeFixed)` } as never;
+    cell.numFmt = '$#,##0';
+  }
+  const stripeFeeRow = row++;
+
+  ws.getRow(row).height = 30;
+  const netLbl = ws.getCell(row, 3);
+  styleCell(netLbl, C.DEEP_TEAL, C.WHITE, 11, true, 'left');
+  netLbl.value = 'Net Commission Revenue';
+  for (let m = 1; m <= MONTHS; m++) {
+    const col = m + 3;
+    const cL = colLtr(col);
+    const cell = ws.getCell(row, col);
+    styleCell(cell, C.DEEP_TEAL, C.WHITE, 11, true, 'right');
+    cell.value = { formula: `${cL}${grossCommRow}+${cL}${stripeFeeRow}` } as never;
+    cell.numFmt = '$#,##0';
+  }
+  const commRow = row;
+  row += 2;
+
+  // 4. SUBSCRIPTION REVENUE
+  secHead(ws, row++, 2, 27, '  4.  SUBSCRIPTION REVENUE  (Owner Pro · Owner Business · Traveler Plus · Traveler Premium)');
+
+  const subDefs: [string, number, string, string][] = [
+    ['    Owner Pro subscriptions',       ownRow,  'gOwn1',  'sOwnerPro'],
+    ['    Owner Business subscriptions',  ownRow,  'gOwn2',  'sOwnerBiz'],
+    ['    Traveler Plus subscriptions',   travRow, 'gTrav1', 'sTravPlus'],
+    ['    Traveler Premium subscriptions',travRow, 'gTrav2', 'sTravPrem'],
+  ];
+  const subRowNums: number[] = [];
+  subDefs.forEach((sd) => {
+    lbl(ws, row, 3, sd[0]);
+    for (let m = 1; m <= MONTHS; m++) {
+      const col = m + 3;
+      const cell = ws.getCell(row, col);
+      styleCell(cell, m % 2 === 0 ? C.WHITE : C.CREAM, C.NAVY, 10, false, 'right');
+      cell.value = { formula: `${colLtr(col)}${sd[1]}*${sd[2]}*${sd[3]}` } as never;
+      cell.numFmt = '$#,##0';
+    }
+    subRowNums.push(row);
+    row++;
+  });
+
+  ws.getRow(row).height = 30;
+  const subSumLbl = ws.getCell(row, 3);
+  styleCell(subSumLbl, C.NAVY_MID, C.WHITE, 11, true, 'left');
+  subSumLbl.value = 'Total Subscription Revenue';
+  for (let m = 1; m <= MONTHS; m++) {
+    const col = m + 3;
+    const cL = colLtr(col);
+    const cell = ws.getCell(row, col);
+    styleCell(cell, C.NAVY_MID, C.WHITE, 11, true, 'right');
+    cell.value = { formula: `SUM(${cL}${subRowNums[0]}:${cL}${subRowNums[subRowNums.length - 1]})` } as never;
+    cell.numFmt = '$#,##0';
+  }
+  const subRevRow = row;
+  row += 2;
+
+  // 5. TOTALS
+  secHead(ws, row++, 2, 27, '  5.  REVENUE vs COSTS vs PROFIT / (LOSS)');
+
+  ws.getRow(row).height = 34;
+  const totRevLbl = ws.getCell(row, 3);
+  styleCell(totRevLbl, C.EMERALD, C.WHITE, 12, true, 'left');
+  totRevLbl.value = 'TOTAL MONTHLY REVENUE';
+  for (let m = 1; m <= MONTHS; m++) {
+    const col = m + 3;
+    const cL = colLtr(col);
+    const cell = ws.getCell(row, col);
+    styleCell(cell, C.EMERALD, C.WHITE, 12, true, 'right');
+    cell.value = { formula: `${cL}${commRow}+${cL}${subRevRow}` } as never;
+    cell.numFmt = '$#,##0';
+  }
+  const totRevRow = row++;
+
+  ws.getRow(row).height = 34;
+  const totCostLbl = ws.getCell(row, 3);
+  styleCell(totCostLbl, C.RED, C.WHITE, 12, true, 'left');
+  totCostLbl.value = 'TOTAL MONTHLY COSTS';
+  for (let m = 1; m <= MONTHS; m++) {
+    const col = m + 3;
+    const cell = ws.getCell(row, col);
+    styleCell(cell, C.RED, C.WHITE, 12, true, 'right');
+    cell.value = {
+      formula:
+        `SUMPRODUCT((EXPENSES!E7:E500="Recurring")*(EXPENSES!H7:H500<=${m})*(EXPENSES!I7:I500>=${m})*` +
+        `IF(EXPENSES!G7:G500="Monthly",EXPENSES!F7:F500,` +
+        `IF(EXPENSES!G7:G500="Annual",EXPENSES!F7:F500/12,` +
+        `IF(EXPENSES!G7:G500="Quarterly",EXPENSES!F7:F500/3,0))))+` +
+        `SUMPRODUCT((EXPENSES!E7:E500="One-Time")*(EXPENSES!H7:H500=${m})*EXPENSES!F7:F500)`,
+    } as never;
+    cell.numFmt = '$#,##0';
+  }
+  const totCostRow = row++;
+
+  ws.getRow(row).height = 36;
+  const netLblCell = ws.getCell(row, 3);
+  styleCell(netLblCell, C.NAVY, C.AMBER, 12, true, 'left');
+  netLblCell.value = 'NET MONTHLY PROFIT / (LOSS)';
+  for (let m = 1; m <= MONTHS; m++) {
+    const col = m + 3;
+    const cL = colLtr(col);
+    const cell = ws.getCell(row, col);
+    styleCell(cell, C.NAVY, C.AMBER, 12, true, 'right');
+    cell.value = { formula: `${cL}${totRevRow}-${cL}${totCostRow}` } as never;
+    cell.numFmt = '$#,##0';
+  }
+  const netRow = row++;
+
+  ws.getRow(row).height = 28;
+  const cumLbl = ws.getCell(row, 3);
+  styleCell(cumLbl, C.WARM_GRAY, C.NAVY, 10, true, 'left');
+  cumLbl.value = '    Cumulative Cash Position';
+  const cumFirst = ws.getCell(row, 4);
+  styleCell(cumFirst, C.WHITE, C.NAVY, 10, false, 'right');
+  cumFirst.value = { formula: `gStartCash+IF(gFundMonth=1,gFundAmt,0)+D${netRow}` } as never;
+  cumFirst.numFmt = '$#,##0';
+  for (let m = 2; m <= MONTHS; m++) {
+    const col = m + 3;
+    const cell = ws.getCell(row, col);
+    styleCell(cell, C.WHITE, C.NAVY, 10, false, 'right');
+    cell.value = { formula: `${colLtr(col - 1)}${row}+IF(gFundMonth=${m},gFundAmt,0)+${colLtr(col)}${netRow}` } as never;
+    cell.numFmt = '$#,##0';
+  }
+
+  // Conditional formatting on cumulative cash row
+  const cumRange = `${colLtr(4)}${row}:${colLtr(MONTHS + 3)}${row}`;
+  ws.addConditionalFormatting({
+    ref: cumRange,
+    rules: [
+      { type: 'cellIs', operator: 'greaterThanOrEqual', formulae: ['0'], priority: 1,
+        style: { fill: { type: 'pattern', pattern: 'solid', fgColor: { argb: C.EMERALD_LITE } }, font: { color: { argb: C.EMERALD } } } } as never,
+      { type: 'cellIs', operator: 'lessThan', formulae: ['0'], priority: 2,
+        style: { fill: { type: 'pattern', pattern: 'solid', fgColor: { argb: C.RED_LIGHT } }, font: { color: { argb: C.RED } } } } as never,
+    ],
+  });
+}


### PR DESCRIPTION
## Summary

Replaces the Google Apps Script financial-model generator with a Node-side TypeScript build. One command (`npm run financials:build`) produces a timestamped `.xlsx` in `docs/financials/` (gitignored, confidential). The `.ts` modules are now the single source of truth for both the Excel generator and the eventual `/executive-dashboard` web tool (Phase 2, post-incorporation).

- **Removes manual round-trip** through script.google.com — no more paste-into-Apps-Script + download + upload dance
- **Same calc engine, future-shared**: data + calc separated from rendering, so the Phase 2 React UI on `/executive-dashboard` will reuse the same TS modules with a different renderer
- **Fixes carried over from in-flight Phase 1a work on the `.gs`**:
  - Funding Ask circular references (D7/D8 now reference value cells, not label cells)
  - Stripe fee netting (Gross → −Stripe Fees → Net Commission rows in Revenue Model)
  - Cumulative cash position seeded with Starting Cash + Funding Inflow (`gStartCash` / `gFundMonth` / `gFundAmt`)
  - Realistic CPA cost ($2,000/yr), 11 new compliance/legal expenses (DE franchise, state franchise, R&D credit prep, D&O/E&O/GL insurance, three trademark filings)
  - New INPUTS Section F: Tax, Cash & Reserves
  - Removed duplicate `gLaunchMo2` named range
- **Filename includes time** (`RAV_Financial_Model_YYYY-MM-DD_HHMM.xlsx`) so same-day reruns don't silently overwrite

## Structure

```
scripts/financial-model/
├── build.ts              ← npm run financials:build
├── data.ts               ← typed inputs, expenses, milestones, facts (source of truth)
├── colors.ts             ← RAV brand palette (BRAND-STYLE-GUIDE compliant)
├── style.ts              ← exceljs helpers (banner, secHead, lbl, inp, calc, note, drop)
└── tabs/
    ├── cover.ts
    ├── inputs.ts         (6 sections incl. new Section F)
    ├── expenses.ts       (47 expense rows + buffer)
    ├── revenue.ts        (24-month projection w/ Stripe fee netting)
    ├── breakeven.ts
    ├── funding.ts        (circular refs fixed)
    └── instructions.ts
```

## Confidentiality

`.gitignore` now blocks `docs/financials/*.xlsx`, `*.xls`, `*.csv`. The generated artifact contains real revenue projections and funding figures — must not be committed. The `.ts` source is structure + formulas only (safe to commit).

## Test plan

- [x] `npm run financials:build` produces a valid `.xlsx`
- [x] 7 sheets present (Cover, INPUTS, EXPENSES, REVENUE MODEL, BREAK-EVEN, FUNDING ASK, INSTRUCTIONS)
- [x] 41 named ranges register correctly (verified with openpyxl)
- [x] Funding Ask formulas reference `D6/D7/D8` not `C7/C8`
- [x] Use of Funds % column divides by `$D$8`
- [x] Stripe Fees row subtracts properly; Net Commission = Gross + (negative) Stripe Fees
- [x] Cumulative Cash uses `gStartCash + IF(gFundMonth=N, gFundAmt, 0) + Net P&L`
- [x] Dropdowns (Scenario, Type, Frequency) work
- [x] Conditional formatting on mix-check and cumulative-cash row
- [x] `npm run docs:sync-check` passes

## Out of scope (Phase 1b — next session)

Unit economics block (CAC/LTV/payback), sensitivity table on top 3 drivers, charts (revenue vs costs with break-even marker), hiring plan, voice/AI overage revenue, cohort-based booking ramp. None affect correctness of current numbers; they're investor-presentation polish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)