### PR TITLE
feat(financials + compliance): Phase 1b financials polish + testing governance + #488 marketplace-facilitator tracker

### DIFF
--- a/docs/testing/TESTING-GUIDELINES.md
+++ b/docs/testing/TESTING-GUIDELINES.md
@@ -1,7 +1,7 @@
 ---
-last_updated: "2026-04-25T06:41:23"
-change_ref: "2dd6116"
-change_type: "session-60"
+last_updated: "2026-05-11T00:00:00"
+change_ref: "manual"
+change_type: "session-65-governance"
 status: "active"
 ---
 # Testing Guidelines — Rent-A-Vacation
@@ -79,8 +79,12 @@ For critical user journeys across multiple pages.
 ### Visual Regression Tests
 For catching unintended visual changes.
 - Use Percy via `@percy/playwright`
-- Run only on PRs (CI gated)
-- Review diffs in Percy dashboard
+- Run only on PRs (CI gated — `if: github.event_name == 'pull_request'` in `ci.yml`)
+- Percy is **active** on the free tier — repo must remain **public** for free tier to work
+- Baseline established: Build #187 (May 2026) — Homepage, Rentals, Login, Signup snapshots approved
+- **Operational rule:** After every PR, someone must log into Percy, review the visual diff, and approve (intentional change) or reject (regression). Unreviewed builds accumulate and waste quota.
+- Percy free tier: 5,000 screenshots/month. Each build = 4 snapshots. ~1,250 builds/month max.
+- Review diffs at: https://percy.io (project: rav-web-app)
 
 ## Mocking Patterns
 
@@ -156,12 +160,106 @@ Coverage is tracked for business logic directories only:
 - `src/contexts/**` — context providers
 
 Thresholds (enforced in `vitest.config.ts`):
-- Statements: 25%
-- Branches: 25%
-- Functions: 30%
-- Lines: 25%
+- Statements: 70%
+- Branches: 70%
+- Functions: 70%
+- Lines: 70%
+
+Actual coverage as of May 2026: ~75% statements, ~77% branches, ~83% functions, ~75% lines.
+**Review trigger:** Raise thresholds to 80% when E2E automation covers 15+ of the 30 manual scenarios, or before acquisition due diligence — whichever comes first.
 
 Run `npm run test:coverage` to see the report locally.
+
+---
+
+## E2E Scenario Governance
+
+This section defines how manual and automated E2E scenarios are created, maintained, and expanded. Follow this process exactly — skipping steps creates unmaintainable tests.
+
+### The 30 Scenarios (S-01 through S-30)
+
+All scenarios live in `docs/testing/E2E-SCENARIO-TESTS.md`. They cover every major RAV business capability across all user roles. **These are the authoritative definition of what the platform is supposed to do.**
+
+### Automation Difficulty Classification
+
+Before scheduling any scenario for automation, classify it:
+
+| Level | Criteria | Examples |
+|-------|----------|----------|
+| **Easy** | Single role, no payment, no realtime, no voice | S-20 (public pages), S-22 (tools), S-16 (search/filter) |
+| **Medium** | Single role, database state required | S-21 (multi-listing), S-28 (iCal), S-25 (exec dashboard) |
+| **Hard** | Multi-role switching required | S-01, S-03, S-04, S-05, S-06 |
+| **Very Hard** | External systems (Stripe, realtime, voice) | S-08 (realtime), S-19 (Stripe edge cases), S-26 (voice) |
+| **Always Manual** | Master lifecycle, judgment calls | S-30 (complete marketplace cycle) |
+
+Multi-role scenarios require Playwright `storageState` — pre-authenticating each user and switching between browser contexts mid-test. Do not attempt these without that architecture in place.
+
+### Phased Automation Plan
+
+| Phase | Scenarios | Prerequisite |
+|-------|-----------|-------------|
+| Phase 1 (now) | S-20, S-22, S-16 (partial) — Easy scenarios | None — start immediately |
+| Phase 2 | S-01, S-03, S-13, S-14 — multi-role with storageState | Playwright storageState architecture built |
+| Phase 3 | S-04, S-05, S-09, S-10 — money flows | Stripe test env wired into CI |
+| Always manual | S-08, S-26, S-30 | — |
+
+**Coverage target:** 15+ automated scenarios before raising CI thresholds to 80%.
+
+### How to Add a New Scenario (S-31 and beyond)
+
+Follow this process every time a new feature ships. No exceptions.
+
+**Step 1 — Write the scenario when the feature ships.**
+Not weeks later. The developer or PM writes the scenario in `E2E-SCENARIO-TESTS.md` following the exact table format of existing scenarios (columns: #, As, Action, Page, Checkpoint). This happens before or alongside the code being merged — not after.
+
+**Step 2 — Assign a number and add to the index.**
+Give it the next sequential number (S-31, S-32, etc.). Add it to:
+- The Scenario Index table at the top of `E2E-SCENARIO-TESTS.md`
+- The appropriate execution Tier (Tier 1 through Tier 7)
+- The Coverage Matrix in the Google Sheets tracking doc
+
+**Step 3 — Run it manually at least twice.**
+A scenario is not considered validated until two clean manual runs have been recorded in the tracking sheet. Record the date, tester, and any bugs found.
+
+**Step 4 — Classify it using the difficulty framework above.**
+Add the classification (Easy / Medium / Hard / Very Hard / Always Manual) to the scenario header in `E2E-SCENARIO-TESTS.md`.
+
+**Step 5 — Schedule automation based on classification.**
+- Easy → schedule in the next available session
+- Medium → schedule within 2 sessions
+- Hard / Very Hard → add to backlog with prerequisite noted
+- Always Manual → document why and leave it
+
+### Percy Visual Regression — Operational Rules
+
+1. **After every PR merge:** Log into Percy, review the 4 snapshots (Homepage, Rentals, Login, Signup)
+2. **Intentional UI change:** Click Approve — this becomes the new baseline
+3. **Unexpected diff:** Click Reject, file a GitHub Issue, do NOT merge until resolved
+4. **Adding new pages:** Add a new `percySnapshot()` call in `e2e/visual/pages.spec.ts` when a major new public page ships
+5. **Quota awareness:** Free tier = 5,000 screenshots/month (~1,250 builds). If approaching limit, restrict Percy to PRs to `main` only, not every push to `dev`
+
+### GitHub Actions Manual Dispatch (for testers)
+
+> **Status: Planned — not yet implemented.** Target: Phase 1 E2E automation session.
+
+Non-developer testers will trigger E2E runs via a “Run workflow” button in GitHub Actions — no terminal or code required. The workflow will support selecting a test suite (all / smoke / specific tier) and environment (dev / prod), with automatic email notification and results link on completion.
+
+Until implemented, testers run scenarios manually using `E2E-SCENARIO-TESTS.md` as the checklist.
+
+### CI Branch Protection Rules
+
+| Job | Required? | Rationale |
+|-----|-----------|----------|
+| Lint & Type Check | **Yes — blocks merge** | Code must compile. Non-negotiable. |
+| Unit & Integration Tests | **Yes — blocks merge** | Business logic must pass. |
+| E2E Tests | No — informational | Suite too small to be a hard gate yet |
+| Visual Regression (Percy) | No — informational | Requires human review in Percy |
+| Lighthouse CI | No — informational | Performance budget aspirational |
+| Documentation Audit | No — informational | Useful signal, not a blocker |
+
+**Review trigger:** Promote E2E to Required when 15+ scenarios are automated and the suite has 3+ consecutive clean CI runs.
+
+---
 
 ## Edge Function Testing (Session 60 / #371)
 

--- a/docs/testing/TESTING-STATUS.md
+++ b/docs/testing/TESTING-STATUS.md
@@ -7,7 +7,7 @@ status: "active"
 # Testing Status
 
 > Current state of the RAV test suite. Updated each session.
-> **Last Updated:** May 6, 2026 (Session 64 — #483 + #484 disclaimer registry + 9 placements + About; #485 No Timeshare Sales validation; #486 state column on listings + Migration 074; +145 tests, +11 test files)
+> **Last Updated:** May 11, 2026 (Session 64 — May 6: #483/#484/#485/#486 compliance work; May 11: #488 marketplace-facilitator registrations admin tab + Migration 075; +160 tests, +12 test files cumulative for the session)
 
 ---
 
@@ -15,8 +15,8 @@ status: "active"
 
 | Metric | Value |
 |--------|-------|
-| **Total tests** | 1637 |
-| **Test files** | 168 |
+| **Total tests** | 1652 |
+| **Test files** | 169 |
 | **P0 critical-path tests** | 290+ tagged `@p0` (Session 64 added @p0 on disclaimer registry, DisclaimerBlock, StateSpecificDisclaimer, Footer registry sourcing, Terms 8.3+8.6, About page, placement audit) |
 | **E2E smoke tests** | 3 (Playwright) |
 | **Local run time** | ~2.5 min (full), ~2s (P0 only) |

--- a/docs/testing/TESTING-STATUS.md
+++ b/docs/testing/TESTING-STATUS.md
@@ -1,7 +1,7 @@
 ---
-last_updated: "2026-05-01T01:38:53"
-change_ref: "b70bd7a"
-change_type: "session-63"
+last_updated: "2026-05-11T00:00:00"
+change_ref: "manual"
+change_type: "session-65-corrections"
 status: "active"
 ---
 # Testing Status
@@ -28,12 +28,16 @@ status: "active"
 
 ## Coverage Thresholds (enforced in CI)
 
-| Metric | Threshold |
-|--------|-----------|
-| Statements | 25% |
-| Branches | 25% |
-| Functions | 30% |
-| Lines | 25% |
+| Metric | Threshold | Actual (May 2026) |
+|--------|-----------|-------------------|
+| Statements | 70% | ~75% |
+| Branches | 70% | ~77% |
+| Functions | 70% | ~83% |
+| Lines | 70% | ~75% |
+
+> Thresholds raised from 25–30% to 70% on 2026-05-11 (actual coverage was already ~75–83%).
+> **Review trigger:** Raise to 80% when E2E automation covers 15+ of the 30 manual scenarios,
+> or before any acquisition due diligence process begins — whichever comes first.
 
 ## Commands
 
@@ -60,7 +64,7 @@ npm run test:e2e:headed   # Playwright with browser visible
 
 - **Unit/Integration:** Vitest + React Testing Library
 - **E2E:** Playwright
-- **Visual Regression:** Percy (disabled — requires paid plan for private repos)
+- **Visual Regression:** Percy (active — free tier works because repo is public; baseline established Build #187, May 2026)
 - **CI:** GitHub Actions + dorny/test-reporter (JUnit XML → PR annotations)
 - **Pre-commit:** Husky + lint-staged (lint + run related tests)
 

--- a/scripts/financial-model/build.ts
+++ b/scripts/financial-model/build.ts
@@ -19,6 +19,8 @@ import { buildInputsTab }       from './tabs/inputs.ts';
 import { buildExpensesTab }     from './tabs/expenses.ts';
 import { buildRevenueTab }      from './tabs/revenue.ts';
 import { buildBreakevenTab }    from './tabs/breakeven.ts';
+import { buildUnitEconTab }     from './tabs/unit-econ.ts';
+import { buildSensitivityTab }  from './tabs/sensitivity.ts';
 import { buildFundingAskTab }   from './tabs/funding.ts';
 import { buildInstructionsTab } from './tabs/instructions.ts';
 
@@ -43,6 +45,8 @@ async function main(): Promise<void> {
   buildExpensesTab(wb);
   buildRevenueTab(wb);
   buildBreakevenTab(wb);
+  buildUnitEconTab(wb);
+  buildSensitivityTab(wb);
   buildFundingAskTab(wb);
   buildInstructionsTab(wb);
 

--- a/scripts/financial-model/data.ts
+++ b/scripts/financial-model/data.ts
@@ -74,13 +74,33 @@ export const HORIZON: InputRow[] = [
 
 // Section F — Tax, Cash & Reserves (new in v3.1)
 export const RESERVES: InputRow[] = [
-  { label: 'Subscription Churn (monthly %)', value: 0.03, fmt: '0.00%',  name: 'gChurn',     note: 'Monthly subscriber attrition. Industry: 2-5% early-stage SaaS. v3.x interprets the tier % inputs as steady-state post-churn; cohort-decay wiring is Phase 1b.' },
+  { label: 'Subscription Churn (monthly %)', value: 0.03, fmt: '0.00%',  name: 'gChurn',     note: 'Monthly subscriber attrition. Industry: 2-5% early-stage SaaS. v3.x interprets the tier % inputs as steady-state post-churn (gross sign-ups - churn = net growth in Section C).' },
   { label: 'Starting Cash on Hand ($)',      value: 0,    fmt: '$#,##0', name: 'gStartCash', note: 'Cash in Mercury at Month 1. Pre-funding = $0 or founder loan. Post-funding = your seed raise.' },
   { label: 'Funding Inflow — Month',         value: 0,    fmt: '0',      name: 'gFundMonth', note: 'Month number when seed funding hits the bank. 0 = not raising yet.' },
   { label: 'Funding Inflow — Amount ($)',    value: 0,    fmt: '$#,##0', name: 'gFundAmt',   note: 'Seed round size. Adds to cash in the month above.' },
   { label: 'Founder Comp — $/founder/month', value: 0,    fmt: '$#,##0', name: 'gFndComp',   note: 'Post-funding monthly salary per founder. $3-8K typical seed-stage.' },
   { label: 'Number of Salaried Founders',    value: 0,    fmt: '0',      name: 'gFndCount',  note: 'How many founders draw salary post-funding.' },
   { label: 'Funded? (1=yes, 0=no)',          value: 0,    fmt: '0',      name: 'gFunded',    note: 'Toggle gating founder comp activation.' },
+];
+
+// Section G — Hiring Plan (new in v3.2 / Phase 1b)
+// Each role has a hire month + burdened monthly cost. Cost includes salary,
+// employer payroll tax (~7.65%), benefits (~15-20%), tools, etc.
+export const HIRING: InputRow[] = [
+  { label: 'First Engineer — Hire Month',    value: 0,    fmt: '0',      name: 'hEngMonth', note: 'Model month when 1st engineer joins. 0 = no hire planned. Activates after funding typically — depends on gFundMonth.' },
+  { label: 'First Engineer — Burdened $/mo', value: 12000, fmt: '$#,##0', name: 'hEngCost',  note: 'Total monthly cost: base salary + 7.65% payroll tax + ~15-20% benefits + tools. Senior eng $10-15K/mo burdened at seed stage.' },
+  { label: 'First Support — Hire Month',     value: 0,    fmt: '0',      name: 'hSupMonth', note: 'Model month when 1st support hire joins. 0 = no hire planned. Typically Month 8-12 once owner volume justifies.' },
+  { label: 'First Support — Burdened $/mo',  value: 6000,  fmt: '$#,##0', name: 'hSupCost',  note: 'Support role burdened cost. $4-8K/mo typical for remote contractor support.' },
+  { label: 'First BD — Hire Month',          value: 0,    fmt: '0',      name: 'hBDMonth',  note: 'Model month when 1st BD/growth hire joins. 0 = no hire planned. Triggers after product-market fit signal.' },
+  { label: 'First BD — Burdened $/mo',       value: 9000,  fmt: '$#,##0', name: 'hBDCost',   note: 'Business development burdened cost. Often base + commission — model just the base here.' },
+];
+
+// Section H — Unit Economics & Cohort Ramp (new in v3.2 / Phase 1b)
+export const UNIT_ECON: InputRow[] = [
+  { label: 'Cohort Ramp (months to full velocity)', value: 3,    fmt: '0',     name: 'uRampMonths',     note: 'New cohort booking velocity ramps from 0 to gBookPerOwn over this many months. Set 1 = immediate full velocity; 3-6 = gradual onboarding curve.' },
+  { label: 'Average Owner Lifetime (months)',       value: 24,   fmt: '0',     name: 'uOwnLife',        note: 'Average months an active owner stays on the platform before churning. Used for LTV calc. 24mo = ~3% monthly churn equivalent.' },
+  { label: 'Average Traveler Lifetime (months)',    value: 18,   fmt: '0',     name: 'uTravLife',       note: 'Average months an active traveler stays. Travelers churn faster than owners typically.' },
+  { label: 'Voice Overage — $/active traveler/mo',   value: 0.50, fmt: '$0.00', name: 'uVoiceOverage',   note: 'Avg monthly voice overage revenue per non-Premium traveler. Conservative default; scales with adoption of voice features post-launch.' },
 ];
 
 // ─── Expense rows ────────────────────────────────────────────────────────────

--- a/scripts/financial-model/tabs/breakeven.ts
+++ b/scripts/financial-model/tabs/breakeven.ts
@@ -90,9 +90,14 @@ export function buildBreakevenTab(wb: Workbook): void {
     revCell.value = { formula: `IFERROR(INDEX('REVENUE MODEL'!${colLetter}:${colLetter},MATCH("TOTAL MONTHLY REVENUE",'REVENUE MODEL'!C:C,0)),0)` } as never;
     revCell.numFmt = '$#,##0';
 
+    // v3.2: pull both the expense line + hiring line and sum them for Total Costs
     const costCell = ws.getCell(row, 5);
     styleCell(costCell, C.RED_LIGHT, C.RED, 10, false, 'right');
-    costCell.value = { formula: `IFERROR(INDEX('REVENUE MODEL'!${colLetter}:${colLetter},MATCH("TOTAL MONTHLY COSTS",'REVENUE MODEL'!C:C,0)),0)` } as never;
+    costCell.value = {
+      formula:
+        `IFERROR(INDEX('REVENUE MODEL'!${colLetter}:${colLetter},MATCH("TOTAL MONTHLY COSTS (Expenses)",'REVENUE MODEL'!C:C,0)),0)` +
+        `+IFERROR(INDEX('REVENUE MODEL'!${colLetter}:${colLetter},MATCH("    Hiring Costs (Eng + Support + BD)",'REVENUE MODEL'!C:C,0)),0)`,
+    } as never;
     costCell.numFmt = '$#,##0';
 
     const netCell = ws.getCell(row, 6);

--- a/scripts/financial-model/tabs/inputs.ts
+++ b/scripts/financial-model/tabs/inputs.ts
@@ -1,7 +1,7 @@
 import type { Workbook, Worksheet } from 'exceljs';
 import { C } from '../colors.ts';
 import { banner, styleCell, styleRange, secHead, lbl, inp, calc, note, setColumnPixelWidths } from '../style.ts';
-import { PLATFORM, SUBSCRIPTIONS, GROWTH, SCENARIOS, HORIZON, RESERVES, type InputRow } from '../data.ts';
+import { PLATFORM, SUBSCRIPTIONS, GROWTH, SCENARIOS, HORIZON, RESERVES, HIRING, UNIT_ECON, type InputRow } from '../data.ts';
 
 function writeInputRow(wb: Workbook, ws: Worksheet, row: number, def: InputRow): void {
   ws.getRow(row).height = 26;
@@ -99,6 +99,16 @@ export function buildInputsTab(wb: Workbook): void {
   // ── Section F (new in v3.1) ──
   secHead(ws, r++, 2, 5, 'F.  TAX, CASH & RESERVE INPUTS  —  Drives cumulative cash, churn, founder comp');
   RESERVES.forEach((res) => writeInputRow(wb, ws, r++, res));
+  r += 2;
+
+  // ── Section G (new in v3.2 — Phase 1b) ──
+  secHead(ws, r++, 2, 5, 'G.  HIRING PLAN  —  Set month + burdened $/mo per role. Costs auto-add to Revenue Model from hire month forward.');
+  HIRING.forEach((h) => writeInputRow(wb, ws, r++, h));
+  r += 2;
+
+  // ── Section H (new in v3.2 — Phase 1b) ──
+  secHead(ws, r++, 2, 5, 'H.  UNIT ECONOMICS & COHORT RAMP  —  Drives cohort-based booking velocity, LTV, CAC, payback calculations');
+  UNIT_ECON.forEach((u) => writeInputRow(wb, ws, r++, u));
 
   r++;
   note(ws, r, 2, 5, 'Change any amber cell — Revenue Model, Break-Even, and Funding Ask tabs all update automatically.');

--- a/scripts/financial-model/tabs/instructions.ts
+++ b/scripts/financial-model/tabs/instructions.ts
@@ -22,6 +22,8 @@ export function buildInstructionsTab(wb: Workbook): void {
         ['Section D',        'Scenario multipliers — how Conservative and Optimistic differ from Base.'],
         ['Section E',        'Planning horizon and model start date label.'],
         ['Section F',        'Tax, Cash & Reserves — churn, starting cash, funding inflow (month + amount), founder comp post-funding. Drives cumulative cash position.'],
+      ['Section G (NEW)',  'Hiring Plan — hire month + burdened cost per role (Eng, Support, BD). Auto-adds to Revenue Model from hire month forward.'],
+      ['Section H (NEW)',  'Unit Economics & Cohort Ramp — ramp months, owner lifetime, traveler lifetime, voice overage rate. Drives UNIT ECON + cohort booking velocity.'],
       ],
     },
     {
@@ -48,6 +50,40 @@ export function buildInstructionsTab(wb: Workbook): void {
         ['BREAK-EVEN',       'Month-by-month cumulative cash. Green = profitable, Red = burning cash.'],
         ['KPI row (row 5)',  'One-time costs, monthly burn, break-even month, 6-mo and 12-mo funding needs.'],
         ['Break-even month', 'First month cumulative cash turns positive. "Not in 24mo" if not achieved.'],
+        ['Costs',            'Includes both EXPENSES tab totals + Hiring Costs from REVENUE MODEL.'],
+      ],
+    },
+    {
+      title: '4b. UNIT ECON (new in v3.2)', color: C.EMERALD, items: [
+        ['UNIT ECON',     '24-month rollups for LTV, CAC, payback. Directional — assumes uniform user behavior across cohorts.'],
+        ['Owner LTV',     '(Avg monthly net commission + avg monthly subscription rev per owner) × uOwnLife.'],
+        ['Traveler LTV',  '(Avg monthly subscription rev + avg voice overage per traveler) × uTravLife.'],
+        ['Blended CAC',   'Total marketing spend ÷ net new users over 24 months.'],
+        ['LTV / CAC',     'Healthy benchmark > 3:1. Owner ratio typically higher than Traveler.'],
+        ['Payback',       'CAC ÷ blended monthly revenue per user. < 12 months is healthy seed-stage.'],
+      ],
+    },
+    {
+      title: '4c. SENSITIVITY (new in v3.2)', color: C.NAVY_LIGHT, items: [
+        ['SENSITIVITY',       '24-month revenue + profit impact when commission rate, avg booking value, or booking volume change ±20%.'],
+        ['Linear assumption', 'Each driver varied alone, holding others at Base. For compounding effects, use the Scenario dropdown on REVENUE MODEL.'],
+        ['Use for diligence', 'Pair worst-case from this tab with Conservative scenario to set the funding-ask lower bound.'],
+      ],
+    },
+    {
+      title: '4d. TAX RESERVES — CASH-FLOW NOTE', color: C.AMBER, items: [
+        ['Lodging + sales tax',  'Once Stripe Tax is activated, RAV collects occupancy/lodging tax from travelers and remits it to state/county/city.'],
+        ['Pass-through liability', 'Tax collected sits in the Mercury account briefly but is NOT RAV revenue — it must be remitted on a schedule (typically monthly per state).'],
+        ['Treat as cash, not P&L', 'Cumulative Cash Position in REVENUE MODEL may look temporarily inflated by tax floats. The 24-mo Net P&L excludes tax pass-throughs (they neither hit revenue nor expense in this model).'],
+        ['When this matters',    'Once monthly bookings × avg occupancy tax > ~$5K/mo, automate via Avalara / TaxJar. Until then, manual remit per state is fine.'],
+      ],
+    },
+    {
+      title: '4e. ADDING CHARTS (manual — Phase 2 will automate)', color: C.NAVY_MID, items: [
+        ['Why manual',     'The exceljs library that builds this workbook does not yet support chart serialization. Real interactive charts come in Phase 2 when the model moves into /executive-dashboard (web app, recharts library).'],
+        ['Revenue vs Costs', 'In Excel: open REVENUE MODEL → select row 34 (TOTAL MONTHLY REVENUE) and row 35 (TOTAL MONTHLY COSTS) from columns D:AA → Insert > Line Chart. Takes 10 seconds.'],
+        ['Cumulative Cash',  'Same — select the Cumulative Cash row from D:AA, Insert > Line Chart. Drop a vertical line marker at the break-even month (use the value from BREAK-EVEN tab E5).'],
+        ['Sensitivity bars', 'On SENSITIVITY tab: select the 3-driver matrix, Insert > Bar Chart. Useful for investor decks.'],
       ],
     },
     {

--- a/scripts/financial-model/tabs/revenue.ts
+++ b/scripts/financial-model/tabs/revenue.ts
@@ -94,12 +94,16 @@ export function buildRevenueTab(wb: Workbook): void {
   // 2. MARKETPLACE ACTIVITY
   secHead(ws, row++, 2, 27, '  2.  MARKETPLACE ACTIVITY  (Listings · Offers · Bookings)');
 
+  // Cohort ramp factor: bookings/owner ramps from 0 to gBookPerOwn over uRampMonths
+  // months post-launch. MIN(1, (months_since_launch + 1) / uRampMonths) caps at 1.0.
+  // Set uRampMonths = 1 in INPUTS to disable the ramp (immediate full velocity).
   lbl(ws, row, 3, 'Monthly Bookings (confirmed)');
   for (let m = 1; m <= MONTHS; m++) {
     const col = m + 3;
     const cell = ws.getCell(row, col);
     styleCell(cell, m % 2 === 0 ? C.WHITE : C.CREAM, C.NAVY, 10, false, 'right');
-    cell.value = { formula: `IF(${m}>=gLaunchMo,${colLtr(col)}${ownRow}*gBookPerOwn*${sBook},0)` } as never;
+    const ramp = `MIN(1,(${m}-gLaunchMo+1)/uRampMonths)`;
+    cell.value = { formula: `IF(${m}>=gLaunchMo,${colLtr(col)}${ownRow}*gBookPerOwn*${ramp}*${sBook},0)` } as never;
     cell.numFmt = '#,##0.0';
   }
   const bookRow = row++;
@@ -220,6 +224,21 @@ export function buildRevenueTab(wb: Workbook): void {
   const subRevRow = row;
   row += 2;
 
+  // 4b. USAGE REVENUE (Voice Overage — new in v3.2 / Phase 1b)
+  secHead(ws, row++, 2, 27, '  4b. USAGE REVENUE  (voice / AI overage — non-Premium travelers only)');
+  lbl(ws, row, 3, '    Voice Overage Revenue');
+  for (let m = 1; m <= MONTHS; m++) {
+    const col = m + 3;
+    const cL = colLtr(col);
+    const cell = ws.getCell(row, col);
+    styleCell(cell, m % 2 === 0 ? C.WHITE : C.CREAM, C.NAVY, 10, false, 'right');
+    // Premium travelers (gTrav2) have unlimited voice — exclude. Overage = (Free + Plus) × per-traveler $
+    cell.value = { formula: `IF(${m}>=gLaunchMo,${cL}${travRow}*(1-gTrav2)*uVoiceOverage,0)` } as never;
+    cell.numFmt = '$#,##0';
+  }
+  const voiceRow = row;
+  row += 2;
+
   // 5. TOTALS
   secHead(ws, row++, 2, 27, '  5.  REVENUE vs COSTS vs PROFIT / (LOSS)');
 
@@ -232,7 +251,8 @@ export function buildRevenueTab(wb: Workbook): void {
     const cL = colLtr(col);
     const cell = ws.getCell(row, col);
     styleCell(cell, C.EMERALD, C.WHITE, 12, true, 'right');
-    cell.value = { formula: `${cL}${commRow}+${cL}${subRevRow}` } as never;
+    // v3.2: Total Revenue = Net Commission + Subscription Total + Voice Overage
+    cell.value = { formula: `${cL}${commRow}+${cL}${subRevRow}+${cL}${voiceRow}` } as never;
     cell.numFmt = '$#,##0';
   }
   const totRevRow = row++;
@@ -240,7 +260,7 @@ export function buildRevenueTab(wb: Workbook): void {
   ws.getRow(row).height = 34;
   const totCostLbl = ws.getCell(row, 3);
   styleCell(totCostLbl, C.RED, C.WHITE, 12, true, 'left');
-  totCostLbl.value = 'TOTAL MONTHLY COSTS';
+  totCostLbl.value = 'TOTAL MONTHLY COSTS (Expenses)';
   for (let m = 1; m <= MONTHS; m++) {
     const col = m + 3;
     const cell = ws.getCell(row, col);
@@ -257,6 +277,27 @@ export function buildRevenueTab(wb: Workbook): void {
   }
   const totCostRow = row++;
 
+  // Hiring Costs row (new in v3.2 / Phase 1b)
+  // Each hire's burdened cost activates from its hire month forward.
+  // Hire month = 0 means "no hire planned" (contributes $0).
+  ws.getRow(row).height = 28;
+  const hireLbl = ws.getCell(row, 3);
+  styleCell(hireLbl, C.NAVY_MID, C.WHITE, 10, true, 'left');
+  hireLbl.value = '    Hiring Costs (Eng + Support + BD)';
+  for (let m = 1; m <= MONTHS; m++) {
+    const col = m + 3;
+    const cell = ws.getCell(row, col);
+    styleCell(cell, m % 2 === 0 ? C.RED_LIGHT : C.WHITE, C.RED, 10, false, 'right');
+    cell.value = {
+      formula:
+        `IF(hEngMonth=0,0,IF(${m}>=hEngMonth,hEngCost,0))+` +
+        `IF(hSupMonth=0,0,IF(${m}>=hSupMonth,hSupCost,0))+` +
+        `IF(hBDMonth=0,0,IF(${m}>=hBDMonth,hBDCost,0))`,
+    } as never;
+    cell.numFmt = '$#,##0';
+  }
+  const hireRow = row++;
+
   ws.getRow(row).height = 36;
   const netLblCell = ws.getCell(row, 3);
   styleCell(netLblCell, C.NAVY, C.AMBER, 12, true, 'left');
@@ -266,7 +307,8 @@ export function buildRevenueTab(wb: Workbook): void {
     const cL = colLtr(col);
     const cell = ws.getCell(row, col);
     styleCell(cell, C.NAVY, C.AMBER, 12, true, 'right');
-    cell.value = { formula: `${cL}${totRevRow}-${cL}${totCostRow}` } as never;
+    // v3.2: Net = Revenue - (Expenses + Hiring)
+    cell.value = { formula: `${cL}${totRevRow}-${cL}${totCostRow}-${cL}${hireRow}` } as never;
     cell.numFmt = '$#,##0';
   }
   const netRow = row++;

--- a/scripts/financial-model/tabs/sensitivity.ts
+++ b/scripts/financial-model/tabs/sensitivity.ts
@@ -1,0 +1,178 @@
+import type { Workbook } from 'exceljs';
+import { C } from '../colors.ts';
+import { banner, styleCell, secHead, note, setColumnPixelWidths } from '../style.ts';
+
+/**
+ * SENSITIVITY tab — shows ±10% / ±20% impact on 24-month outputs for
+ * 3 key drivers: commission rate, average booking value, booking volume.
+ *
+ * IMPLEMENTATION NOTE: Excel doesn't have a clean way to vary a named input
+ * just for one calculation while leaving others alone. So instead of "what
+ * if pCommBase were 12% instead of 15%?" we use the linear property of the
+ * model: commission revenue scales linearly with commission rate, linearly
+ * with booking volume, and linearly with avg booking value (since GBV =
+ * bookings × avg_value).
+ *
+ * For drivers that scale non-linearly (e.g., growth rate over time has
+ * compounding effects), the user can use the Scenario dropdown on REVENUE
+ * MODEL to switch Conservative / Base / Optimistic — those use real
+ * recomputation rather than a linear approximation.
+ */
+
+const sumRow = (label: string) =>
+  `SUM(INDEX('REVENUE MODEL'!D:AA,MATCH("${label}",'REVENUE MODEL'!C:C,0),0))`;
+
+export function buildSensitivityTab(wb: Workbook): void {
+  const ws = wb.addWorksheet('SENSITIVITY', { properties: { tabColor: { argb: C.NAVY_LIGHT } } });
+
+  setColumnPixelWidths(ws, [20, 30, 290, 130, 130, 130, 130, 130, 280]);
+
+  ws.getRow(1).height = 52;
+  banner(ws, 1, 2, 8, 'RAV SENSITIVITY ANALYSIS — Top 3 Drivers', C.NAVY, C.AMBER, 16, true);
+  ws.getRow(2).height = 22;
+  banner(ws, 2, 2, 8, '24-month total impact of varying each driver ±10% and ±20% (linear approximation)', C.AMBER_LIGHT, C.AMBER, 9, false);
+  ws.getRow(3).height = 8;
+
+  let r = 4;
+
+  // ─── Section 1: Sensitivity matrix ───────────────────────────────────────
+  secHead(ws, r++, 2, 8, '  COMMISSION-LINKED 24-MONTH REVENUE  —  Varying each driver, holding others at Base');
+
+  // Header row
+  const hdrs = ['Driver', '−20%', '−10%', 'Base', '+10%', '+20%', 'Behaviour'];
+  ws.getRow(r).height = 28;
+  hdrs.forEach((h, i) => {
+    const cell = ws.getCell(r, i + 3);
+    styleCell(cell, C.NAVY, C.WHITE, 10, true, i === 0 || i === 6 ? 'left' : 'center');
+    cell.value = h;
+  });
+  r++;
+
+  // Reference: base 24-mo Net Commission revenue
+  const baseCommSum = sumRow('Net Commission Revenue');
+
+  const drivers: [string, string, string][] = [
+    [
+      'Commission Rate (pCommBase)',
+      baseCommSum,
+      'Commission scales linearly with rate. ±20% rate → ±20% commission revenue. Subscription rev unchanged.',
+    ],
+    [
+      'Average Booking Value (pAvgBooking)',
+      baseCommSum,
+      'GBV is bookings × avg value, so commission scales linearly with avg value.',
+    ],
+    [
+      'Booking Volume',
+      baseCommSum,
+      'Total bookings × avg value × rate — linear in volume. Use Scenario dropdown for compounding volume + growth effects.',
+    ],
+  ];
+
+  const multipliers = [0.8, 0.9, 1.0, 1.1, 1.2];
+
+  drivers.forEach((d, idx) => {
+    ws.getRow(r).height = 28;
+    const alt = idx % 2 === 0 ? C.WHITE : C.CREAM;
+
+    const lblCell = ws.getCell(r, 3);
+    styleCell(lblCell, C.SAND, C.NAVY, 10, true, 'left');
+    lblCell.value = d[0];
+
+    multipliers.forEach((mult, i) => {
+      const cell = ws.getCell(r, 4 + i);
+      const isBase = mult === 1.0;
+      styleCell(cell, isBase ? C.EMERALD : alt, isBase ? C.WHITE : C.NAVY, 10, isBase, 'right');
+      cell.value = { formula: `${d[1]}*${mult}` } as never;
+      cell.numFmt = '$#,##0';
+    });
+
+    const noteCell = ws.getCell(r, 9);
+    styleCell(noteCell, alt, C.SLATE, 9, false, 'left', true);
+    noteCell.value = d[2];
+    r++;
+  });
+
+  r += 2;
+
+  // ─── Section 2: Profitability impact ─────────────────────────────────────
+  secHead(ws, r++, 2, 8, '  24-MONTH PROFIT IMPACT  —  How each driver moves the bottom line');
+
+  ws.getRow(r).height = 28;
+  hdrs.forEach((h, i) => {
+    const cell = ws.getCell(r, i + 3);
+    styleCell(cell, C.NAVY, C.WHITE, 10, true, i === 0 || i === 6 ? 'left' : 'center');
+    cell.value = h;
+  });
+  r++;
+
+  // 24-mo base totals
+  const baseTotRev = sumRow('TOTAL MONTHLY REVENUE');
+  const baseTotCost = `${sumRow('TOTAL MONTHLY COSTS (Expenses)')}+${sumRow('    Hiring Costs (Eng + Support + BD)')}`;
+  // Base profit = total rev - total cost
+  // For sensitivities, only commission portion changes; subscriptions + voice stay fixed
+
+  const profitDrivers: [string, string, string][] = [
+    [
+      'Commission Rate sensitivity',
+      `(${baseTotRev}-${baseCommSum})+(${baseCommSum})*MULT-(${baseTotCost})`,
+      '24-mo profit = (non-commission rev) + (commission × multiplier) − (total costs)',
+    ],
+    [
+      'Avg Booking Value sensitivity',
+      `(${baseTotRev}-${baseCommSum})+(${baseCommSum})*MULT-(${baseTotCost})`,
+      'Linear: avg value changes scale commission directly. Same formula as commission rate variation.',
+    ],
+    [
+      'Booking Volume sensitivity',
+      `(${baseTotRev}-${baseCommSum})+(${baseCommSum})*MULT-(${baseTotCost})`,
+      'Linear assumption — for compounding volume + growth combined, switch Scenario dropdown.',
+    ],
+  ];
+
+  profitDrivers.forEach((d, idx) => {
+    ws.getRow(r).height = 28;
+    const alt = idx % 2 === 0 ? C.WHITE : C.CREAM;
+
+    const lblCell = ws.getCell(r, 3);
+    styleCell(lblCell, C.SAND, C.NAVY, 10, true, 'left');
+    lblCell.value = d[0];
+
+    multipliers.forEach((mult, i) => {
+      const cell = ws.getCell(r, 4 + i);
+      const isBase = mult === 1.0;
+      // Substitute the literal multiplier into the formula template
+      const formula = d[1].replace(/MULT/g, String(mult));
+      const isLoss = mult < 1.0;
+      styleCell(cell, isBase ? C.AMBER : (isLoss ? C.RED_LIGHT : alt), isBase ? C.NAVY : (isLoss ? C.RED : C.NAVY), 10, isBase, 'right');
+      cell.value = { formula } as never;
+      cell.numFmt = '$#,##0';
+    });
+
+    const noteCell = ws.getCell(r, 9);
+    styleCell(noteCell, alt, C.SLATE, 9, false, 'left', true);
+    noteCell.value = d[2];
+    r++;
+  });
+
+  r += 2;
+
+  // ─── Section 3: Read-this-first ──────────────────────────────────────────
+  secHead(ws, r++, 2, 8, '  HOW TO USE THIS TAB');
+
+  const guidance = [
+    'Use the linear sensitivities above to estimate impact of single-variable changes. They assume only one driver moves at a time.',
+    'For combined scenarios (e.g., low volume AND low growth AND high churn), use the Scenario dropdown on REVENUE MODEL!D4 — Conservative/Base/Optimistic recompute the full 24-month trajectory using the multipliers in INPUTS Section D.',
+    'For permanent assumption changes, edit the relevant cell in INPUTS (Section A for commission/booking value, Section C for growth rates). The whole model recomputes — this Sensitivity tab also updates.',
+    'Sensitivities here vary commission-linked revenue. Subscription and voice overage revenue are unaffected by these levers — they depend on user counts, not commission rate.',
+    'For investor diligence: pair this with the Conservative scenario in REVENUE MODEL to show the worst plausible case, and Optimistic for the upside case.',
+  ];
+  guidance.forEach((g, i) => {
+    ws.getRow(r).height = 36;
+    ws.mergeCells(r, 3, r, 9);
+    const cell = ws.getCell(r, 3);
+    styleCell(cell, i % 2 === 0 ? C.CREAM : C.WHITE, C.NAVY, 10, false, 'left', true);
+    cell.value = `${i + 1}.  ${g}`;
+    r++;
+  });
+}

--- a/scripts/financial-model/tabs/unit-econ.ts
+++ b/scripts/financial-model/tabs/unit-econ.ts
@@ -1,0 +1,138 @@
+import type { Workbook } from 'exceljs';
+import { C } from '../colors.ts';
+import { banner, styleCell, secHead, note, lbl, setColumnPixelWidths } from '../style.ts';
+
+/**
+ * UNIT ECONOMICS tab — directional CAC, LTV, payback metrics derived from
+ * the 24-month projection. Uses INDEX/MATCH against row labels in REVENUE
+ * MODEL so this tab survives row reordering in revenue.ts.
+ *
+ * NOTE: this is a "ballpark" view, not investor-grade cohort accounting.
+ * For diligence-grade unit econ, cohort-level LTV/CAC tracking would
+ * require restructuring the model around cohort vintages. Adequate for
+ * pre-revenue planning + first investor conversations.
+ */
+
+// INDEX/MATCH wrapper — pulls a whole row from REVENUE MODEL by label,
+// returning either SUM of all 24 monthly columns or just one month.
+const matchRow = (label: string) =>
+  `INDEX('REVENUE MODEL'!D:AA,MATCH("${label}",'REVENUE MODEL'!C:C,0),0)`;
+
+const sumRow = (label: string) => `SUM(${matchRow(label)})`;
+
+export function buildUnitEconTab(wb: Workbook): void {
+  const ws = wb.addWorksheet('UNIT ECON', { properties: { tabColor: { argb: C.EMERALD } } });
+
+  setColumnPixelWidths(ws, [20, 30, 320, 160, 320]);
+
+  ws.getRow(1).height = 52;
+  banner(ws, 1, 2, 4, 'RAV UNIT ECONOMICS — LTV, CAC, Payback', C.NAVY, C.EMERALD, 16, true);
+  ws.getRow(2).height = 22;
+  banner(ws, 2, 2, 4, '24-month projection averages. Directional, not cohort-grade — see note at bottom.', C.EMERALD_LITE, C.EMERALD, 9, false);
+  ws.getRow(3).height = 8;
+
+  let r = 4;
+
+  // ─── Section 1: Lifetime Value ────────────────────────────────────────────
+  secHead(ws, r++, 2, 4, '  1.  LIFETIME VALUE (LTV)  —  derived from 24-month totals × user lifetime');
+
+  // Helper for one metric row: label | value | note
+  const metric = (label: string, formula: string, fmt: string, hint: string, highlight = false) => {
+    ws.getRow(r).height = 26;
+    const lblCell = ws.getCell(r, 3);
+    styleCell(lblCell, highlight ? C.DEEP_TEAL : C.SAND, highlight ? C.WHITE : C.NAVY, 10, highlight, 'left');
+    lblCell.value = label;
+    const valCell = ws.getCell(r, 4);
+    styleCell(valCell, highlight ? C.EMERALD : C.TEAL_LIGHT, highlight ? C.WHITE : C.NAVY, highlight ? 12 : 10, true, 'right');
+    valCell.value = { formula } as never;
+    valCell.numFmt = fmt;
+    const hintCell = ws.getCell(r, 5);
+    styleCell(hintCell, C.WHITE, C.SLATE, 9, false, 'left', true);
+    hintCell.value = hint;
+    r++;
+  };
+
+  // Owner LTV
+  ws.getRow(r).height = 24;
+  ws.mergeCells(r, 3, r, 4);
+  const ownHdr = ws.getCell(r, 3);
+  styleCell(ownHdr, C.TEAL_MID, C.NAVY, 10, true, 'left');
+  ownHdr.value = '  Owner Side';
+  r++;
+
+  metric('24-mo Total Net Commission Revenue',     sumRow('Net Commission Revenue'),                                                 '$#,##0',     'Sum of monthly Net Commission across 24 months');
+  metric('24-mo Sum of Active Owner-Months',       sumRow('Active Owners'),                                                          '#,##0.0',    'SUM of monthly Active Owners count (proxy for owner exposure)');
+  metric('Avg Net Commission per Owner-Month',     `IFERROR(${sumRow('Net Commission Revenue')}/${sumRow('Active Owners')},0)`,      '$#,##0.00',  'Per-owner monthly contribution from booking commission');
+  metric('24-mo Total Owner Subscription Rev',     `${sumRow('    Owner Pro subscriptions')}+${sumRow('    Owner Business subscriptions')}`, '$#,##0', 'Owner Pro + Owner Business subscription revenue');
+  metric('Avg Owner Subscription Rev / Owner-Month', `IFERROR((${sumRow('    Owner Pro subscriptions')}+${sumRow('    Owner Business subscriptions')})/${sumRow('Active Owners')},0)`, '$#,##0.00', 'Per-owner monthly subscription revenue');
+  metric('Owner LTV', `(IFERROR(${sumRow('Net Commission Revenue')}/${sumRow('Active Owners')},0)+IFERROR((${sumRow('    Owner Pro subscriptions')}+${sumRow('    Owner Business subscriptions')})/${sumRow('Active Owners')},0))*uOwnLife`, '$#,##0', '(Avg monthly revenue per owner) × Average Owner Lifetime (uOwnLife)', true);
+
+  r++;
+
+  // Traveler LTV
+  ws.getRow(r).height = 24;
+  ws.mergeCells(r, 3, r, 4);
+  const travHdr = ws.getCell(r, 3);
+  styleCell(travHdr, C.TEAL_MID, C.NAVY, 10, true, 'left');
+  travHdr.value = '  Traveler Side';
+  r++;
+
+  metric('24-mo Total Traveler Subscription Rev',   `${sumRow('    Traveler Plus subscriptions')}+${sumRow('    Traveler Premium subscriptions')}`, '$#,##0', 'Traveler Plus + Premium subscription revenue');
+  metric('24-mo Sum of Active Traveler-Months',     sumRow('Active Travelers'),                                                  '#,##0.0',   'SUM of monthly Active Travelers');
+  metric('Avg Traveler Sub Rev / Traveler-Month',   `IFERROR((${sumRow('    Traveler Plus subscriptions')}+${sumRow('    Traveler Premium subscriptions')})/${sumRow('Active Travelers')},0)`, '$#,##0.00', 'Per-traveler monthly subscription revenue');
+  metric('24-mo Voice Overage Revenue',             sumRow('    Voice Overage Revenue'),                                          '$#,##0',    'Voice/AI overage from non-Premium travelers');
+  metric('Avg Voice Rev / Traveler-Month',          `IFERROR(${sumRow('    Voice Overage Revenue')}/${sumRow('Active Travelers')},0)`, '$#,##0.00', 'Per-traveler monthly voice overage');
+  metric('Traveler LTV', `(IFERROR((${sumRow('    Traveler Plus subscriptions')}+${sumRow('    Traveler Premium subscriptions')})/${sumRow('Active Travelers')},0)+IFERROR(${sumRow('    Voice Overage Revenue')}/${sumRow('Active Travelers')},0))*uTravLife`, '$#,##0', '(Avg monthly revenue per traveler) × Avg Traveler Lifetime (uTravLife)', true);
+
+  r += 2;
+
+  // ─── Section 2: CAC ───────────────────────────────────────────────────────
+  secHead(ws, r++, 2, 4, '  2.  CUSTOMER ACQUISITION COST (CAC)  —  Blended');
+
+  // Marketing spend (one-time + monthly × 24)
+  metric('24-mo Total Marketing Spend',
+    `SUMIFS(EXPENSES!F:F,EXPENSES!C:C,"Marketing & Launch",EXPENSES!E:E,"One-Time")+SUMIFS(EXPENSES!J:J,EXPENSES!C:C,"Marketing & Launch",EXPENSES!E:E,"Recurring")*24`,
+    '$#,##0', 'One-time marketing + (monthly recurring marketing × 24 months)');
+
+  metric('Net New Owners (24mo)',
+    `INDEX('REVENUE MODEL'!AA:AA,MATCH("Active Owners",'REVENUE MODEL'!C:C,0))-INDEX('REVENUE MODEL'!D:D,MATCH("Active Owners",'REVENUE MODEL'!C:C,0))`,
+    '#,##0.0', 'Active Owners (Mo 24) − Active Owners (Mo 1). Under-counts due to churn.');
+
+  metric('Net New Travelers (24mo)',
+    `INDEX('REVENUE MODEL'!AA:AA,MATCH("Active Travelers",'REVENUE MODEL'!C:C,0))-INDEX('REVENUE MODEL'!D:D,MATCH("Active Travelers",'REVENUE MODEL'!C:C,0))`,
+    '#,##0.0', 'Active Travelers (Mo 24) − Active Travelers (Mo 1). Under-counts due to churn.');
+
+  // CAC = total marketing / total new users (blended)
+  metric('Blended CAC',
+    `IFERROR((SUMIFS(EXPENSES!F:F,EXPENSES!C:C,"Marketing & Launch",EXPENSES!E:E,"One-Time")+SUMIFS(EXPENSES!J:J,EXPENSES!C:C,"Marketing & Launch",EXPENSES!E:E,"Recurring")*24)/((INDEX('REVENUE MODEL'!AA:AA,MATCH("Active Owners",'REVENUE MODEL'!C:C,0))-INDEX('REVENUE MODEL'!D:D,MATCH("Active Owners",'REVENUE MODEL'!C:C,0)))+(INDEX('REVENUE MODEL'!AA:AA,MATCH("Active Travelers",'REVENUE MODEL'!C:C,0))-INDEX('REVENUE MODEL'!D:D,MATCH("Active Travelers",'REVENUE MODEL'!C:C,0)))),0)`,
+    '$#,##0', 'Total marketing spend ÷ total net new users. Healthy benchmark: < 1/3 of LTV.', true);
+
+  r += 2;
+
+  // ─── Section 3: LTV/CAC + Payback ────────────────────────────────────────
+  secHead(ws, r++, 2, 4, '  3.  LTV/CAC RATIO + PAYBACK PERIOD');
+  ws.getRow(r).height = 22;
+  note(ws, r++, 2, 4, 'Healthy SaaS benchmark: LTV/CAC > 3:1, payback < 12 months. Lower ratios = burn-funded growth.');
+
+  // Row references for cross-section formulas
+  // To avoid hardcoding rows, use INDEX/MATCH against the labels in this same sheet.
+  const ownerLtvRef = `INDEX(D:D,MATCH("Owner LTV",C:C,0))`;
+  const travLtvRef  = `INDEX(D:D,MATCH("Traveler LTV",C:C,0))`;
+  const cacRef      = `INDEX(D:D,MATCH("Blended CAC",C:C,0))`;
+
+  metric('Owner LTV / CAC',     `IFERROR(${ownerLtvRef}/${cacRef},0)`,   '0.00"x"', 'Owner LTV ÷ Blended CAC. >3x is healthy.', true);
+  metric('Traveler LTV / CAC',  `IFERROR(${travLtvRef}/${cacRef},0)`,    '0.00"x"', 'Traveler LTV ÷ Blended CAC. Travelers churn faster — lower ratio expected.', true);
+
+  // Payback months = CAC / blended monthly revenue per user
+  // Blended monthly rev per user = (Total Revenue / Total User-Months)
+  const totUserMonths = `(${sumRow('Active Owners')}+${sumRow('Active Travelers')})`;
+  const blendedMRPU = `IFERROR(${sumRow('TOTAL MONTHLY REVENUE')}/${totUserMonths},0)`;
+  metric('Blended Monthly Revenue per User', blendedMRPU, '$#,##0.00', 'Total 24-mo revenue ÷ total user-months.');
+  metric('Payback Period (months)', `IFERROR(${cacRef}/${blendedMRPU},0)`, '0.0" mo"', 'CAC ÷ Monthly Revenue per User. <12mo is healthy seed-stage.', true);
+
+  r += 2;
+
+  // Footer note
+  ws.getRow(r).height = 60;
+  banner(ws, r, 2, 4, 'Directional metrics — assumes uniform user behavior, ignores cohort vintages. For investor diligence, request cohort retention curves and per-channel CAC. Voice overage revenue is included in Total Monthly Revenue but excluded from Owner LTV (attributed to travelers).', C.AMBER_LIGHT, C.AMBER, 9, false);
+}

--- a/src/components/admin/AdminMarketplaceRegistrations.tsx
+++ b/src/components/admin/AdminMarketplaceRegistrations.tsx
@@ -1,0 +1,393 @@
+import { useEffect, useMemo, useState } from "react";
+import { supabase } from "@/lib/supabase";
+import { useAuth } from "@/hooks/useAuth";
+import { useToast } from "@/hooks/use-toast";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { MapPin, Pencil, AlertTriangle } from "lucide-react";
+
+type RegistrationStatus = "not_required" | "pending" | "registered" | "exempt";
+
+interface MarketplaceRegistrationRow {
+  state: string;
+  registration_status: RegistrationStatus;
+  registered_date: string | null;
+  first_return_due: string | null;
+  last_return_filed: string | null;
+  next_return_due: string | null;
+  registration_id: string | null;
+  notes: string | null;
+  updated_at: string;
+  updated_by: string | null;
+}
+
+const STATUS_LABELS: Record<RegistrationStatus, string> = {
+  not_required: "Not required",
+  pending: "Pending",
+  registered: "Registered",
+  exempt: "Exempt",
+};
+
+const STATUS_VARIANTS: Record<RegistrationStatus, "default" | "secondary" | "outline" | "destructive"> = {
+  not_required: "outline",
+  pending: "secondary",
+  registered: "default",
+  exempt: "outline",
+};
+
+function formatDate(value: string | null): string {
+  if (!value) return "—";
+  return new Date(value).toLocaleDateString("en-US", { year: "numeric", month: "short", day: "numeric" });
+}
+
+function toDateInputValue(value: string | null): string {
+  if (!value) return "";
+  return new Date(value).toISOString().slice(0, 10);
+}
+
+interface EditDraft {
+  registration_status: RegistrationStatus;
+  registered_date: string;
+  first_return_due: string;
+  last_return_filed: string;
+  next_return_due: string;
+  registration_id: string;
+  notes: string;
+}
+
+function rowToDraft(row: MarketplaceRegistrationRow): EditDraft {
+  return {
+    registration_status: row.registration_status,
+    registered_date: toDateInputValue(row.registered_date),
+    first_return_due: toDateInputValue(row.first_return_due),
+    last_return_filed: toDateInputValue(row.last_return_filed),
+    next_return_due: toDateInputValue(row.next_return_due),
+    registration_id: row.registration_id ?? "",
+    notes: row.notes ?? "",
+  };
+}
+
+export function AdminMarketplaceRegistrations() {
+  const { user } = useAuth();
+  const { toast } = useToast();
+  const [rows, setRows] = useState<MarketplaceRegistrationRow[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [editTarget, setEditTarget] = useState<MarketplaceRegistrationRow | null>(null);
+  const [draft, setDraft] = useState<EditDraft | null>(null);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+
+  useEffect(() => {
+    void load();
+    // load is a stable closure that uses no component state on read — safe to omit from deps.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  async function load() {
+    setIsLoading(true);
+    const { data, error } = await supabase
+      .from("marketplace_registrations")
+      .select("*")
+      .order("state");
+    if (error) {
+      toast({ title: "Failed to load registrations", description: error.message, variant: "destructive" });
+      setIsLoading(false);
+      return;
+    }
+    setRows((data ?? []) as MarketplaceRegistrationRow[]);
+    setIsLoading(false);
+  }
+
+  const summary = useMemo(() => {
+    const counts: Record<RegistrationStatus, number> = {
+      not_required: 0,
+      pending: 0,
+      registered: 0,
+      exempt: 0,
+    };
+    for (const r of rows) counts[r.registration_status] = (counts[r.registration_status] ?? 0) + 1;
+    return counts;
+  }, [rows]);
+
+  function openEdit(row: MarketplaceRegistrationRow) {
+    setEditTarget(row);
+    setDraft(rowToDraft(row));
+  }
+
+  function closeEdit() {
+    setEditTarget(null);
+    setDraft(null);
+    setConfirmOpen(false);
+  }
+
+  async function save() {
+    if (!editTarget || !draft || !user) return;
+    setIsSaving(true);
+    const payload = {
+      registration_status: draft.registration_status,
+      registered_date: draft.registered_date || null,
+      first_return_due: draft.first_return_due || null,
+      last_return_filed: draft.last_return_filed || null,
+      next_return_due: draft.next_return_due || null,
+      registration_id: draft.registration_id.trim() || null,
+      notes: draft.notes.trim() || null,
+      updated_by: user.id,
+    };
+    const { error } = await supabase
+      .from("marketplace_registrations")
+      .update(payload)
+      .eq("state", editTarget.state);
+    setIsSaving(false);
+    if (error) {
+      toast({ title: "Failed to save", description: error.message, variant: "destructive" });
+      return;
+    }
+    toast({
+      title: `${editTarget.state} registration updated`,
+      description: `Status set to ${STATUS_LABELS[draft.registration_status]}.`,
+    });
+    closeEdit();
+    void load();
+  }
+
+  if (isLoading) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Marketplace-facilitator registrations</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-2">
+          {Array.from({ length: 5 }).map((_, i) => (
+            <Skeleton key={i} className="h-8 w-full" />
+          ))}
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <MapPin className="h-5 w-5 text-primary" />
+            Marketplace-facilitator registrations
+          </CardTitle>
+          <CardDescription>
+            State-by-state tax registration status. Required by Compliance Brief § 3.4 — counsel question C7 fills in
+            the values per state. Only RAV admins can change a row's status; every change records who, when, and the
+            notes you leave.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="grid grid-cols-4 gap-3 mb-6">
+            {(Object.keys(STATUS_LABELS) as RegistrationStatus[]).map((s) => (
+              <div key={s} className="rounded-lg border border-border p-3">
+                <p className="text-xs text-muted-foreground">{STATUS_LABELS[s]}</p>
+                <p className="text-2xl font-semibold">{summary[s]}</p>
+              </div>
+            ))}
+          </div>
+
+          <div className="rounded-md border overflow-x-auto">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>State</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead>Registered</TableHead>
+                  <TableHead>Next return due</TableHead>
+                  <TableHead>Registration ID</TableHead>
+                  <TableHead>Notes</TableHead>
+                  <TableHead className="text-right">Action</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {rows.map((row) => (
+                  <TableRow key={row.state} data-state-row={row.state}>
+                    <TableCell className="font-mono font-semibold">{row.state}</TableCell>
+                    <TableCell>
+                      <Badge variant={STATUS_VARIANTS[row.registration_status]}>
+                        {STATUS_LABELS[row.registration_status]}
+                      </Badge>
+                    </TableCell>
+                    <TableCell className="text-sm text-muted-foreground">{formatDate(row.registered_date)}</TableCell>
+                    <TableCell className="text-sm text-muted-foreground">{formatDate(row.next_return_due)}</TableCell>
+                    <TableCell className="text-sm text-muted-foreground">{row.registration_id ?? "—"}</TableCell>
+                    <TableCell className="text-xs text-muted-foreground max-w-[260px] truncate" title={row.notes ?? ""}>
+                      {row.notes ?? "—"}
+                    </TableCell>
+                    <TableCell className="text-right">
+                      <Button variant="ghost" size="sm" onClick={() => openEdit(row)}>
+                        <Pencil className="h-4 w-4 mr-1.5" />
+                        Edit
+                      </Button>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Dialog open={editTarget !== null} onOpenChange={(open) => !open && closeEdit()}>
+        <DialogContent className="max-w-lg">
+          <DialogHeader>
+            <DialogTitle>Edit {editTarget?.state} registration</DialogTitle>
+            <DialogDescription>
+              Changes record your user ID + timestamp. You'll confirm before save.
+            </DialogDescription>
+          </DialogHeader>
+
+          {draft && editTarget && (
+            <div className="space-y-3">
+              <div>
+                <label className="text-sm font-medium block mb-1">Status</label>
+                <Select
+                  value={draft.registration_status}
+                  onValueChange={(v) => setDraft({ ...draft, registration_status: v as RegistrationStatus })}
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {(Object.keys(STATUS_LABELS) as RegistrationStatus[]).map((s) => (
+                      <SelectItem key={s} value={s}>
+                        {STATUS_LABELS[s]}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+
+              <div className="grid grid-cols-2 gap-3">
+                <div>
+                  <label className="text-sm font-medium block mb-1">Registered date</label>
+                  <Input
+                    type="date"
+                    value={draft.registered_date}
+                    onChange={(e) => setDraft({ ...draft, registered_date: e.target.value })}
+                  />
+                </div>
+                <div>
+                  <label className="text-sm font-medium block mb-1">Next return due</label>
+                  <Input
+                    type="date"
+                    value={draft.next_return_due}
+                    onChange={(e) => setDraft({ ...draft, next_return_due: e.target.value })}
+                  />
+                </div>
+                <div>
+                  <label className="text-sm font-medium block mb-1">First return due</label>
+                  <Input
+                    type="date"
+                    value={draft.first_return_due}
+                    onChange={(e) => setDraft({ ...draft, first_return_due: e.target.value })}
+                  />
+                </div>
+                <div>
+                  <label className="text-sm font-medium block mb-1">Last return filed</label>
+                  <Input
+                    type="date"
+                    value={draft.last_return_filed}
+                    onChange={(e) => setDraft({ ...draft, last_return_filed: e.target.value })}
+                  />
+                </div>
+              </div>
+
+              <div>
+                <label className="text-sm font-medium block mb-1">Registration ID</label>
+                <Input
+                  placeholder="State-issued account / license number"
+                  value={draft.registration_id}
+                  onChange={(e) => setDraft({ ...draft, registration_id: e.target.value })}
+                />
+              </div>
+
+              <div>
+                <label className="text-sm font-medium block mb-1">Notes</label>
+                <Textarea
+                  placeholder="Counsel guidance, filing cadence, rate notes…"
+                  value={draft.notes}
+                  onChange={(e) => setDraft({ ...draft, notes: e.target.value })}
+                  rows={3}
+                />
+              </div>
+            </div>
+          )}
+
+          <DialogFooter>
+            <Button variant="outline" onClick={closeEdit}>
+              Cancel
+            </Button>
+            <Button onClick={() => setConfirmOpen(true)} disabled={!draft}>
+              Save…
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <AlertDialog open={confirmOpen} onOpenChange={setConfirmOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle className="flex items-center gap-2">
+              <AlertTriangle className="h-5 w-5 text-amber-500" />
+              Confirm registration change for {editTarget?.state}
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              You're changing how RAV files marketplace-facilitator taxes for{" "}
+              <strong>{editTarget?.state}</strong>: from{" "}
+              <strong>{editTarget && STATUS_LABELS[editTarget.registration_status]}</strong> to{" "}
+              <strong>{draft && STATUS_LABELS[draft.registration_status]}</strong>. This affects tax behavior at
+              platform scale. Your user ID is recorded as the change author.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isSaving}>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={save} disabled={isSaving}>
+              {isSaving ? "Saving…" : "I understand — save"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}

--- a/src/lib/disclaimers/marketplaceRegistrations.test.ts
+++ b/src/lib/disclaimers/marketplaceRegistrations.test.ts
@@ -1,0 +1,82 @@
+// @vitest-environment jsdom
+// @p0
+/**
+ * Migration audit for Migration 075 — marketplace-facilitator registrations
+ * tracker (#488). Reads the SQL file and asserts the key clauses are present:
+ * table + 51-jurisdiction seed + status enum + RLS + indexes.
+ *
+ * @see docs/legal/compliance-gap-analysis.md item P-5
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const sqlPath = resolve(
+  __dirname,
+  "../../../supabase/migrations/075_marketplace_registrations.sql",
+);
+const sql = readFileSync(sqlPath, "utf-8");
+
+describe("Migration 075 — marketplace_registrations table", () => {
+  it("creates the public.marketplace_registrations table (idempotent via IF NOT EXISTS)", () => {
+    expect(sql).toMatch(/CREATE TABLE IF NOT EXISTS public\.marketplace_registrations/);
+  });
+
+  it("makes state the primary key with a 2-letter uppercase format constraint", () => {
+    expect(sql).toMatch(/state TEXT PRIMARY KEY CHECK \(state ~ '\^\[A-Z\]\{2\}\$'\)/);
+  });
+
+  it("constrains registration_status to the four documented values", () => {
+    expect(sql).toMatch(/CHECK \(registration_status IN \('not_required', 'pending', 'registered', 'exempt'\)\)/);
+  });
+
+  it("defaults registration_status to 'not_required'", () => {
+    expect(sql).toMatch(/registration_status TEXT NOT NULL DEFAULT 'not_required'/);
+  });
+
+  it("seeds all 50 states + DC (51 jurisdictions) idempotently via ON CONFLICT DO NOTHING", () => {
+    // Spot-check a few states; full state list is documented in the migration source
+    for (const state of ["AL", "AK", "CA", "FL", "HI", "NV", "AZ", "NY", "TX", "DC", "WY"]) {
+      expect(sql).toContain(`('${state}')`);
+    }
+    expect(sql).toMatch(/ON CONFLICT \(state\) DO NOTHING/);
+  });
+
+  it("creates an updated_at touch trigger via CREATE OR REPLACE FUNCTION", () => {
+    expect(sql).toMatch(/CREATE OR REPLACE FUNCTION public\.touch_marketplace_registrations_updated_at/);
+    expect(sql).toMatch(/CREATE TRIGGER marketplace_registrations_updated_at\s+BEFORE UPDATE/);
+  });
+
+  it("enables row-level security", () => {
+    expect(sql).toMatch(/ALTER TABLE public\.marketplace_registrations ENABLE ROW LEVEL SECURITY/);
+  });
+
+  it("grants SELECT to any RAV team member via is_rav_team()", () => {
+    expect(sql).toMatch(/"RAV team can read marketplace registrations"/);
+    expect(sql).toMatch(/public\.is_rav_team\(auth\.uid\(\)\)/);
+  });
+
+  it("restricts UPDATE to rav_admin / rav_owner only", () => {
+    expect(sql).toMatch(/"RAV admins can update marketplace registrations"/);
+    expect(sql).toMatch(/ur\.role IN \('rav_admin', 'rav_owner'\)/);
+  });
+
+  it("does NOT expose INSERT or DELETE via RLS (fixed-membership table)", () => {
+    expect(sql).not.toMatch(/CREATE POLICY[^"]+FOR INSERT[^"]+marketplace_registrations/);
+    expect(sql).not.toMatch(/CREATE POLICY[^"]+FOR DELETE[^"]+marketplace_registrations/);
+  });
+
+  it("indexes status for the 'show pending registrations' admin query", () => {
+    expect(sql).toMatch(/CREATE INDEX IF NOT EXISTS idx_marketplace_registrations_status/);
+  });
+
+  it("indexes next_return_due as a partial index for upcoming-return queries", () => {
+    expect(sql).toMatch(/CREATE INDEX IF NOT EXISTS idx_marketplace_registrations_next_return_due/);
+    expect(sql).toMatch(/WHERE next_return_due IS NOT NULL/);
+  });
+
+  it("wraps everything in a transaction", () => {
+    expect(sql).toMatch(/^BEGIN;/m);
+    expect(sql).toMatch(/^COMMIT;/m);
+  });
+});

--- a/src/lib/disclaimers/placements.test.ts
+++ b/src/lib/disclaimers/placements.test.ts
@@ -121,6 +121,14 @@ const PLACEMENTS: ReadonlyArray<Placement> = [
     ],
     notes: "Checkout must prefer the denormalized listing.state (Migration 074) and fall back to resort.location.state.",
   },
+  {
+    file: "src/pages/AdminDashboard.tsx",
+    required: [
+      `AdminMarketplaceRegistrations`,
+      `value="registrations"`,
+    ],
+    notes: "Admin dashboard must register the marketplace-facilitator tracker tab (#488).",
+  },
 ];
 
 describe("Disclaimer placement audit — required <DisclaimerBlock /> usages per page", () => {

--- a/src/pages/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard.tsx
@@ -39,6 +39,7 @@ import {
   Bell,
   Headphones,
   LifeBuoy,
+  MapPin,
 } from "lucide-react";
 import AdminOverview from "@/components/admin/AdminOverview";
 import AdminProperties from "@/components/admin/AdminProperties";
@@ -58,6 +59,7 @@ import { DevTools } from "@/components/admin/DevTools";
 import { VoiceControls } from "@/components/admin/VoiceControls";
 import AdminDisputes from "@/components/admin/AdminDisputes";
 import AdminTaxReporting from "@/components/admin/AdminTaxReporting";
+import { AdminMarketplaceRegistrations } from "@/components/admin/AdminMarketplaceRegistrations";
 import AdminResortImport from "@/components/admin/AdminResortImport";
 import AdminResortTagEditor from "@/components/admin/AdminResortTagEditor";
 import { LaunchReadinessChecklist } from "@/components/admin/LaunchReadinessChecklist";
@@ -243,6 +245,12 @@ const AdminDashboard = () => {
               </TabsTrigger>
             )}
             {isRavAdmin() && (
+              <TabsTrigger value="registrations" className="gap-2">
+                <MapPin className="h-4 w-4" />
+                <span className="hidden sm:inline">Tax registrations</span>
+              </TabsTrigger>
+            )}
+            {isRavAdmin() && (
               <TabsTrigger value="payouts" className="gap-2">
                 <Wallet className="h-4 w-4" />
                 <span className="hidden sm:inline">Payouts</span>
@@ -379,6 +387,12 @@ const AdminDashboard = () => {
           {isRavAdmin() && (
             <TabsContent value="tax">
               <AdminTaxReporting />
+            </TabsContent>
+          )}
+
+          {isRavAdmin() && (
+            <TabsContent value="registrations">
+              <AdminMarketplaceRegistrations />
             </TabsContent>
           )}
 

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -993,6 +993,45 @@ export type Database = {
         }
         Relationships: []
       }
+      marketplace_registrations: {
+        Row: {
+          first_return_due: string | null
+          last_return_filed: string | null
+          next_return_due: string | null
+          notes: string | null
+          registered_date: string | null
+          registration_id: string | null
+          registration_status: string
+          state: string
+          updated_at: string
+          updated_by: string | null
+        }
+        Insert: {
+          first_return_due?: string | null
+          last_return_filed?: string | null
+          next_return_due?: string | null
+          notes?: string | null
+          registered_date?: string | null
+          registration_id?: string | null
+          registration_status?: string
+          state: string
+          updated_at?: string
+          updated_by?: string | null
+        }
+        Update: {
+          first_return_due?: string | null
+          last_return_filed?: string | null
+          next_return_due?: string | null
+          notes?: string | null
+          registered_date?: string | null
+          registration_id?: string | null
+          registration_status?: string
+          state?: string
+          updated_at?: string
+          updated_by?: string | null
+        }
+        Relationships: []
+      }
       notifications: {
         Row: {
           bid_id: string | null

--- a/supabase/migrations/075_marketplace_registrations.sql
+++ b/supabase/migrations/075_marketplace_registrations.sql
@@ -1,0 +1,98 @@
+-- 075_marketplace_registrations.sql
+--
+-- Marketplace-facilitator tax registration tracker per US jurisdiction.
+-- Compliance Brief § 3.4 requires a state-by-state registration status field
+-- in the admin dashboard so RAV staff (and eventually counsel + tax pros) can
+-- coordinate the 40+ state registrations required by post-Wayfair marketplace-
+-- facilitator statutes. Counsel question C7 fills in the actual status values
+-- per state — this migration creates the table + UI surface only.
+--
+-- GitHub issue #488; compliance gap analysis item P-5.
+
+BEGIN;
+
+-- ── Table ────────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS public.marketplace_registrations (
+  state TEXT PRIMARY KEY CHECK (state ~ '^[A-Z]{2}$'),
+  registration_status TEXT NOT NULL DEFAULT 'not_required'
+    CHECK (registration_status IN ('not_required', 'pending', 'registered', 'exempt')),
+  registered_date TIMESTAMPTZ,
+  first_return_due TIMESTAMPTZ,
+  last_return_filed TIMESTAMPTZ,
+  next_return_due TIMESTAMPTZ,
+  registration_id TEXT,
+  notes TEXT,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_by UUID REFERENCES auth.users(id) ON DELETE SET NULL
+);
+
+COMMENT ON TABLE public.marketplace_registrations IS
+  'Marketplace-facilitator tax registration status per US jurisdiction. Required by Compliance Brief § 3.4. Updated only by RAV admins via the admin dashboard. See GitHub issue #488.';
+
+COMMENT ON COLUMN public.marketplace_registrations.registration_status IS
+  'not_required (default, until counsel directs), pending (registration in flight), registered (active, returns filing), exempt (counsel-confirmed no obligation).';
+
+-- ── Seed 50 states + DC (51 jurisdictions) ─────────────────────────────────
+INSERT INTO public.marketplace_registrations (state) VALUES
+  ('AL'), ('AK'), ('AZ'), ('AR'), ('CA'), ('CO'), ('CT'), ('DE'), ('FL'),
+  ('GA'), ('HI'), ('ID'), ('IL'), ('IN'), ('IA'), ('KS'), ('KY'), ('LA'),
+  ('ME'), ('MD'), ('MA'), ('MI'), ('MN'), ('MS'), ('MO'), ('MT'), ('NE'),
+  ('NV'), ('NH'), ('NJ'), ('NM'), ('NY'), ('NC'), ('ND'), ('OH'), ('OK'),
+  ('OR'), ('PA'), ('RI'), ('SC'), ('SD'), ('TN'), ('TX'), ('UT'), ('VT'),
+  ('VA'), ('WA'), ('WV'), ('WI'), ('WY'), ('DC')
+ON CONFLICT (state) DO NOTHING;
+
+-- ── updated_at trigger ─────────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION public.touch_marketplace_registrations_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS marketplace_registrations_updated_at ON public.marketplace_registrations;
+CREATE TRIGGER marketplace_registrations_updated_at
+  BEFORE UPDATE ON public.marketplace_registrations
+  FOR EACH ROW EXECUTE FUNCTION public.touch_marketplace_registrations_updated_at();
+
+-- ── RLS ────────────────────────────────────────────────────────────────────
+ALTER TABLE public.marketplace_registrations ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "RAV team can read marketplace registrations" ON public.marketplace_registrations;
+CREATE POLICY "RAV team can read marketplace registrations"
+  ON public.marketplace_registrations FOR SELECT
+  TO authenticated
+  USING (public.is_rav_team(auth.uid()));
+
+DROP POLICY IF EXISTS "RAV admins can update marketplace registrations" ON public.marketplace_registrations;
+CREATE POLICY "RAV admins can update marketplace registrations"
+  ON public.marketplace_registrations FOR UPDATE
+  TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.user_roles ur
+      WHERE ur.user_id = auth.uid()
+        AND ur.role IN ('rav_admin', 'rav_owner')
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM public.user_roles ur
+      WHERE ur.user_id = auth.uid()
+        AND ur.role IN ('rav_admin', 'rav_owner')
+    )
+  );
+
+COMMENT ON POLICY "RAV admins can update marketplace registrations" ON public.marketplace_registrations IS
+  'Only rav_admin / rav_owner can update registration status. Read access is wider (any RAV team member). INSERT/DELETE are not exposed via RLS — the table is fixed-membership (51 rows seeded by Migration 075); structural changes require service-role access.';
+
+-- ── Index ──────────────────────────────────────────────────────────────────
+CREATE INDEX IF NOT EXISTS idx_marketplace_registrations_status
+  ON public.marketplace_registrations (registration_status);
+
+CREATE INDEX IF NOT EXISTS idx_marketplace_registrations_next_return_due
+  ON public.marketplace_registrations (next_return_due)
+  WHERE next_return_due IS NOT NULL;
+
+COMMIT;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -40,11 +40,15 @@ export default defineConfig({
         // Test fixtures + mocks — never measure
         "supabase/functions/_shared/__tests__/**",
       ],
+      // Thresholds raised to 70% on 2026-05-11 (actual coverage: ~75% stmts, ~77% branches, ~83% fns).
+      // Gap between actual and threshold is intentional — buffer for new untested code during active dev.
+      // REVIEW TRIGGER: raise to 80% when E2E automation covers 15+ of the 30 manual scenarios,
+      // or before any acquisition due diligence process begins — whichever comes first.
       thresholds: {
-        statements: 25,
-        branches: 25,
-        functions: 30,
-        lines: 25,
+        statements: 70,
+        branches: 70,
+        functions: 70,
+        lines: 70,
       },
     },
     reporters: ["default", "junit"],


### PR DESCRIPTION
## Summary

Three independent dev-branch commits bundled into one PR to main.

### cf7e873 — Phase 1b financials polish (your prior work)
Unit econ, sensitivity, cohort ramp, hiring, voice overage in the financial model.

### a03099f — testing governance
Fix Percy status, raise coverage thresholds to 70%, add E2E governance.

### ff7d6cc — Compliance #488 marketplace-facilitator registration tracker
Closes #488. Compliance Brief § 3.4 requires "a state registration status field in [the] admin dashboard." Counsel question C7 fills the status values per state; this commit ships the surface that holds them.

**Migration 075** creates `marketplace_registrations` (state PK + status enum + registration_id + 4 date fields + notes + updated_by/at); seeds all 50 states + DC with `not_required` default; touch-updated_at trigger; RLS (read = any RAV team via `is_rav_team()`; update = rav_admin/rav_owner only); indexes on status + next_return_due (partial).

**AdminMarketplaceRegistrations** — Card with 4-cell status-count summary + 51-row table; per-row Edit dialog with status Select, four date inputs, registration_id, notes; **AlertDialog confirmation** per Admin Safeguards Convention before any update; toast on success.

**AdminDashboard** registers a new "Tax registrations" tab next to Tax & 1099, gated on `isRavAdmin()`.

**Migration 075 applied to DEV** in this session via `supabase db push`. PROD push will follow after merge.

## Test plan

- [x] `npm run test` — **1652 / 1652** pass (+15 net: 13 migration-audit + 2 placement-audit)
- [x] `npm run build` — clean
- [x] ESLint clean
- [x] Zero new TypeScript errors
- [x] Migration 075 applied to DEV; `marketplace_registrations` has 51 seeded rows

## Audit scoreboard impact

Row 7 in the attorney dossier ("Tax collection & remittance" → marketplace-facilitator registration tracker) flips Gap → Implemented for the engineering deliverable. State-by-state status values remain counsel-pending (C7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)