### PR TITLE
fix(financials): seed users at launch month (REVENUE MODEL was returning 0 for any gLaunchMo > 1)

### DIFF
--- a/scripts/financial-model/tabs/revenue.ts
+++ b/scripts/financial-model/tabs/revenue.ts
@@ -60,31 +60,48 @@ export function buildRevenueTab(wb: Workbook): void {
   // 1. USER GROWTH
   secHead(ws, row++, 2, 27, '  1.  USER GROWTH');
 
+  // Active Owners — three cases per month:
+  //   m < gLaunchMo: 0 (pre-launch)
+  //   m = gLaunchMo: gStartOwn (seed value at launch)
+  //   m > gLaunchMo: prev_month × (1 + growth × scenario_multiplier)
+  // Previously the formula seeded gStartOwn at Month 1 regardless of gLaunchMo,
+  // so any gLaunchMo > 1 left the whole projection at 0.
   lbl(ws, row, 3, 'Active Owners');
   for (let m = 1; m <= MONTHS; m++) {
     const col = m + 3;
     const cell = ws.getCell(row, col);
     if (m === 1) {
       styleCell(cell, C.TEAL_LIGHT, C.NAVY, 10, false, 'right');
-      cell.value = { formula: 'IF(1>=gLaunchMo,gStartOwn,0)' } as never;
+      cell.value = { formula: 'IF(1=gLaunchMo,gStartOwn,0)' } as never;
     } else {
       styleCell(cell, m % 2 === 0 ? C.WHITE : C.CREAM, C.NAVY, 10, false, 'right');
-      cell.value = { formula: `IF(${m}>=gLaunchMo,${colLtr(col - 1)}${row}*(1+gOwnGrowth*${sGrow}),0)` } as never;
+      cell.value = {
+        formula:
+          `IF(${m}<gLaunchMo,0,` +
+          `IF(${m}=gLaunchMo,gStartOwn,` +
+          `${colLtr(col - 1)}${row}*(1+gOwnGrowth*${sGrow})))`,
+      } as never;
     }
     cell.numFmt = '#,##0';
   }
   const ownRow = row++;
 
+  // Active Travelers — same three-case pattern
   lbl(ws, row, 3, 'Active Travelers');
   for (let m = 1; m <= MONTHS; m++) {
     const col = m + 3;
     const cell = ws.getCell(row, col);
     if (m === 1) {
       styleCell(cell, C.TEAL_LIGHT, C.NAVY, 10, false, 'right');
-      cell.value = { formula: 'IF(1>=gLaunchMo,gStartTrav,0)' } as never;
+      cell.value = { formula: 'IF(1=gLaunchMo,gStartTrav,0)' } as never;
     } else {
       styleCell(cell, m % 2 === 0 ? C.WHITE : C.CREAM, C.NAVY, 10, false, 'right');
-      cell.value = { formula: `IF(${m}>=gLaunchMo,${colLtr(col - 1)}${row}*(1+gTravGrowth*${sGrow}),0)` } as never;
+      cell.value = {
+        formula:
+          `IF(${m}<gLaunchMo,0,` +
+          `IF(${m}=gLaunchMo,gStartTrav,` +
+          `${colLtr(col - 1)}${row}*(1+gTravGrowth*${sGrow})))`,
+      } as never;
     }
     cell.numFmt = '#,##0';
   }


### PR DESCRIPTION
## Problem

User reported via screenshots: INPUTS tab filled in correctly (Launch Month = 5, Starting Active Owners = 3, Starting Active Travelers = 10, growth rates set) — but REVENUE MODEL showed $0 across every cell, every month, every revenue line.

## Root cause

Carry-over bug from the original `.gs` implementation. The seed value (`gStartOwn`, `gStartTrav`) was only assigned at Month 1:

```
Month 1:  IF(1 >= gLaunchMo, gStartOwn, 0)
Month N:  IF(N >= gLaunchMo, prev × (1 + growth × scenario), 0)
```

With `gLaunchMo = 5`:
- Months 1–4: returns 0 (correct — pre-launch)
- Month 5: `IF(5 >= 5, Month_4 × growth, 0) = 0 × 1.2 = 0` ❌ seed never injected
- Months 6+: 0 forever

The model only worked correctly when `gLaunchMo = 1`. Any other launch month silently produced an all-zero projection.

## Fix

Rewrite Active Owners + Active Travelers row formulas as a three-case IF chain:

```
IF(m < gLaunchMo, 0,                              -- pre-launch: 0
  IF(m = gLaunchMo, gStartOwn,                    -- launch month: seed value
    prev_month × (1 + growth × scenario)))        -- post-launch: compound
```

This produces the expected trajectory:
- gLaunchMo = 5, gStartOwn = 3: Mo 4 = 0, **Mo 5 = 3**, Mo 6 = 3.6, Mo 7 = 4.32, …
- gLaunchMo = 1, gStartOwn = 3: Mo 1 = 3, Mo 2 = 3.6, …

## Test plan

- [x] Formula renders correctly across launch transition (verified with openpyxl dump)
- [x] No regression at gLaunchMo = 1 (the only previously-working case)
- [ ] User to verify Active Owners shows 3 at Month 5 after merging + regenerating

🤖 Generated with [Claude Code](https://claude.com/claude-code)