### PR TITLE
fix(financials): recurring costs missing from monthly + break-even MATCH + frozen pane

### DIFF
--- a/scripts/financial-model/tabs/breakeven.ts
+++ b/scripts/financial-model/tabs/breakeven.ts
@@ -8,7 +8,9 @@ export function buildBreakevenTab(wb: Workbook): void {
   const ws = wb.addWorksheet('BREAK-EVEN', { properties: { tabColor: { argb: C.AMBER } } });
 
   setColumnPixelWidths(ws, [20, 30, 200, 150, 150, 150, 150, 160]);
-  ws.views = [{ state: 'frozen', ySplit: 6 }];
+  // Freeze rows 1-8 — KPI section AND the month-by-month table headers (row 8)
+  // remain visible when the user scrolls through the 24 monthly rows below.
+  ws.views = [{ state: 'frozen', ySplit: 8 }];
 
   ws.getRow(1).height = 52;
   banner(ws, 1, 2, 7, 'RAV BREAK-EVEN & RUNWAY ANALYSIS', C.NAVY, C.AMBER, 16, true);
@@ -39,8 +41,16 @@ export function buildBreakevenTab(wb: Workbook): void {
 
   const breakeven = ws.getCell(5, 5);
   styleCell(breakeven, C.TEAL_LIGHT, C.DEEP_TEAL, 14, true, 'center');
-  // Find the first month (col D=Mo1..AA=Mo24 on this sheet, rows 9..32) where Cumulative Cash > 0
-  breakeven.value = { formula: `IFERROR(MATCH(TRUE,G9:G${8 + MONTHS}>0,0),"Not in 24mo")` } as never;
+  // Find the first month (rows 9..32 on this sheet) where Cumulative Cash > 0.
+  // Old formula MATCH(TRUE, G9:G32>0, 0) required dynamic-array Excel to work
+  // correctly — older versions evaluated only the first cell. New approach:
+  //   1. Check whether ANY month went positive (COUNTIF).
+  //   2. If yes, use the INDEX trick to coerce the comparison to a 0/1 array
+  //      without requiring CSE entry, then MATCH(1, ...) for the first hit.
+  //   3. If no month went positive, fallback to "Not in 24mo".
+  breakeven.value = {
+    formula: `IF(COUNTIF(G9:G${8 + MONTHS},">0")=0,"Not in 24mo",MATCH(1,INDEX((G9:G${8 + MONTHS}>0)+0,0),0))`,
+  } as never;
   breakeven.numFmt = '0';
 
   const sixMo = ws.getCell(5, 6);

--- a/scripts/financial-model/tabs/revenue.ts
+++ b/scripts/financial-model/tabs/revenue.ts
@@ -278,17 +278,22 @@ export function buildRevenueTab(wb: Workbook): void {
   const totCostLbl = ws.getCell(row, 3);
   styleCell(totCostLbl, C.RED, C.WHITE, 12, true, 'left');
   totCostLbl.value = 'TOTAL MONTHLY COSTS (Expenses)';
+  // The EXPENSES J column already holds each row's monthly-equivalent amount
+  // (handles Monthly/Annual/Quarterly via row-level IF). So the month-N cost
+  // is: (sum of J for active recurring rows) + (sum of F for one-time rows
+  // hitting this exact month). Splitting into two SUMPRODUCTs (no inner IF)
+  // avoids the dynamic-array dependency that broke older Excel versions —
+  // recurring costs were silently dropping to 0 for months past any one-time
+  // spike, making break-even artificially optimistic.
+  // Bounded range (J7:J81) matches the EXPENSES summary fix.
   for (let m = 1; m <= MONTHS; m++) {
     const col = m + 3;
     const cell = ws.getCell(row, col);
     styleCell(cell, C.RED, C.WHITE, 12, true, 'right');
     cell.value = {
       formula:
-        `SUMPRODUCT((EXPENSES!E7:E500="Recurring")*(EXPENSES!H7:H500<=${m})*(EXPENSES!I7:I500>=${m})*` +
-        `IF(EXPENSES!G7:G500="Monthly",EXPENSES!F7:F500,` +
-        `IF(EXPENSES!G7:G500="Annual",EXPENSES!F7:F500/12,` +
-        `IF(EXPENSES!G7:G500="Quarterly",EXPENSES!F7:F500/3,0))))+` +
-        `SUMPRODUCT((EXPENSES!E7:E500="One-Time")*(EXPENSES!H7:H500=${m})*EXPENSES!F7:F500)`,
+        `SUMPRODUCT((EXPENSES!E7:E81="Recurring")*(EXPENSES!H7:H81<=${m})*(EXPENSES!I7:I81>=${m})*EXPENSES!J7:J81)` +
+        `+SUMPRODUCT((EXPENSES!E7:E81="One-Time")*(EXPENSES!H7:H81=${m})*EXPENSES!F7:F81)`,
     } as never;
     cell.numFmt = '$#,##0';
   }


### PR DESCRIPTION
## Problem

User screenshots of BREAK-EVEN tab revealed three issues, listed in order of severity:

### 1. Recurring costs missing from Monthly Costs column (consequential)

The Monthly Costs column in the month-by-month table showed only one-time spikes (Atlas/attorneys at Mo 1, trademarks at Mo 3, conference at Mo 6) and **$0 from Month 7 onwards**. Recurring SaaS costs (Claude Max, Vercel, Supabase, etc., ~$1,280/mo) were silently dropping out.

This caused the **model to display an artificially early break-even** at Month 17, when with proper recurring-cost accounting the trajectory would shift materially (potentially "Not in 24mo" legitimately).

### 2. Break-Even Month KPI showed "Not in 24mo" when break-even WAS in the data

Cumulative Cash clearly transitioned negative → positive at Month 17, but the KPI cell stuck on the fallback string.

### 3. Last column header ("Runway Signal") invisible while scrolling

Freeze pane at row 6 left rows 7-8 (section header + table column headers) below the freeze line. When scrolling through 24 months, table headers scrolled away.

## Root causes

| Bug | Cause |
|---|---|
| Missing recurring costs | `SUMPRODUCT(... × IF(Freq="Monthly", F, IF(Freq="Annual", F/12, ...)))` had an inner `IF` returning per-row arrays. Without dynamic-array Excel, the `IF` collapsed to a scalar — the row-by-row multiplication zeroed out for any month past a one-time spike. |
| Break-even false negative | `MATCH(TRUE, G9:G32>0, 0)` required dynamic-array Excel. Older versions evaluated only the first cell of the range. |
| Headers scrolling away | `ySplit=6` froze rows 1-6 but the table header at row 8 sat below the freeze. |

## Fixes

**1. Cost formula** — split into two SUMPRODUCTs without inner IF, using EXPENSES `J` column (per-row monthly-equivalent, already amortized at row level):

```
SUMPRODUCT((Type="Recurring")×(Start≤m)×(End≥m)×EXPENSES!J)
+ SUMPRODUCT((Type="One-Time")×(Start=m)×EXPENSES!F)
```

**2. Break-even formula** — use COUNTIF for the empty-case guard + INDEX-trick array coercion:

```
=IF(COUNTIF(G9:G32,">0")=0, "Not in 24mo", MATCH(1, INDEX((G9:G32>0)+0, 0), 0))
```

**3. Freeze pane** — `ySplit: 6` → `ySplit: 8` so KPI section + table headers both stay visible.

## Test plan

- [x] Cost formula split verified — Month 7 formula now uses `J` column (recurring) + `F` column (one-time), no inner IF
- [x] Break-even formula uses COUNTIF guard + INDEX trick
- [x] BREAK-EVEN freeze pane updated to row 8
- [ ] User to verify after merge + regenerate:
  - [ ] Monthly Costs column shows ~$1,280+ from Month 7 onwards
  - [ ] Break-Even Month KPI shows a real month number (or correctly "Not in 24mo" if cumulative never goes positive with full costs)
  - [ ] Scrolling through monthly rows keeps the table column headers visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)