### PR TITLE
feat(financials): hover-note layer — 133 in-cell tooltips across all calculated tabs

### DIFF
--- a/scripts/financial-model/style.ts
+++ b/scripts/financial-model/style.ts
@@ -151,6 +151,21 @@ export function drop(cell: Cell, opts: string[]): void {
 }
 
 /**
+ * Attach a hover-note (legacy Excel comment) to a cell. Shows as a small
+ * popup when the user hovers — useful to explain WHY a calculated value
+ * is what it is, what an abbreviation means, or where the number comes from.
+ *
+ * Keep notes short (1-3 sentences). Long notes get truncated and lose value.
+ */
+export function addNote(cell: Cell, text: string): Cell {
+  cell.note = {
+    texts: [{ text }],
+    margins: { insetmode: 'auto' },
+  } as never;
+  return cell;
+}
+
+/**
  * Convenience: write a cell with a formula (handles leading '=').
  */
 export function formula(cell: Cell, f: string, fmt?: string): Cell {

--- a/scripts/financial-model/tabs/breakeven.ts
+++ b/scripts/financial-model/tabs/breakeven.ts
@@ -1,6 +1,6 @@
 import type { Workbook } from 'exceljs';
 import { C } from '../colors.ts';
-import { banner, styleCell, secHead, setColumnPixelWidths } from '../style.ts';
+import { banner, styleCell, secHead, addNote, setColumnPixelWidths } from '../style.ts';
 
 const MONTHS = 24;
 
@@ -33,11 +33,13 @@ export function buildBreakevenTab(wb: Workbook): void {
   styleCell(oneTime, C.CORAL_LIGHT, C.CORAL, 14, true, 'center');
   oneTime.value = { formula: 'SUMIF(EXPENSES!E7:E500,"One-Time",EXPENSES!F7:F500)' } as never;
   oneTime.numFmt = '$#,##0';
+  addNote(oneTime, 'Sum of all one-time costs on EXPENSES tab: incorporation ($500), attorneys, IP assignments, trademarks (3), ToS/Privacy review, conference (registration + travel + booth), launch ads. Hits cash in the months they\'re scheduled.');
 
   const burn = ws.getCell(5, 4);
   styleCell(burn, C.RED_LIGHT, C.RED, 14, true, 'center');
   burn.value = { formula: 'SUMIF(EXPENSES!E7:E500,"Recurring",EXPENSES!J7:J500)' } as never;
   burn.numFmt = '$#,##0';
+  addNote(burn, 'Steady-state monthly cost — sum of every Recurring row\'s Monthly $ (column J) on EXPENSES tab. This is what you spend every month "to keep the lights on" once everything is running: SaaS subscriptions, insurance amortized, accounting, marketing ads. Multiply by 12 for annual run-rate.');
 
   const breakeven = ws.getCell(5, 5);
   styleCell(breakeven, C.TEAL_LIGHT, C.DEEP_TEAL, 14, true, 'center');
@@ -52,27 +54,38 @@ export function buildBreakevenTab(wb: Workbook): void {
     formula: `IF(COUNTIF(G9:G${8 + MONTHS},">0")=0,"Not in 24mo",MATCH(1,INDEX((G9:G${8 + MONTHS}>0)+0,0),0))`,
   } as never;
   breakeven.numFmt = '0';
+  addNote(breakeven, 'First month in the 24-month projection when Cumulative Cash Position (column G below) turns positive. If never positive within 24 months, displays "Not in 24mo" — which means you need more starting cash, more funding inflow, faster growth, or longer runway than this model captures.');
 
   const sixMo = ws.getCell(5, 6);
   styleCell(sixMo, C.AMBER_LIGHT, C.AMBER, 14, true, 'center');
   sixMo.value = { formula: 'C5+D5*6' } as never;
   sixMo.numFmt = '$#,##0';
+  addNote(sixMo, 'One-Time Costs + (Monthly Burn × 6). Minimum cash needed to survive 6 months from Month 1, assuming zero revenue. Use this as the floor for a "MVP launch" budget.');
 
   const twelveMo = ws.getCell(5, 7);
   styleCell(twelveMo, C.AMBER_LIGHT, C.AMBER, 14, true, 'center');
   twelveMo.value = { formula: 'C5+D5*12' } as never;
   twelveMo.numFmt = '$#,##0';
+  addNote(twelveMo, 'One-Time Costs + (Monthly Burn × 12). The number FUNDING ASK uses for "12-Month Runway". This is what a typical seed-stage runway looks like — enough to launch, iterate, get traction, and start fundraising again.');
 
   ws.getRow(6).height = 8;
 
   let row = 7;
   secHead(ws, row++, 2, 7, '  Month-by-Month: Revenue vs Costs vs Cumulative Cash Position');
 
-  const thdrs = ['Month', 'Monthly Revenue', 'Monthly Costs', 'Net (Rev − Cost)', 'Cumulative Cash', 'Runway Signal'];
-  thdrs.forEach((h, i) => {
+  const thdrs: [string, string][] = [
+    ['Month', 'Month number from gLaunchMo on INPUTS Section C. Pre-launch months still appear but show $0 revenue.'],
+    ['Monthly Revenue', 'Pulled from REVENUE MODEL row "TOTAL MONTHLY REVENUE". Net Commission + Subscription Total + Voice Overage. Read-only — to change, edit INPUTS.'],
+    ['Monthly Costs', 'Pulled from REVENUE MODEL: "TOTAL MONTHLY COSTS (Expenses)" + "Hiring Costs". All recurring SaaS + insurance + any one-time spend hitting this month + active hires.'],
+    ['Net (Rev − Cost)', 'Single-month profit/loss. Negative = burning cash this month; positive = made money this month. Doesn\'t mean you\'re cash-positive overall — see Cumulative Cash column for that.'],
+    ['Cumulative Cash', 'Running total starting from Starting Cash on Hand (INPUTS F) + any Funding Inflow at gFundMonth. Green when positive, red when negative.'],
+    ['Runway Signal', '"Profitable" when Cumulative Cash > 0; "Burning Cash" when < 0. First "Profitable" row = your break-even point.'],
+  ];
+  thdrs.forEach(([h, note], i) => {
     const cell = ws.getCell(row, i + 3);
     styleCell(cell, C.NAVY_MID, C.WHITE, 10, true, 'center');
     cell.value = h;
+    addNote(cell, note);
   });
   ws.getRow(row).height = 26;
   row++;

--- a/scripts/financial-model/tabs/expenses.ts
+++ b/scripts/financial-model/tabs/expenses.ts
@@ -1,6 +1,6 @@
 import type { Workbook, BorderStyle } from 'exceljs';
 import { C } from '../colors.ts';
-import { banner, styleCell, secHead, drop, setColumnPixelWidths } from '../style.ts';
+import { banner, styleCell, secHead, drop, addNote, setColumnPixelWidths } from '../style.ts';
 import { EXPENSES, EXPENSE_CATEGORIES, type ExpenseCategory } from '../data.ts';
 
 const CAT_BG: Record<string, string> = {
@@ -66,6 +66,8 @@ export function buildExpensesTab(wb: Workbook): void {
       bottom: { style: 'thin' as BorderStyle, color: { argb: C.AMBER } },
       right: { style: 'thin' as BorderStyle, color: { argb: C.AMBER } },
     };
+    // Hover note surfaces the row's description as a tooltip on the Amount cell
+    addNote(amtCell, `${e.item}\n\n${e.notes}`);
 
     const freqCell = ws.getCell(row, 7);
     styleCell(freqCell, alt, C.NAVY, 10, false, 'left');
@@ -158,6 +160,7 @@ export function buildExpensesTab(wb: Workbook): void {
     styleCell(sumCell, C.TEAL_LIGHT, C.NAVY, 10, true, 'right');
     sumCell.value = { formula: `SUMIF(C7:C${lastDataRow},"${cat}",J7:J${lastDataRow})` } as never;
     sumCell.numFmt = '$#,##0.00';
+    addNote(sumCell, `Steady-state monthly burn for ${cat}. Sum of the "Monthly $" column (J) for every row tagged ${cat}, including amortized annual/quarterly costs.`);
     row++;
   });
 
@@ -167,6 +170,7 @@ export function buildExpensesTab(wb: Workbook): void {
   styleCell(burnCell, C.NAVY, C.CORAL, 13, true, 'right');
   burnCell.value = { formula: `SUM(J7:J${lastDataRow})` } as never;
   burnCell.numFmt = '$#,##0.00';
+  addNote(burnCell, 'Total recurring monthly burn across all categories. Sum of column J. This is the "$X/month to keep the lights on" number — multiply by 12 for annual run-rate.');
   row++;
 
   ws.getRow(row).height = 26;
@@ -175,4 +179,5 @@ export function buildExpensesTab(wb: Workbook): void {
   styleCell(oneTimeCell, C.NAVY_MID, C.AMBER, 11, true, 'right');
   oneTimeCell.value = { formula: `SUMIF(E7:E${lastDataRow},"One-Time",F7:F${lastDataRow})` } as never;
   oneTimeCell.numFmt = '$#,##0.00';
+  addNote(oneTimeCell, 'Sum of all one-time costs — incorporation, attorney fees, trademarks, conference, launch ads. These hit your cash flow once in the month they\'re scheduled (column H).');
 }

--- a/scripts/financial-model/tabs/funding.ts
+++ b/scripts/financial-model/tabs/funding.ts
@@ -1,6 +1,6 @@
 import type { Workbook } from 'exceljs';
 import { C } from '../colors.ts';
-import { banner, styleCell, secHead, note, setColumnPixelWidths } from '../style.ts';
+import { banner, styleCell, secHead, note, addNote, setColumnPixelWidths } from '../style.ts';
 import { PLATFORM_FACTS, MILESTONES } from '../data.ts';
 
 export function buildFundingAskTab(wb: Workbook): void {
@@ -27,6 +27,12 @@ export function buildFundingAskTab(wb: Workbook): void {
     ['Contingency Buffer (15%)',          '=D6*0.15',          '15% buffer on 12-month runway for unknowns'],
     ['RECOMMENDED SEED ASK',             '=D6+D7',            'Total: 12-month runway + contingency buffer'],
   ];
+  const askNotes = [
+    'Pulled from BREAK-EVEN tab cell F5 (= One-Time Costs + Monthly Burn × 6). The minimum to survive 6 months from incorporation to platform launch + first owners with zero revenue assumed.',
+    'Pulled from BREAK-EVEN tab cell G5 (= One-Time Costs + Monthly Burn × 12). Industry-standard seed-stage runway: enough to launch, iterate, hit metrics, and start fundraising again before running out.',
+    '15% of 12-Month Runway. Accounts for unknowns: legal review surprises, conference travel expansion, hire ramp-up, marketing channel testing. Below 10% is too tight; above 25% suggests the runway estimate is too speculative.',
+    'D6 (12-month runway) + D7 (contingency) = the recommended seed ask. This is the number to use in investor conversations as "how much we\'re raising". Use of Funds breakdown below shows where it goes.',
+  ];
   asks.forEach((a, i) => {
     const isTotal = i === 3;
     ws.getRow(r).height = isTotal ? 40 : 28;
@@ -38,6 +44,7 @@ export function buildFundingAskTab(wb: Workbook): void {
     styleCell(valCell, isTotal ? C.CORAL : C.TEAL_LIGHT, isTotal ? C.WHITE : C.NAVY, isTotal ? 20 : 13, true, 'right');
     valCell.value = { formula: a[1].replace(/^=/, '') } as never;
     valCell.numFmt = '$#,##0';
+    addNote(valCell, askNotes[i]);
 
     ws.mergeCells(r, 5, r, 6);
     const noteCell = ws.getCell(r, 5);
@@ -83,11 +90,13 @@ export function buildFundingAskTab(wb: Workbook): void {
     styleCell(amtCell, C.TEAL_LIGHT, C.NAVY, 10, false, 'right');
     amtCell.value = { formula: f[1] } as never;
     amtCell.numFmt = '$#,##0';
+    addNote(amtCell, `Sum of all EXPENSES tab rows tagged "${f[0]}": one-time costs at full amount + recurring monthly costs × 12 months. To change this number, edit the matching rows on the EXPENSES tab — this updates automatically.`);
 
     const pctCell = ws.getCell(r, 5);
     styleCell(pctCell, i % 2 === 0 ? C.WHITE : C.CREAM, C.SLATE, 10, false, 'center');
     pctCell.value = { formula: `D${r}/$D$8` } as never;
     pctCell.numFmt = '0.0%';
+    addNote(pctCell, `What share of the recommended seed ask this category consumes (= category total ÷ $D$8). Useful for investor diligence: "where does your money go?"`);
 
     const notesCell = ws.getCell(r, 6);
     styleCell(notesCell, i % 2 === 0 ? C.WHITE : C.CREAM, C.SLATE, 9, false, 'left', true);

--- a/scripts/financial-model/tabs/revenue.ts
+++ b/scripts/financial-model/tabs/revenue.ts
@@ -1,6 +1,6 @@
 import type { Workbook, BorderStyle } from 'exceljs';
 import { C } from '../colors.ts';
-import { banner, styleCell, secHead, lbl, drop, colLtr, setColumnPixelWidths } from '../style.ts';
+import { banner, styleCell, secHead, lbl, drop, addNote, colLtr, setColumnPixelWidths } from '../style.ts';
 
 const MONTHS = 24;
 
@@ -66,7 +66,8 @@ export function buildRevenueTab(wb: Workbook): void {
   //   m > gLaunchMo: prev_month × (1 + growth × scenario_multiplier)
   // Previously the formula seeded gStartOwn at Month 1 regardless of gLaunchMo,
   // so any gLaunchMo > 1 left the whole projection at 0.
-  lbl(ws, row, 3, 'Active Owners');
+  addNote(lbl(ws, row, 3, 'Active Owners'),
+    'Pre-launch: 0. Launch month: gStartOwn (seed). After launch: previous month × (1 + gOwnGrowth × scenario multiplier). Edit gStartOwn / gOwnGrowth / gLaunchMo on INPUTS Section C to change.');
   for (let m = 1; m <= MONTHS; m++) {
     const col = m + 3;
     const cell = ws.getCell(row, col);
@@ -87,7 +88,8 @@ export function buildRevenueTab(wb: Workbook): void {
   const ownRow = row++;
 
   // Active Travelers — same three-case pattern
-  lbl(ws, row, 3, 'Active Travelers');
+  addNote(lbl(ws, row, 3, 'Active Travelers'),
+    'Same logic as Active Owners but with gStartTrav / gTravGrowth. Travelers typically grow faster than owners (lower friction to sign up).');
   for (let m = 1; m <= MONTHS; m++) {
     const col = m + 3;
     const cell = ws.getCell(row, col);
@@ -114,7 +116,8 @@ export function buildRevenueTab(wb: Workbook): void {
   // Cohort ramp factor: bookings/owner ramps from 0 to gBookPerOwn over uRampMonths
   // months post-launch. MIN(1, (months_since_launch + 1) / uRampMonths) caps at 1.0.
   // Set uRampMonths = 1 in INPUTS to disable the ramp (immediate full velocity).
-  lbl(ws, row, 3, 'Monthly Bookings (confirmed)');
+  addNote(lbl(ws, row, 3, 'Monthly Bookings (confirmed)'),
+    'Active Owners × gBookPerOwn × cohort-ramp × scenario multiplier. Cohort ramp: new owners take uRampMonths months to reach full booking velocity (33% → 67% → 100% with uRampMonths=3). Set uRampMonths=1 on INPUTS Section H to disable.');
   for (let m = 1; m <= MONTHS; m++) {
     const col = m + 3;
     const cell = ws.getCell(row, col);
@@ -139,7 +142,8 @@ export function buildRevenueTab(wb: Workbook): void {
   }
   row++;
 
-  lbl(ws, row, 3, '    Gross Booking Value (GBV)');
+  addNote(lbl(ws, row, 3, '    Gross Booking Value (GBV)'),
+    'Bookings × pAvgBooking. The total dollar value of travel sold through the platform in this month — owner payouts + RAV commission + traveler-paid taxes (when activated). Industry benchmark — track as the headline "GMV" metric.');
   for (let m = 1; m <= MONTHS; m++) {
     const col = m + 3;
     const cell = ws.getCell(row, col);
@@ -167,6 +171,7 @@ export function buildRevenueTab(wb: Workbook): void {
   const grossLbl = ws.getCell(row, 3);
   styleCell(grossLbl, C.DEEP_TEAL, C.WHITE, 11, true, 'left');
   grossLbl.value = 'Gross Commission Revenue';
+  addNote(grossLbl, 'GBV × blended commission rate. Blended = weighted average of Free/Pro/Business owner tier rates, weighted by gMix0/1/2 booking mix from INPUTS Section C.');
   for (let m = 1; m <= MONTHS; m++) {
     const col = m + 3;
     const cell = ws.getCell(row, col);
@@ -177,7 +182,8 @@ export function buildRevenueTab(wb: Workbook): void {
   const grossCommRow = row++;
 
   // Stripe Fees row (subtractive)
-  lbl(ws, row, 3, '    Stripe Processing Fees (absorbed by RAV)');
+  addNote(lbl(ws, row, 3, '    Stripe Processing Fees (absorbed by RAV)'),
+    'Stripe takes 2.9% + $0.30 per booking on the WHOLE traveler payment (GBV + commission), not just RAV\'s commission slice. RAV absorbs this from its commission margin — so net commission is materially smaller than gross. On a $2,000 booking at 15% commission: gross $300, Stripe ~$67, net ~$233.');
   for (let m = 1; m <= MONTHS; m++) {
     const col = m + 3;
     const cL = colLtr(col);
@@ -192,6 +198,7 @@ export function buildRevenueTab(wb: Workbook): void {
   const netLbl = ws.getCell(row, 3);
   styleCell(netLbl, C.DEEP_TEAL, C.WHITE, 11, true, 'left');
   netLbl.value = 'Net Commission Revenue';
+  addNote(netLbl, 'Gross Commission + Stripe Fees (negative). This is the line that actually flows to Total Monthly Revenue — what RAV keeps after the payment processor takes its cut.');
   for (let m = 1; m <= MONTHS; m++) {
     const col = m + 3;
     const cL = colLtr(col);
@@ -243,7 +250,8 @@ export function buildRevenueTab(wb: Workbook): void {
 
   // 4b. USAGE REVENUE (Voice Overage — new in v3.2 / Phase 1b)
   secHead(ws, row++, 2, 27, '  4b. USAGE REVENUE  (voice / AI overage — non-Premium travelers only)');
-  lbl(ws, row, 3, '    Voice Overage Revenue');
+  addNote(lbl(ws, row, 3, '    Voice Overage Revenue'),
+    'Active Travelers × (1 − gTrav2) × uVoiceOverage. Premium tier travelers have unlimited voice, so they\'re excluded. Edit uVoiceOverage on INPUTS Section H — conservative default $0.50/non-Premium traveler/month.');
   for (let m = 1; m <= MONTHS; m++) {
     const col = m + 3;
     const cL = colLtr(col);
@@ -263,6 +271,7 @@ export function buildRevenueTab(wb: Workbook): void {
   const totRevLbl = ws.getCell(row, 3);
   styleCell(totRevLbl, C.EMERALD, C.WHITE, 12, true, 'left');
   totRevLbl.value = 'TOTAL MONTHLY REVENUE';
+  addNote(totRevLbl, 'Net Commission Revenue + Total Subscription Revenue + Voice Overage Revenue. All three RAV revenue streams summed.');
   for (let m = 1; m <= MONTHS; m++) {
     const col = m + 3;
     const cL = colLtr(col);
@@ -278,6 +287,7 @@ export function buildRevenueTab(wb: Workbook): void {
   const totCostLbl = ws.getCell(row, 3);
   styleCell(totCostLbl, C.RED, C.WHITE, 12, true, 'left');
   totCostLbl.value = 'TOTAL MONTHLY COSTS (Expenses)';
+  addNote(totCostLbl, 'Recurring expenses active this month (from EXPENSES column J, amortized monthly) + one-time expenses scheduled this month (column F where Start Month = this month). Does NOT include hiring costs — see separate Hiring Costs row below.');
   // The EXPENSES J column already holds each row's monthly-equivalent amount
   // (handles Monthly/Annual/Quarterly via row-level IF). So the month-N cost
   // is: (sum of J for active recurring rows) + (sum of F for one-time rows
@@ -306,6 +316,7 @@ export function buildRevenueTab(wb: Workbook): void {
   const hireLbl = ws.getCell(row, 3);
   styleCell(hireLbl, C.NAVY_MID, C.WHITE, 10, true, 'left');
   hireLbl.value = '    Hiring Costs (Eng + Support + BD)';
+  addNote(hireLbl, 'Sum of burdened cost (salary + payroll tax + benefits + tools) for each hire active in this month. Hire month = 0 in INPUTS Section G means "no hire planned" — that role contributes $0.');
   for (let m = 1; m <= MONTHS; m++) {
     const col = m + 3;
     const cell = ws.getCell(row, col);
@@ -324,6 +335,7 @@ export function buildRevenueTab(wb: Workbook): void {
   const netLblCell = ws.getCell(row, 3);
   styleCell(netLblCell, C.NAVY, C.AMBER, 12, true, 'left');
   netLblCell.value = 'NET MONTHLY PROFIT / (LOSS)';
+  addNote(netLblCell, 'Total Monthly Revenue − Total Monthly Costs (Expenses) − Hiring Costs. Negative = burning cash; positive = monthly profit. Month-over-month tracking shows when operations turn profitable on a monthly basis (not yet cumulative).');
   for (let m = 1; m <= MONTHS; m++) {
     const col = m + 3;
     const cL = colLtr(col);
@@ -339,6 +351,7 @@ export function buildRevenueTab(wb: Workbook): void {
   const cumLbl = ws.getCell(row, 3);
   styleCell(cumLbl, C.WARM_GRAY, C.NAVY, 10, true, 'left');
   cumLbl.value = '    Cumulative Cash Position';
+  addNote(cumLbl, 'Running total of cash from Month 1 onwards. Month 1 seeded with gStartCash (INPUTS Section F). Funding inflow added in month matching gFundMonth. Then each month\'s Net P&L is added. Green = positive (you have cash); red = negative (you need funding). The month it first turns positive = break-even point.');
   const cumFirst = ws.getCell(row, 4);
   styleCell(cumFirst, C.WHITE, C.NAVY, 10, false, 'right');
   cumFirst.value = { formula: `gStartCash+IF(gFundMonth=1,gFundAmt,0)+D${netRow}` } as never;

--- a/scripts/financial-model/tabs/sensitivity.ts
+++ b/scripts/financial-model/tabs/sensitivity.ts
@@ -1,6 +1,6 @@
 import type { Workbook } from 'exceljs';
 import { C } from '../colors.ts';
-import { banner, styleCell, secHead, note, setColumnPixelWidths } from '../style.ts';
+import { banner, styleCell, secHead, note, addNote, setColumnPixelWidths } from '../style.ts';
 
 /**
  * SENSITIVITY tab — shows ±10% / ±20% impact on 24-month outputs for
@@ -78,6 +78,7 @@ export function buildSensitivityTab(wb: Workbook): void {
     const lblCell = ws.getCell(r, 3);
     styleCell(lblCell, C.SAND, C.NAVY, 10, true, 'left');
     lblCell.value = d[0];
+    addNote(lblCell, d[2]);
 
     multipliers.forEach((mult, i) => {
       const cell = ws.getCell(r, 4 + i);
@@ -85,6 +86,8 @@ export function buildSensitivityTab(wb: Workbook): void {
       styleCell(cell, isBase ? C.EMERALD : alt, isBase ? C.WHITE : C.NAVY, 10, isBase, 'right');
       cell.value = { formula: `${d[1]}*${mult}` } as never;
       cell.numFmt = '$#,##0';
+      const pct = mult === 1.0 ? 'Base case' : `${mult > 1 ? '+' : ''}${Math.round((mult - 1) * 100)}%`;
+      addNote(cell, `${pct} on ${d[0]}. Base 24-month Net Commission × ${mult}. Holds all other drivers at base.`);
     });
 
     const noteCell = ws.getCell(r, 9);

--- a/scripts/financial-model/tabs/unit-econ.ts
+++ b/scripts/financial-model/tabs/unit-econ.ts
@@ -1,6 +1,6 @@
 import type { Workbook } from 'exceljs';
 import { C } from '../colors.ts';
-import { banner, styleCell, secHead, note, lbl, setColumnPixelWidths } from '../style.ts';
+import { banner, styleCell, secHead, note, lbl, addNote, setColumnPixelWidths } from '../style.ts';
 
 /**
  * UNIT ECONOMICS tab — directional CAC, LTV, payback metrics derived from
@@ -37,6 +37,8 @@ export function buildUnitEconTab(wb: Workbook): void {
   secHead(ws, r++, 2, 4, '  1.  LIFETIME VALUE (LTV)  —  derived from 24-month totals × user lifetime');
 
   // Helper for one metric row: label | value | note
+  // Hover note on the value cell surfaces the hint text + extra context
+  // (useful when scrolling and the right-side hint column is off-screen).
   const metric = (label: string, formula: string, fmt: string, hint: string, highlight = false) => {
     ws.getRow(r).height = 26;
     const lblCell = ws.getCell(r, 3);
@@ -46,6 +48,7 @@ export function buildUnitEconTab(wb: Workbook): void {
     styleCell(valCell, highlight ? C.EMERALD : C.TEAL_LIGHT, highlight ? C.WHITE : C.NAVY, highlight ? 12 : 10, true, 'right');
     valCell.value = { formula } as never;
     valCell.numFmt = fmt;
+    addNote(valCell, `${label}\n\n${hint}`);
     const hintCell = ws.getCell(r, 5);
     styleCell(hintCell, C.WHITE, C.SLATE, 9, false, 'left', true);
     hintCell.value = hint;


### PR DESCRIPTION
## What this adds

Excel hover-tooltips (legacy "cell notes") on **133 meaningful cells** across the workbook. Hover any cell with the red triangle indicator → small popup explains what the number is, where it came from, and what input to edit to change it.

Requested by user feedback — they wanted context bubbles like "this $5,000 is the conference exhibitor booth fee" without having to scroll to find a Notes column.

## Distribution

| Tab | Notes | What gets a hover note |
|---|---|---|
| **EXPENSES** | 55 | Every Amount cell (surfaces row's description from `data.ts`) + 5 category-summary cells + 2 grand totals |
| **REVENUE MODEL** | 13 | Row labels for Active Owners, Travelers, Bookings, GBV, Gross/Net Commission, Stripe Fees, Voice Overage, Total Rev/Cost, Hiring, Net P&L, Cumulative Cash |
| **BREAK-EVEN** | 11 | 5 KPI cells + 6 table column headers (Month, Revenue, Costs, Net, Cumulative, Runway Signal) |
| **UNIT ECON** | 20 | Every metric value cell with formula derivation + healthy benchmark |
| **SENSITIVITY** | 18 | 3 driver labels + 15 multiplier cells showing "+10% on Commission" etc. |
| **FUNDING ASK** | 16 | 4 Ask rows + 6 Use of Funds amounts + 6 % of Ask cells |

## Intentionally skipped

- **INPUTS** — already has descriptive note text in column F next to every amber input cell. Hover notes would duplicate.
- **Cover** + **INSTRUCTIONS** — pure-text tabs, no calculated cells to explain.

## Implementation

One helper in `style.ts`:

```typescript
export function addNote(cell: Cell, text: string): Cell {
  cell.note = { texts: [{ text }], margins: { insetmode: 'auto' } } as never;
  return cell;
}
```

Per-tab integration via `addNote(cell, "tooltip text")` after styling each meaningful cell. No layout changes — just metadata.

## Test plan

- [x] Build produces 9-sheet xlsx with 133 hover notes
- [x] Sample notes verified via openpyxl: EXPENSES F7 shows Atlas description, REVENUE MODEL C9 shows Active Owners formula explanation
- [ ] User to hover over cells in Excel and confirm popups render legibly

🤖 Generated with [Claude Code](https://claude.com/claude-code)