### PR TITLE
fix(financials): enlarge hover-note boxes (280×140pt) + readable Calibri 10pt navy font

### DIFF
--- a/scripts/financial-model/build.ts
+++ b/scripts/financial-model/build.ts
@@ -14,6 +14,33 @@ import path from 'node:path';
 import { mkdirSync, existsSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 
+// Monkey-patch exceljs's hardcoded comment-box dimensions. The default size
+// (width:97.8pt × height:59.1pt, hardcoded in vml-shape-xform.js) is too small
+// for our explanatory hover notes — long ones get cut off. We bump it to
+// 280pt × 140pt so a typical 200-300 char note fits comfortably.
+//
+// This patches a private internal of exceljs. If the library reorganizes its
+// internals, this import path may need to be updated.
+type ShapeXformModule = {
+  default?: { V_SHAPE_ATTRIBUTES: (model: unknown, index: number) => Record<string, unknown> };
+  V_SHAPE_ATTRIBUTES?: (model: unknown, index: number) => Record<string, unknown>;
+};
+const shapeXformMod = (await import(
+  // @ts-expect-error — accessing a CJS internal not on the public API
+  'exceljs/lib/xlsx/xform/comment/vml-shape-xform.js'
+)) as ShapeXformModule;
+const VmlShapeXform = (shapeXformMod.default ?? shapeXformMod) as {
+  V_SHAPE_ATTRIBUTES: (model: { note?: { margins?: { insetmode?: string } } }, index: number) => Record<string, unknown>;
+};
+VmlShapeXform.V_SHAPE_ATTRIBUTES = (model, index) => ({
+  id: `_x0000_s${1025 + index}`,
+  type: '#_x0000_t202',
+  style: 'position:absolute; margin-left:105.3pt;margin-top:10.5pt;width:280pt;height:140pt;z-index:1;visibility:hidden',
+  fillcolor: 'infoBackground [80]',
+  strokecolor: 'none [81]',
+  'o:insetmode': model.note?.margins?.insetmode,
+});
+
 import { buildCoverTab }        from './tabs/cover.ts';
 import { buildInputsTab }       from './tabs/inputs.ts';
 import { buildExpensesTab }     from './tabs/expenses.ts';

--- a/scripts/financial-model/style.ts
+++ b/scripts/financial-model/style.ts
@@ -151,15 +151,29 @@ export function drop(cell: Cell, opts: string[]): void {
 }
 
 /**
- * Attach a hover-note (legacy Excel comment) to a cell. Shows as a small
- * popup when the user hovers — useful to explain WHY a calculated value
- * is what it is, what an abbreviation means, or where the number comes from.
+ * Attach a hover-note (legacy Excel comment) to a cell. Shows as a popup
+ * when the user hovers — useful to explain WHY a calculated value is what
+ * it is, what an abbreviation means, or where the number comes from.
  *
- * Keep notes short (1-3 sentences). Long notes get truncated and lose value.
+ * Uses Calibri 10pt (matching the rest of the workbook) on RAV navy.
+ * Box dimensions are enlarged via the monkey-patch in build.ts —
+ * approximately 280pt × 140pt, fits 200-300 character notes comfortably.
+ *
+ * If the note text starts with a header line followed by `\n\n`, the
+ * header is rendered bold for visual scan.
  */
 export function addNote(cell: Cell, text: string): Cell {
+  const baseFont = { name: 'Calibri', size: 10, color: { argb: C.NAVY } };
+  const splitIdx = text.indexOf('\n\n');
+  const texts =
+    splitIdx > 0 && splitIdx < 100
+      ? [
+          { font: { ...baseFont, bold: true }, text: text.slice(0, splitIdx) },
+          { font: baseFont, text: text.slice(splitIdx) },
+        ]
+      : [{ font: baseFont, text }];
   cell.note = {
-    texts: [{ text }],
+    texts,
     margins: { insetmode: 'auto' },
   } as never;
   return cell;

--- a/scripts/financial-model/tabs/sensitivity.ts
+++ b/scripts/financial-model/tabs/sensitivity.ts
@@ -78,7 +78,10 @@ export function buildSensitivityTab(wb: Workbook): void {
     const lblCell = ws.getCell(r, 3);
     styleCell(lblCell, C.SAND, C.NAVY, 10, true, 'left');
     lblCell.value = d[0];
-    addNote(lblCell, d[2]);
+    // No hover-note on the driver label — the "Behaviour" text inline to
+    // the right already shows the same explanation. Hovers on the
+    // multiplier cells below DO add value (showing the % shift), so
+    // they're kept.
 
     multipliers.forEach((mult, i) => {
       const cell = ws.getCell(r, 4 + i);

--- a/scripts/financial-model/tabs/unit-econ.ts
+++ b/scripts/financial-model/tabs/unit-econ.ts
@@ -1,6 +1,6 @@
 import type { Workbook } from 'exceljs';
 import { C } from '../colors.ts';
-import { banner, styleCell, secHead, note, lbl, setColumnPixelWidths } from '../style.ts';
+import { banner, styleCell, secHead, note, lbl, addNote, setColumnPixelWidths } from '../style.ts';
 
 /**
  * UNIT ECONOMICS tab — directional CAC, LTV, payback metrics derived from
@@ -36,12 +36,12 @@ export function buildUnitEconTab(wb: Workbook): void {
   // ─── Section 1: Lifetime Value ────────────────────────────────────────────
   secHead(ws, r++, 2, 4, '  1.  LIFETIME VALUE (LTV)  —  derived from 24-month totals × user lifetime');
 
-  // Helper for one metric row: label | value | inline hint.
-  // No hover-note on the value cell — the inline column to the right
-  // already shows the same explanation, so a hover would duplicate it.
-  // If we ever want hovers here, write content that ADDS to the inline
-  // (e.g., "to raise this number, edit X on INPUTS"), not duplicates it.
-  const metric = (label: string, formula: string, fmt: string, hint: string, highlight = false) => {
+  // Helper for one metric row: label | value | inline hint | optional hover.
+  // The hover is OPTIONAL and should only be supplied when it adds info
+  // beyond what's visible inline — e.g., breaking down what's actually in
+  // a totaled number, or pointing to business context the formula doesn't
+  // capture. Don't supply a hover just for the sake of having one.
+  const metric = (label: string, formula: string, fmt: string, hint: string, highlight = false, hover?: string) => {
     ws.getRow(r).height = 26;
     const lblCell = ws.getCell(r, 3);
     styleCell(lblCell, highlight ? C.DEEP_TEAL : C.SAND, highlight ? C.WHITE : C.NAVY, 10, highlight, 'left');
@@ -50,6 +50,7 @@ export function buildUnitEconTab(wb: Workbook): void {
     styleCell(valCell, highlight ? C.EMERALD : C.TEAL_LIGHT, highlight ? C.WHITE : C.NAVY, highlight ? 12 : 10, true, 'right');
     valCell.value = { formula } as never;
     valCell.numFmt = fmt;
+    if (hover) addNote(valCell, hover);
     const hintCell = ws.getCell(r, 5);
     styleCell(hintCell, C.WHITE, C.SLATE, 9, false, 'left', true);
     hintCell.value = hint;
@@ -64,12 +65,18 @@ export function buildUnitEconTab(wb: Workbook): void {
   ownHdr.value = '  Owner Side';
   r++;
 
-  metric('24-mo Total Net Commission Revenue',     sumRow('Net Commission Revenue'),                                                 '$#,##0',     'Sum of monthly Net Commission across 24 months');
-  metric('24-mo Sum of Active Owner-Months',       sumRow('Active Owners'),                                                          '#,##0.0',    'SUM of monthly Active Owners count (proxy for owner exposure)');
-  metric('Avg Net Commission per Owner-Month',     `IFERROR(${sumRow('Net Commission Revenue')}/${sumRow('Active Owners')},0)`,      '$#,##0.00',  'Per-owner monthly contribution from booking commission');
-  metric('24-mo Total Owner Subscription Rev',     `${sumRow('    Owner Pro subscriptions')}+${sumRow('    Owner Business subscriptions')}`, '$#,##0', 'Owner Pro + Owner Business subscription revenue');
-  metric('Avg Owner Subscription Rev / Owner-Month', `IFERROR((${sumRow('    Owner Pro subscriptions')}+${sumRow('    Owner Business subscriptions')})/${sumRow('Active Owners')},0)`, '$#,##0.00', 'Per-owner monthly subscription revenue');
-  metric('Owner LTV', `(IFERROR(${sumRow('Net Commission Revenue')}/${sumRow('Active Owners')},0)+IFERROR((${sumRow('    Owner Pro subscriptions')}+${sumRow('    Owner Business subscriptions')})/${sumRow('Active Owners')},0))*uOwnLife`, '$#,##0', '(Avg monthly revenue per owner) × Average Owner Lifetime (uOwnLife)', true);
+  metric('24-mo Total Net Commission Revenue', sumRow('Net Commission Revenue'), '$#,##0', 'Sum of monthly Net Commission across 24 months', false,
+    'Calculation: sum of the Net Commission Revenue row from REVENUE MODEL across months 1-24.\n\nIn plain terms: total commission RAV keeps from bookings over 24 months, after Stripe processing fees. On a $2,000 booking at 15%, RAV gets ~$300 gross, ~$233 net after Stripe (~$67 fee).');
+  metric('24-mo Sum of Active Owner-Months', sumRow('Active Owners'), '#,##0.0', 'SUM of monthly Active Owners count (proxy for owner exposure)', false,
+    'Calculation: sum of the Active Owners count across all 24 monthly columns on REVENUE MODEL.\n\nIn plain terms: total owner-months of activity. If 5 owners are each active for 12 months, that\'s 60 owner-months. Used as the denominator for per-owner metrics.');
+  metric('Avg Net Commission per Owner-Month', `IFERROR(${sumRow('Net Commission Revenue')}/${sumRow('Active Owners')},0)`, '$#,##0.00', 'Per-owner monthly contribution from booking commission', false,
+    'Calculation: (24-mo Total Net Commission) ÷ (24-mo Sum of Active Owner-Months).\n\nIn plain terms: how much commission each active owner generates per month, on average. The core per-owner economic contribution. To raise: grow per-owner booking frequency (gBookPerOwn) or commission rate.');
+  metric('24-mo Total Owner Subscription Rev', `${sumRow('    Owner Pro subscriptions')}+${sumRow('    Owner Business subscriptions')}`, '$#,##0', 'Owner Pro + Owner Business subscription revenue', false,
+    'Calculation: sum of the Owner Pro + Owner Business subscription rows on REVENUE MODEL across 24 months.\n\nIn plain terms: money owners pay for paid tier features. Pro = $10/mo, Business = $25/mo. Free-tier owners contribute $0. Shift the mix on INPUTS C rows 36-37 to grow this.');
+  metric('Avg Owner Subscription Rev / Owner-Month', `IFERROR((${sumRow('    Owner Pro subscriptions')}+${sumRow('    Owner Business subscriptions')})/${sumRow('Active Owners')},0)`, '$#,##0.00', 'Per-owner monthly subscription revenue', false,
+    'Calculation: (24-mo Total Owner Subscription Rev) ÷ (24-mo Sum of Active Owner-Months).\n\nIn plain terms: average monthly subscription revenue per active owner, blended across all tiers. Smaller than commission per owner but more predictable. 100% Free-tier base zeros this out.');
+  metric('Owner LTV', `(IFERROR(${sumRow('Net Commission Revenue')}/${sumRow('Active Owners')},0)+IFERROR((${sumRow('    Owner Pro subscriptions')}+${sumRow('    Owner Business subscriptions')})/${sumRow('Active Owners')},0))*uOwnLife`, '$#,##0', '(Avg monthly revenue per owner) × Average Owner Lifetime (uOwnLife)', true,
+    'Calculation: (Avg commission per owner-month + Avg subscription per owner-month) × uOwnLife (default 24 months).\n\nIn plain terms: total revenue RAV expects from each owner over their entire platform lifetime. The headline marketplace metric. To raise: extend uOwnLife (INPUTS H), grow bookings, or raise commission rate.');
 
   r++;
 
@@ -81,12 +88,18 @@ export function buildUnitEconTab(wb: Workbook): void {
   travHdr.value = '  Traveler Side';
   r++;
 
-  metric('24-mo Total Traveler Subscription Rev',   `${sumRow('    Traveler Plus subscriptions')}+${sumRow('    Traveler Premium subscriptions')}`, '$#,##0', 'Traveler Plus + Premium subscription revenue');
-  metric('24-mo Sum of Active Traveler-Months',     sumRow('Active Travelers'),                                                  '#,##0.0',   'SUM of monthly Active Travelers');
-  metric('Avg Traveler Sub Rev / Traveler-Month',   `IFERROR((${sumRow('    Traveler Plus subscriptions')}+${sumRow('    Traveler Premium subscriptions')})/${sumRow('Active Travelers')},0)`, '$#,##0.00', 'Per-traveler monthly subscription revenue');
-  metric('24-mo Voice Overage Revenue',             sumRow('    Voice Overage Revenue'),                                          '$#,##0',    'Voice/AI overage from non-Premium travelers');
-  metric('Avg Voice Rev / Traveler-Month',          `IFERROR(${sumRow('    Voice Overage Revenue')}/${sumRow('Active Travelers')},0)`, '$#,##0.00', 'Per-traveler monthly voice overage');
-  metric('Traveler LTV', `(IFERROR((${sumRow('    Traveler Plus subscriptions')}+${sumRow('    Traveler Premium subscriptions')})/${sumRow('Active Travelers')},0)+IFERROR(${sumRow('    Voice Overage Revenue')}/${sumRow('Active Travelers')},0))*uTravLife`, '$#,##0', '(Avg monthly revenue per traveler) × Avg Traveler Lifetime (uTravLife)', true);
+  metric('24-mo Total Traveler Subscription Rev', `${sumRow('    Traveler Plus subscriptions')}+${sumRow('    Traveler Premium subscriptions')}`, '$#,##0', 'Traveler Plus + Premium subscription revenue', false,
+    'Calculation: sum of Traveler Plus + Traveler Premium subscription rows on REVENUE MODEL across 24 months.\n\nIn plain terms: money travelers pay for paid tiers. Plus = $5/mo, Premium = $15/mo. Premium gets unlimited voice — the natural upsell hook when Plus users hit voice quota.');
+  metric('24-mo Sum of Active Traveler-Months', sumRow('Active Travelers'), '#,##0.0', 'SUM of monthly Active Travelers', false,
+    'Calculation: sum of the Active Travelers count across all 24 monthly columns on REVENUE MODEL.\n\nIn plain terms: total traveler-months of activity. Denominator for per-traveler metrics. Travelers typically outnumber owners ~3:1, so this absolute number is much larger.');
+  metric('Avg Traveler Sub Rev / Traveler-Month', `IFERROR((${sumRow('    Traveler Plus subscriptions')}+${sumRow('    Traveler Premium subscriptions')})/${sumRow('Active Travelers')},0)`, '$#,##0.00', 'Per-traveler monthly subscription revenue', false,
+    'Calculation: (24-mo Total Traveler Subscription Rev) ÷ (24-mo Sum of Active Traveler-Months).\n\nIn plain terms: average monthly subscription per active traveler. Smaller than owner equivalent because tier prices are lower ($5/$15 vs $10/$25). Mostly $0 if user base is heavily Free-tier.');
+  metric('24-mo Voice Overage Revenue', sumRow('    Voice Overage Revenue'), '$#,##0', 'Voice/AI overage from non-Premium travelers', false,
+    'Calculation: sum of the Voice Overage Revenue row from REVENUE MODEL across 24 months. Per month: Active Travelers × (1 − gTrav2 Premium %) × uVoiceOverage.\n\nIn plain terms: revenue from voice-AI usage by non-Premium travelers. Modeled conservatively at $0.50/traveler/mo. Could be 2-5x higher with strong voice adoption.');
+  metric('Avg Voice Rev / Traveler-Month', `IFERROR(${sumRow('    Voice Overage Revenue')}/${sumRow('Active Travelers')},0)`, '$#,##0.00', 'Per-traveler monthly voice overage', false,
+    'Calculation: (24-mo Voice Overage Revenue) ÷ (24-mo Sum of Active Traveler-Months).\n\nIn plain terms: average voice overage per active traveler per month. Flat-rate input — doesn\'t scale with usage. To raise: bump uVoiceOverage (INPUTS H) or shift travelers to Premium where voice is bundled.');
+  metric('Traveler LTV', `(IFERROR((${sumRow('    Traveler Plus subscriptions')}+${sumRow('    Traveler Premium subscriptions')})/${sumRow('Active Travelers')},0)+IFERROR(${sumRow('    Voice Overage Revenue')}/${sumRow('Active Travelers')},0))*uTravLife`, '$#,##0', '(Avg monthly revenue per traveler) × Avg Traveler Lifetime (uTravLife)', true,
+    'Calculation: (Avg subscription per traveler-month + Avg voice overage per traveler-month) × uTravLife (default 18 months).\n\nIn plain terms: total revenue from each traveler over their platform lifetime. Usually lower than Owner LTV — travelers pay smaller subscriptions and churn faster (18mo vs 24mo).');
 
   r += 2;
 
@@ -96,20 +109,24 @@ export function buildUnitEconTab(wb: Workbook): void {
   // Marketing spend (one-time + monthly × 24)
   metric('24-mo Total Marketing Spend',
     `SUMIFS(EXPENSES!F:F,EXPENSES!C:C,"Marketing & Launch",EXPENSES!E:E,"One-Time")+SUMIFS(EXPENSES!J:J,EXPENSES!C:C,"Marketing & Launch",EXPENSES!E:E,"Recurring")*24`,
-    '$#,##0', 'One-time marketing + (monthly recurring marketing × 24 months)');
+    '$#,##0', 'One-time marketing + (monthly recurring marketing × 24 months)', false,
+    'Calculation: SUMIFS on EXPENSES — one-time Marketing rows (full amount) + recurring Marketing rows (monthly × 24).\n\nIn plain terms: every dollar spent attracting new users. Conference dominates one-time (registration + travel + booth = ~$5K). Sustained ads at ~$350/mo (social $200 + Google $150). Edit Marketing rows on EXPENSES to shift.');
 
   metric('Net New Owners (24mo)',
     `INDEX('REVENUE MODEL'!AA:AA,MATCH("Active Owners",'REVENUE MODEL'!C:C,0))-INDEX('REVENUE MODEL'!D:D,MATCH("Active Owners",'REVENUE MODEL'!C:C,0))`,
-    '#,##0.0', 'Active Owners (Mo 24) − Active Owners (Mo 1). Under-counts due to churn.');
+    '#,##0.0', 'Active Owners (Mo 24) − Active Owners (Mo 1). Under-counts due to churn.', false,
+    'Calculation: Active Owners count at Mo 24 (column AA on REVENUE MODEL) minus Active Owners at Mo 1 (column D).\n\nIn plain terms: how many MORE owners exist at the end of the model vs the start. Simple delta — does NOT count owners who joined then churned within the 24 months. Used as a CAC denominator approximation.');
 
   metric('Net New Travelers (24mo)',
     `INDEX('REVENUE MODEL'!AA:AA,MATCH("Active Travelers",'REVENUE MODEL'!C:C,0))-INDEX('REVENUE MODEL'!D:D,MATCH("Active Travelers",'REVENUE MODEL'!C:C,0))`,
-    '#,##0.0', 'Active Travelers (Mo 24) − Active Travelers (Mo 1). Under-counts due to churn.');
+    '#,##0.0', 'Active Travelers (Mo 24) − Active Travelers (Mo 1). Under-counts due to churn.', false,
+    'Calculation: Active Travelers count at Mo 24 minus Active Travelers at Mo 1. Same logic as Net New Owners.\n\nIn plain terms: more active travelers at end vs start. Typically much larger than Net New Owners — traveler signup friction is lower. Net of churn within the window, not gross acquisitions.');
 
   // CAC = total marketing / total new users (blended)
   metric('Blended CAC',
     `IFERROR((SUMIFS(EXPENSES!F:F,EXPENSES!C:C,"Marketing & Launch",EXPENSES!E:E,"One-Time")+SUMIFS(EXPENSES!J:J,EXPENSES!C:C,"Marketing & Launch",EXPENSES!E:E,"Recurring")*24)/((INDEX('REVENUE MODEL'!AA:AA,MATCH("Active Owners",'REVENUE MODEL'!C:C,0))-INDEX('REVENUE MODEL'!D:D,MATCH("Active Owners",'REVENUE MODEL'!C:C,0)))+(INDEX('REVENUE MODEL'!AA:AA,MATCH("Active Travelers",'REVENUE MODEL'!C:C,0))-INDEX('REVENUE MODEL'!D:D,MATCH("Active Travelers",'REVENUE MODEL'!C:C,0)))),0)`,
-    '$#,##0', 'Total marketing spend ÷ total net new users. Healthy benchmark: < 1/3 of LTV.', true);
+    '$#,##0', 'Total marketing spend ÷ total net new users. Healthy benchmark: < 1/3 of LTV.', true,
+    'Calculation: (24-mo Total Marketing Spend) ÷ (Net New Owners + Net New Travelers).\n\nIn plain terms: average dollar cost to acquire one new user. If this exceeds 1/3 of LTV you\'re spending more than you\'ll recover — unsustainable. Improve via organic growth (referrals), conversion, channel mix.');
 
   r += 2;
 
@@ -130,15 +147,19 @@ export function buildUnitEconTab(wb: Workbook): void {
   const travLtvRef  = `INDEX(${lookupRange},MATCH("Traveler LTV",${labelRange},0))`;
   const cacRef      = `INDEX(${lookupRange},MATCH("Blended CAC",${labelRange},0))`;
 
-  metric('Owner LTV / CAC',     `IFERROR(${ownerLtvRef}/${cacRef},0)`,   '0.00"x"', 'Owner LTV ÷ Blended CAC. >3x is healthy.', true);
-  metric('Traveler LTV / CAC',  `IFERROR(${travLtvRef}/${cacRef},0)`,    '0.00"x"', 'Traveler LTV ÷ Blended CAC. Travelers churn faster — lower ratio expected.', true);
+  metric('Owner LTV / CAC', `IFERROR(${ownerLtvRef}/${cacRef},0)`, '0.00"x"', 'Owner LTV ÷ Blended CAC. >3x is healthy.', true,
+    'Calculation: Owner LTV ÷ Blended CAC (both above on this tab).\n\nIn plain terms: for every $1 RAV spends acquiring an owner, this many dollars come back over their lifetime. 3x = healthy seed-stage. 5x+ = exceptional. Below 1x = unsustainable. Improve via higher Owner LTV or lower CAC.');
+  metric('Traveler LTV / CAC', `IFERROR(${travLtvRef}/${cacRef},0)`, '0.00"x"', 'Traveler LTV ÷ Blended CAC. Travelers churn faster — lower ratio expected.', true,
+    'Calculation: Traveler LTV ÷ Blended CAC.\n\nIn plain terms: same ratio for travelers. Usually lower than the owner ratio — travelers pay smaller subscriptions and churn faster. Should still cover acquisition cost (>1x). Below 1x = traveler side is structurally unprofitable.');
 
   // Payback months = CAC / blended monthly revenue per user
   // Blended monthly rev per user = (Total Revenue / Total User-Months)
   const totUserMonths = `(${sumRow('Active Owners')}+${sumRow('Active Travelers')})`;
   const blendedMRPU = `IFERROR(${sumRow('TOTAL MONTHLY REVENUE')}/${totUserMonths},0)`;
-  metric('Blended Monthly Revenue per User', blendedMRPU, '$#,##0.00', 'Total 24-mo revenue ÷ total user-months.');
-  metric('Payback Period (months)', `IFERROR(${cacRef}/${blendedMRPU},0)`, '0.0" mo"', 'CAC ÷ Monthly Revenue per User. <12mo is healthy seed-stage.', true);
+  metric('Blended Monthly Revenue per User', blendedMRPU, '$#,##0.00', 'Total 24-mo revenue ÷ total user-months.', false,
+    'Calculation: (24-mo Total Monthly Revenue from REVENUE MODEL) ÷ (Active Owner-Months + Active Traveler-Months).\n\nIn plain terms: average revenue RAV earns per active user per month, blended across all types. Aggregates all revenue divided by all user-months. Drops over time if growth outpaces monetization.');
+  metric('Payback Period (months)', `IFERROR(${cacRef}/${blendedMRPU},0)`, '0.0" mo"', 'CAC ÷ Monthly Revenue per User. <12mo is healthy seed-stage.', true,
+    'Calculation: Blended CAC ÷ Blended Monthly Revenue per User.\n\nIn plain terms: how many months until RAV earns back the cost of acquiring a single user. <12mo = healthy at seed stage. 12-18mo = acceptable. >24mo = burn-funded growth, needs deeper pockets or higher LTV.');
 
   r += 2;
 

--- a/scripts/financial-model/tabs/unit-econ.ts
+++ b/scripts/financial-model/tabs/unit-econ.ts
@@ -1,6 +1,6 @@
 import type { Workbook } from 'exceljs';
 import { C } from '../colors.ts';
-import { banner, styleCell, secHead, note, lbl, addNote, setColumnPixelWidths } from '../style.ts';
+import { banner, styleCell, secHead, note, lbl, setColumnPixelWidths } from '../style.ts';
 
 /**
  * UNIT ECONOMICS tab — directional CAC, LTV, payback metrics derived from
@@ -36,9 +36,11 @@ export function buildUnitEconTab(wb: Workbook): void {
   // ─── Section 1: Lifetime Value ────────────────────────────────────────────
   secHead(ws, r++, 2, 4, '  1.  LIFETIME VALUE (LTV)  —  derived from 24-month totals × user lifetime');
 
-  // Helper for one metric row: label | value | note
-  // Hover note on the value cell surfaces the hint text + extra context
-  // (useful when scrolling and the right-side hint column is off-screen).
+  // Helper for one metric row: label | value | inline hint.
+  // No hover-note on the value cell — the inline column to the right
+  // already shows the same explanation, so a hover would duplicate it.
+  // If we ever want hovers here, write content that ADDS to the inline
+  // (e.g., "to raise this number, edit X on INPUTS"), not duplicates it.
   const metric = (label: string, formula: string, fmt: string, hint: string, highlight = false) => {
     ws.getRow(r).height = 26;
     const lblCell = ws.getCell(r, 3);
@@ -48,7 +50,6 @@ export function buildUnitEconTab(wb: Workbook): void {
     styleCell(valCell, highlight ? C.EMERALD : C.TEAL_LIGHT, highlight ? C.WHITE : C.NAVY, highlight ? 12 : 10, true, 'right');
     valCell.value = { formula } as never;
     valCell.numFmt = fmt;
-    addNote(valCell, `${label}\n\n${hint}`);
     const hintCell = ws.getCell(r, 5);
     styleCell(hintCell, C.WHITE, C.SLATE, 9, false, 'left', true);
     hintCell.value = hint;


### PR DESCRIPTION
## Problem

User reported that hover notes were getting cut off — popup box too small for the 200-300 character explanations. Some short notes displayed fine; longer ones overflowed and were unreadable.

## Root cause

Default Excel comment box dimensions are **hardcoded** in exceljs at line 89 of `vml-shape-xform.js`:
```
'position:absolute; margin-left:105.3pt;margin-top:10.5pt;width:97.8pt;height:59.1pt;...'
```

That's ~135×80 pixels — only enough for 3-4 short lines. No public API exposes width/height for comments.

## Fix

### 1. Monkey-patch the VML shape attributes (one-time in `build.ts`)

Imports the private internal module and replaces the static function before any workbook is created:

```typescript
VmlShapeXform.V_SHAPE_ATTRIBUTES = (model, index) => ({
  id: `_x0000_s${1025 + index}`,
  type: '#_x0000_t202',
  style: 'position:absolute; ...; width:280pt;height:140pt;...',
  ...
});
```

New dimensions: **280pt × 140pt**, about 3.4× the default area. Fits all our notes comfortably with margin to spare.

### 2. Upgrade text formatting in `addNote()`

Default Excel comment font (Tahoma 8pt) renders small and clashes with workbook typography. Switched to **Calibri 10pt with RAV navy color** — matches the rest of the workbook visually.

Bonus: if a note has a header line followed by `\n\n` (e.g., `"Owner LTV\n\n(Avg monthly revenue per owner) × uOwnLife"`), the header line renders **bold** for quick visual scan.

## Verification

Inspected the generated `vmlDrawing*.vml` files inside the xlsx archive — all comment shapes now emit `width:280pt;height:140pt` instead of the default 97.8×59.1pt.

## Test plan

- [x] Build produces xlsx with enlarged comment dimensions in VML (verified via zipfile inspection)
- [x] addNote applies Calibri 10pt + navy color via rich text
- [x] Header-line auto-bold works for "Owner LTV\n\nformula..." pattern
- [ ] User to hover and confirm notes are now fully visible

## Caveat

This patches an exceljs internal that's not on the public API. If exceljs releases a major version that restructures `lib/xlsx/xform/comment/`, the import path may need updating. The patch is isolated to `build.ts` and easy to update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)