### PR TITLE
feat(compliance) + refactor(commission): Guest Protection Policy (#489) + central commission config (#510)

### DIFF
--- a/docs/testing/TESTING-STATUS.md
+++ b/docs/testing/TESTING-STATUS.md
@@ -7,7 +7,7 @@ status: "active"
 # Testing Status
 
 > Current state of the RAV test suite. Updated each session.
-> **Last Updated:** May 11, 2026 (Session 64 — May 6: #483/#484/#485/#486 compliance work; May 11: #488 marketplace-facilitator registrations admin tab + Migration 075; +160 tests, +12 test files cumulative for the session)
+> **Last Updated:** May 11, 2026 (Session 64 — compliance hardening: #483/#484/#485/#486/#488/#489 cumulative; +171 tests, +14 test files for the session)
 
 ---
 
@@ -15,8 +15,8 @@ status: "active"
 
 | Metric | Value |
 |--------|-------|
-| **Total tests** | 1652 |
-| **Test files** | 169 |
+| **Total tests** | 1663 |
+| **Test files** | 171 |
 | **P0 critical-path tests** | 290+ tagged `@p0` (Session 64 added @p0 on disclaimer registry, DisclaimerBlock, StateSpecificDisclaimer, Footer registry sourcing, Terms 8.3+8.6, About page, placement audit) |
 | **E2E smoke tests** | 3 (Playwright) |
 | **Local run time** | ~2.5 min (full), ~2s (P0 only) |

--- a/scripts/financial-model/data.ts
+++ b/scripts/financial-model/data.ts
@@ -4,7 +4,14 @@
  * When the Phase 2 web tool is built at /executive-dashboard, it will import
  * from this module — the same inputs / expenses / scenarios feed both the
  * Excel generator and the React UI. Calculation logic lives in calc.ts.
+ *
+ * Issue #510: commission-rate defaults are imported from the central config
+ * (src/config/commission.ts). Changing the platform commission requires
+ * editing ONE file — that change flows here, into src/lib/pricing.ts, and
+ * into every component that imports from either.
  */
+
+import { DEFAULT_COMMISSION } from '../../src/config/commission.ts';
 
 // ─── Input rows ──────────────────────────────────────────────────────────────
 // Each input row produces one editable cell (amber) with a label, value,
@@ -18,11 +25,13 @@ export type InputRow = {
   note: string;
 };
 
-// Section A — Platform Parameters
+// Section A — Platform Parameters.
+// Defaults sourced from src/config/commission.ts so the financial model and
+// the live product (src/lib/pricing.ts) can never drift.
 export const PLATFORM: InputRow[] = [
-  { label: 'Base Commission Rate',          value: 0.15,  fmt: '0.00%',  name: 'pCommBase',    note: 'RAV charges owners this % per booking (system_settings.platform_commission_rate). Editable — adjust as pricing strategy evolves.' },
-  { label: 'Owner Pro Discount',            value: 0.02,  fmt: '0.00%',  name: 'pProDisc',     note: 'Pro tier effective rate = Base − Pro Discount.' },
-  { label: 'Owner Business Discount',       value: 0.05,  fmt: '0.00%',  name: 'pBizDisc',     note: 'Business tier effective rate = Base − Business Discount.' },
+  { label: 'Base Commission Rate',          value: DEFAULT_COMMISSION.base,             fmt: '0.00%',  name: 'pCommBase',    note: 'RAV charges owners this % per booking. Default is sourced from src/config/commission.ts — editing the .xlsx amber cell here only changes THIS scenario; to change the platform default, edit the config file and rebuild.' },
+  { label: 'Owner Pro Discount',            value: DEFAULT_COMMISSION.proDiscount,       fmt: '0.00%',  name: 'pProDisc',     note: 'Pro tier effective rate = Base − Pro Discount. Default from central config.' },
+  { label: 'Owner Business Discount',       value: DEFAULT_COMMISSION.businessDiscount,  fmt: '0.00%',  name: 'pBizDisc',     note: 'Business tier effective rate = Base − Business Discount. Default from central config.' },
   { label: 'Average Booking Value ($)',     value: 2000,  fmt: '$#,##0', name: 'pAvgBooking',  note: 'Typical timeshare week rental price.' },
   { label: 'Average Nights Per Booking',    value: 7,     fmt: '0',      name: 'pAvgNights',   note: 'Most timeshare listings are fixed 7-night weeks.' },
   { label: 'Stripe Processing Fee (%)',     value: 0.029, fmt: '0.000%', name: 'pStripePct',   note: '~2.9% per transaction — absorbed by RAV, baked into margin.' },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -47,6 +47,7 @@ const UserJourneys = lazy(() => import("./pages/UserJourneys"));
 const Terms = lazy(() => import("./pages/Terms"));
 const Privacy = lazy(() => import("./pages/Privacy"));
 const About = lazy(() => import("./pages/About"));
+const GuestProtection = lazy(() => import("./pages/GuestProtection"));
 const ApiDocs = lazy(() => import("./pages/ApiDocs"));
 const Developers = lazy(() => import("./pages/Developers"));
 const DestinationDetail = lazy(() => import("./pages/DestinationDetail"));
@@ -202,6 +203,7 @@ const App = () => (
             <Route path="/terms" element={<Terms />} />
             <Route path="/privacy" element={<Privacy />} />
             <Route path="/about" element={<About />} />
+            <Route path="/guest-protection" element={<GuestProtection />} />
             <Route path="/pending-approval" element={<PendingApproval />} />
             <Route path="/welcome" element={<ProtectedRoute><WelcomePage /></ProtectedRoute>} />
             <Route path="/documentation" element={<Documentation />} />

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -33,6 +33,7 @@ const Footer = () => {
               <li><Link to="/destinations" className="hover:text-white transition-colors">Destinations</Link></li>
               <li><Link to="/user-guide" className="hover:text-white transition-colors">User Guide</Link></li>
               <li><Link to="/faq" className="hover:text-white transition-colors">FAQs</Link></li>
+              <li><Link to="/guest-protection" className="hover:text-white transition-colors">Guest Protection</Link></li>
             </ul>
           </div>
 

--- a/src/components/legal/GuestProtectionBadge.test.tsx
+++ b/src/components/legal/GuestProtectionBadge.test.tsx
@@ -1,0 +1,35 @@
+// @vitest-environment jsdom
+// @p0
+/**
+ * Tests for <GuestProtectionBadge /> (#489) — the consumer-facing surface
+ * of RAV Guest Protection on listing pages and checkout.
+ */
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { GuestProtectionBadge } from "./GuestProtectionBadge";
+
+const renderBadge = (variant?: "badge" | "banner") =>
+  render(
+    <MemoryRouter>
+      <GuestProtectionBadge variant={variant} />
+    </MemoryRouter>,
+  );
+
+describe("GuestProtectionBadge", () => {
+  it("renders the compact badge variant by default", () => {
+    renderBadge();
+    const el = screen.getByTestId("guest-protection-badge");
+    expect(el.textContent).toContain("RAV Guest Protection");
+    expect(el.getAttribute("href")).toBe("/guest-protection");
+  });
+
+  it("renders the banner variant with the explanatory copy", () => {
+    renderBadge("banner");
+    const el = screen.getByTestId("guest-protection-banner");
+    expect(el.textContent).toContain("RAV Guest Protection");
+    expect(el.textContent).toMatch(/full refund within 5 business days/i);
+    expect(el.textContent).toMatch(/30 days of check-in/i);
+    expect(el.getAttribute("href")).toBe("/guest-protection");
+  });
+});

--- a/src/components/legal/GuestProtectionBadge.tsx
+++ b/src/components/legal/GuestProtectionBadge.tsx
@@ -1,0 +1,63 @@
+import { Link } from "react-router-dom";
+import { ShieldCheck } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface GuestProtectionBadgeProps {
+  /**
+   * `badge` — compact inline pill suitable for the trust-badges row on PropertyDetail.
+   * `banner` — full-width row with explanatory copy + CTA, for placement above the Pay button on Checkout.
+   */
+  variant?: "badge" | "banner";
+  className?: string;
+}
+
+/**
+ * Surfaces the RAV Guest Protection promise (full refund within 5 business days
+ * for Host cancellations within 30 days of check-in) at the points where it
+ * matters to the Guest: the listing page and the checkout flow. The underlying
+ * policy text is Legal Dossier § 8.5; this component is the product surface
+ * required by Compliance Brief § 3.6 / compliance-gap-analysis item P-12.
+ */
+export function GuestProtectionBadge({
+  variant = "badge",
+  className,
+}: GuestProtectionBadgeProps) {
+  if (variant === "banner") {
+    return (
+      <Link
+        to="/guest-protection"
+        data-testid="guest-protection-banner"
+        className={cn(
+          "flex items-start gap-3 rounded-lg border border-primary/30 bg-primary/5 p-4 transition-colors hover:bg-primary/10",
+          className,
+        )}
+      >
+        <ShieldCheck className="h-5 w-5 mt-0.5 text-primary flex-shrink-0" />
+        <div className="flex-1">
+          <p className="text-sm font-semibold text-foreground">
+            RAV Guest Protection
+          </p>
+          <p className="text-xs text-muted-foreground leading-relaxed mt-0.5">
+            If the Host cancels within 30 days of check-in, you receive a full refund
+            within 5 business days. Click for details.
+          </p>
+        </div>
+      </Link>
+    );
+  }
+
+  // Default compact badge
+  return (
+    <Link
+      to="/guest-protection"
+      data-testid="guest-protection-badge"
+      className={cn(
+        "inline-flex items-center gap-1.5 rounded-full border border-primary/30 bg-primary/5 px-2.5 py-1 text-xs font-medium text-primary transition-colors hover:bg-primary/10",
+        className,
+      )}
+    >
+      <ShieldCheck className="h-3.5 w-3.5" />
+      RAV Guest Protection
+    </Link>
+  );
+}

--- a/src/config/commission.ts
+++ b/src/config/commission.ts
@@ -1,0 +1,59 @@
+/**
+ * Central commission rate config — single source of truth.
+ *
+ * Issue #510: the commission rate used to be hardcoded in multiple places
+ * (src/lib/pricing.ts, scripts/financial-model/data.ts, multiple docs).
+ * Now it lives here, and every consumer imports from this file.
+ *
+ * To change the commission rate going forward, edit DEFAULT_COMMISSION below
+ * and re-run the build. Live runtime should eventually read from
+ * `system_settings.platform_commission_rate` (DB) — that's a follow-up to
+ * this issue.
+ *
+ * The financial model uses these values as the DEFAULT for INPUTS Section A.
+ * Users can still override in the .xlsx amber input cells without changing
+ * code — those edits stay local to their saved scenarios.
+ */
+
+export const DEFAULT_COMMISSION = {
+  /**
+   * Base commission rate charged on the booking subtotal.
+   * RAV keeps this % of every booking; the rest is owner payout.
+   * 0.15 = 15%.
+   */
+  base: 0.15,
+
+  /**
+   * Discount applied to the base rate for Owner Pro tier subscribers.
+   * Effective rate = base - proDiscount.
+   * 0.02 = 2 percentage points off (e.g., 15% base → 13% effective).
+   */
+  proDiscount: 0.02,
+
+  /**
+   * Discount applied to the base rate for Owner Business tier subscribers.
+   * Effective rate = base - businessDiscount.
+   * 0.05 = 5 percentage points off (e.g., 15% base → 10% effective).
+   */
+  businessDiscount: 0.05,
+} as const;
+
+/**
+ * Effective commission rate for each owner tier, derived from the defaults.
+ * Useful for displays that show "your tier's rate is X%".
+ */
+export const EFFECTIVE_RATES = {
+  free: DEFAULT_COMMISSION.base,
+  pro: DEFAULT_COMMISSION.base - DEFAULT_COMMISSION.proDiscount,
+  business: DEFAULT_COMMISSION.base - DEFAULT_COMMISSION.businessDiscount,
+} as const;
+
+/**
+ * Format a rate as a percentage string for display.
+ *   formatRate(0.15) -> "15%"
+ *   formatRate(0.125) -> "12.5%"
+ */
+export function formatRate(rate: number): string {
+  const pct = rate * 100;
+  return Number.isInteger(pct) ? `${pct}%` : `${pct.toFixed(1)}%`;
+}

--- a/src/lib/disclaimers/placements.test.ts
+++ b/src/lib/disclaimers/placements.test.ts
@@ -129,6 +129,28 @@ const PLACEMENTS: ReadonlyArray<Placement> = [
     ],
     notes: "Admin dashboard must register the marketplace-facilitator tracker tab (#488).",
   },
+  {
+    file: "src/pages/PropertyDetail.tsx",
+    required: [
+      `<GuestProtectionBadge />`,
+    ],
+    notes: "Listing page must surface the RAV Guest Protection badge (#489).",
+  },
+  {
+    file: "src/pages/Checkout.tsx",
+    required: [
+      `<GuestProtectionBadge variant="banner"`,
+    ],
+    notes: "Checkout must surface the Guest Protection banner above the Pay button (#489).",
+  },
+  {
+    file: "src/App.tsx",
+    required: [
+      `path="/guest-protection"`,
+      `GuestProtection`,
+    ],
+    notes: "Guest Protection page route must be registered (#489).",
+  },
 ];
 
 describe("Disclaimer placement audit — required <DisclaimerBlock /> usages per page", () => {

--- a/src/lib/pricing.ts
+++ b/src/lib/pricing.ts
@@ -6,9 +6,16 @@
  *
  * computeListingPricing — derives owner_price, rav_markup, and final_price
  * from a nightly rate and number of nights.
+ *
+ * Issue #510: the commission rate now lives in src/config/commission.ts.
+ * RAV_MARKUP_RATE is re-exported for backwards compatibility with existing
+ * consumers, but new code should import DEFAULT_COMMISSION from
+ * @/config/commission. Future work: read from system_settings at runtime.
  */
 
-export const RAV_MARKUP_RATE = 0.15; // 15% base commission
+import { DEFAULT_COMMISSION } from '@/config/commission';
+
+export const RAV_MARKUP_RATE = DEFAULT_COMMISSION.base; // sourced from central config (issue #510)
 const STRIPE_RATE = 0.029; // 2.9%
 const STRIPE_FIXED = 0.30; // $0.30 per transaction
 

--- a/src/pages/Checkout.tsx
+++ b/src/pages/Checkout.tsx
@@ -29,6 +29,7 @@ import { EmailVerificationBanner } from "@/components/EmailVerificationBanner";
 import { CancellationPolicyDetail } from "@/components/CancellationPolicyDetail";
 import { DisclaimerBlock } from "@/components/legal/DisclaimerBlock";
 import { StateSpecificDisclaimer } from "@/components/legal/StateSpecificDisclaimer";
+import { GuestProtectionBadge } from "@/components/legal/GuestProtectionBadge";
 import { usePageMeta } from "@/hooks/usePageMeta";
 import { trackEvent } from "@/lib/posthog";
 
@@ -391,6 +392,10 @@ const Checkout = () => {
                         <span>{error}</span>
                       </div>
                     )}
+
+                    {/* #489 — RAV Guest Protection banner surfaces the 5-business-day
+                        Host-cancellation refund promise immediately above the Pay button. */}
+                    <GuestProtectionBadge variant="banner" className="mt-2" />
 
                     <Button
                       className="w-full mt-4"

--- a/src/pages/FAQ.tsx
+++ b/src/pages/FAQ.tsx
@@ -114,7 +114,7 @@ const faqCategories = [
       {
         question: "What is your satisfaction guarantee?",
         answer:
-          "If your accommodation doesn't match the listing or there's a significant issue that can't be resolved, we'll provide a full refund or help you find alternative accommodation.",
+          "RAV Guest Protection: if your Host cancels within 30 days of check-in, you receive a full refund within 5 business days — guaranteed. Renter-initiated cancellations follow the listing's cancellation policy. Post-check-in issues (cleanliness, accuracy, access) are handled through our dispute system. Full policy at /guest-protection.",
       },
     ],
   },

--- a/src/pages/GuestProtection.test.tsx
+++ b/src/pages/GuestProtection.test.tsx
@@ -1,0 +1,69 @@
+// @vitest-environment jsdom
+// @p0
+/**
+ * Tests for the /guest-protection page (#489). Asserts the consumer-facing
+ * promise + verbatim Disclaimer 8.5 from the central registry + scope boundaries.
+ */
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+
+vi.mock("@/hooks/usePageMeta", () => ({
+  usePageMeta: vi.fn(),
+}));
+vi.mock("@/components/Header", () => ({
+  default: () => <header data-testid="stub-header" />,
+}));
+vi.mock("@/components/Footer", () => ({
+  default: () => <footer data-testid="stub-footer" />,
+}));
+
+import GuestProtection from "./GuestProtection";
+
+const renderPage = () =>
+  render(
+    <MemoryRouter>
+      <GuestProtection />
+    </MemoryRouter>,
+  );
+
+describe("GuestProtection page", () => {
+  it("renders the headline and headline promise", () => {
+    renderPage();
+    expect(screen.getByRole("heading", { level: 1 }).textContent).toContain("RAV Guest Protection");
+    expect(screen.getByText(/if your Host cancels close to check-in, you get every dollar back fast/i)).toBeTruthy();
+  });
+
+  it("renders the three-pillar What/When/HowFast section", () => {
+    renderPage();
+    // These phrases appear in both the pillar copy and the verbatim 8.5 disclaimer;
+    // assert presence (>= 1 match) rather than uniqueness.
+    expect(screen.getAllByText(/Host cancellation within 30 days of check-in/i).length).toBeGreaterThan(0);
+    expect(screen.getByText(/100% refund of your booking total/i)).toBeTruthy();
+    expect(screen.getAllByText(/within 5 business days/i).length).toBeGreaterThan(0);
+    // Pillar-specific headings
+    expect(screen.getByText(/What this covers/i)).toBeTruthy();
+  });
+
+  it("explains the Pay Safe / Stripe escrow architecture", () => {
+    renderPage();
+    expect(screen.getByText(/Pay Safe service routes payments through Stripe/i)).toBeTruthy();
+    expect(screen.getByText(/Renter funds never sit in a Rent-A-Vacation bank account/i)).toBeTruthy();
+  });
+
+  it("clearly states what is NOT covered (renter-initiated cancellations + post-check-in issues)", () => {
+    renderPage();
+    expect(screen.getByText(/Renter-initiated cancellations follow the listing's cancellation policy/i)).toBeTruthy();
+    expect(screen.getByText(/handled through the dispute system/i)).toBeTruthy();
+  });
+
+  it("renders Disclaimer 8.5 verbatim from the central registry", () => {
+    renderPage();
+    const block = screen.getByTestId("disclaimer-8.5");
+    expect(block.getAttribute("data-disclaimer-id")).toBe("8.5");
+    // Verbatim load-bearing phrases from Legal Dossier § 8.5
+    expect(block.textContent).toMatch(/Host cancellation within 30 days of check-in/);
+    expect(block.textContent).toMatch(/full refund within 5 business days/);
+    expect(block.textContent).toMatch(/platform fee is non-refundable except in cases of Host cancellation or verified fraud/);
+  });
+});

--- a/src/pages/GuestProtection.tsx
+++ b/src/pages/GuestProtection.tsx
@@ -1,0 +1,143 @@
+import Header from "@/components/Header";
+import Footer from "@/components/Footer";
+import { usePageMeta } from "@/hooks/usePageMeta";
+import { DisclaimerBlock } from "@/components/legal/DisclaimerBlock";
+import { ShieldCheck, Clock, Banknote, AlertCircle } from "lucide-react";
+
+const GuestProtection = () => {
+  usePageMeta({
+    title: "RAV Guest Protection — full refund within 5 business days for Host cancellations",
+    description:
+      "If your Host cancels within 30 days of check-in, RAV refunds 100% of your booking total within 5 business days. The Pay Safe (Stripe-held escrow) architecture means your funds never sit in a RAV bank account.",
+    canonicalPath: "/guest-protection",
+  });
+
+  return (
+    <div className="min-h-screen bg-background">
+      <Header />
+
+      <main className="pt-24 md:pt-28 pb-16 md:pb-20">
+        <div className="container mx-auto px-4">
+          <div className="max-w-3xl mx-auto">
+            <div className="flex items-center gap-3 mb-3">
+              <ShieldCheck className="h-10 w-10 text-primary" />
+              <h1 className="font-display text-4xl md:text-5xl font-bold text-foreground tracking-tight">
+                RAV Guest Protection
+              </h1>
+            </div>
+            <p className="text-muted-foreground text-lg mb-10">
+              The simple promise: if your Host cancels close to check-in, you get every dollar back fast.
+            </p>
+
+            <section className="mb-10 rounded-xl border border-border bg-card p-6 md:p-8">
+              <h2 className="font-display text-2xl font-semibold text-foreground mb-4">
+                What this covers
+              </h2>
+              <div className="grid grid-cols-1 md:grid-cols-3 gap-5">
+                <div>
+                  <div className="flex items-center gap-2 mb-2">
+                    <Clock className="h-5 w-5 text-primary" />
+                    <p className="font-semibold text-foreground">When</p>
+                  </div>
+                  <p className="text-sm text-muted-foreground leading-relaxed">
+                    Host cancellation within 30 days of check-in.
+                  </p>
+                </div>
+                <div>
+                  <div className="flex items-center gap-2 mb-2">
+                    <Banknote className="h-5 w-5 text-primary" />
+                    <p className="font-semibold text-foreground">What you get</p>
+                  </div>
+                  <p className="text-sm text-muted-foreground leading-relaxed">
+                    100% refund of your booking total. RAV's platform fee is also refunded for Host
+                    cancellations and verified fraud.
+                  </p>
+                </div>
+                <div>
+                  <div className="flex items-center gap-2 mb-2">
+                    <ShieldCheck className="h-5 w-5 text-primary" />
+                    <p className="font-semibold text-foreground">How fast</p>
+                  </div>
+                  <p className="text-sm text-muted-foreground leading-relaxed">
+                    Within 5 business days. Refund timing on your card is governed by Stripe + the
+                    card network.
+                  </p>
+                </div>
+              </div>
+            </section>
+
+            <section className="mb-10">
+              <h2 className="font-display text-2xl font-semibold text-foreground mb-3">
+                Why we can promise this
+              </h2>
+              <p className="text-muted-foreground leading-relaxed mb-3">
+                Renter funds never sit in a Rent-A-Vacation bank account. Our Pay Safe service routes
+                payments through Stripe — a licensed payment processor — and Stripe holds the funds
+                until the Host has earned them (after check-in). If the Host cancels, Stripe issues a
+                refund directly back to your original payment method.
+              </p>
+              <p className="text-muted-foreground leading-relaxed">
+                We don't have to wait for the Host to forward your money back. Stripe never released
+                it to them.
+              </p>
+            </section>
+
+            <section className="mb-10">
+              <h2 className="font-display text-2xl font-semibold text-foreground mb-3">
+                What this does NOT cover
+              </h2>
+              <div className="rounded-lg border border-amber-500/30 bg-amber-50 dark:bg-amber-950/20 p-4 flex gap-3">
+                <AlertCircle className="h-5 w-5 text-amber-600 mt-0.5 flex-shrink-0" />
+                <div className="space-y-2 text-sm">
+                  <p className="text-foreground font-medium">
+                    Renter-initiated cancellations follow the listing's cancellation policy (Flexible /
+                    Moderate / Strict / Super Strict).
+                  </p>
+                  <p className="text-muted-foreground leading-relaxed">
+                    The policy is shown on every listing page and on the Checkout screen before you
+                    pay. Read it before booking. If you need to cancel, the refund amount depends on
+                    when you cancel relative to check-in — that's the Host's decision per the policy
+                    they chose, not RAV's.
+                  </p>
+                  <p className="text-muted-foreground leading-relaxed">
+                    Issues with the property after check-in (cleanliness, accuracy, access, etc.) are
+                    handled through the dispute system — open an issue from your booking page and our
+                    team will investigate.
+                  </p>
+                </div>
+              </div>
+            </section>
+
+            <section className="mb-10">
+              <h2 className="font-display text-2xl font-semibold text-foreground mb-3">
+                The official language
+              </h2>
+              <DisclaimerBlock id="8.5" variant="full" className="bg-muted/30" />
+            </section>
+
+            <section>
+              <h2 className="font-display text-2xl font-semibold text-foreground mb-3">
+                Questions?
+              </h2>
+              <p className="text-muted-foreground leading-relaxed">
+                Email{" "}
+                <a href="mailto:support@rent-a-vacation.com" className="text-primary underline hover:text-primary/80">
+                  support@rent-a-vacation.com
+                </a>{" "}
+                or open a chat from any page. For the full terms governing your booking, see our{" "}
+                <a href="/terms" className="text-primary underline hover:text-primary/80">
+                  Terms of Service
+                </a>
+                .
+              </p>
+            </section>
+          </div>
+        </div>
+      </main>
+
+      <Footer />
+    </div>
+  );
+};
+
+export default GuestProtection;

--- a/src/pages/PropertyDetail.tsx
+++ b/src/pages/PropertyDetail.tsx
@@ -52,6 +52,7 @@ import ReviewSummary from "@/components/reviews/ReviewSummary";
 import { calculateNights, computeFeeBreakdown } from "@/lib/pricing";
 import { DisclaimerBlock } from "@/components/legal/DisclaimerBlock";
 import { StateSpecificDisclaimer } from "@/components/legal/StateSpecificDisclaimer";
+import { GuestProtectionBadge } from "@/components/legal/GuestProtectionBadge";
 import { CancellationPolicyDetail } from "@/components/CancellationPolicyDetail";
 import { OwnerProfileCard } from "@/components/OwnerProfileCard";
 import { InquiryDialog } from "@/components/InquiryDialog";
@@ -854,6 +855,10 @@ const PropertyDetail = () => {
           aria-label="Listing disclaimers"
         >
           <div className="container mx-auto px-4 max-w-4xl space-y-3">
+            {/* #489 — RAV Guest Protection badge surfaces the 5-business-day refund promise. */}
+            <div className="flex justify-end">
+              <GuestProtectionBadge />
+            </div>
             <DisclaimerBlock id="8.1" variant="compact" />
             <DisclaimerBlock id="8.2" variant="compact" />
             <DisclaimerBlock id="8.5" variant="compact" />


### PR DESCRIPTION
> **⚠️ This PR contains two unrelated changes that landed on `dev` from separate sessions.** Both are independently ready to ship. Reviewers should evaluate them as two separate concerns.

---

# 1. Guest Protection Policy product surface (#489)

## Summary

Closes **#489**. The refund logic was already wired (Host cancellation → `process-cancellation/handler.ts` issues 100% Stripe refund). What was missing was the **consumer-facing surface** required by Compliance Brief § 3.6 / compliance-gap-analysis item P-12.

- **New `/guest-protection` page** — three-pillar When/What/HowFast summary, Pay Safe/Stripe architecture explainer, "What is NOT covered" boundary statement, verbatim Disclaimer 8.5 from the central registry.
- **`<GuestProtectionBadge />`** component — `badge` variant (compact pill for listing trust-badges area) + `banner` variant (full-width row with explanatory copy for Checkout). Both link to `/guest-protection`.
- **Wiring**: PropertyDetail.tsx (badge), Checkout.tsx (banner above Pay button), FAQ.tsx (satisfaction-guarantee answer rewritten + link), Footer.tsx (For Renters column), App.tsx (lazy route).
- No claims exceed the documented refund policy; the verbatim text comes from the central disclaimer registry so any counsel revision propagates without rewording the marketing page.

## Test plan

- [x] `npm run test` — **1663 / 1663** pass (added 11 net: 5 page tests + 2 badge tests + 4 placement-audit assertions)
- [x] `npm run build` — clean
- [x] ESLint clean across changed files
- [x] Zero new TypeScript errors

## Audit scoreboard impact

Row 18 (Guest Protection Policy) flips Gap → Implemented for the engineering deliverable. Counsel sign-off on the verbatim 8.5 text remains tracked under #494.

---

# 2. Central commission config — MVP (#510)

## What this does

Closes the architectural debt called out in issue #510 — at the MVP level. Creates **one** file (`src/config/commission.ts`) that holds the commission rate defaults. Both consumers (live pricing + financial model) now import from it.

**No value change** — still 15% base, 2% Pro discount, 5% Business discount. This is purely "stop hardcoding in two places."

## Why now

Phase 2 Stage 2a (financial model in the web app at `/executive-dashboard`) needs a single source of truth before it imports commission values into React components. Without this, we'd create a third hardcoded copy in JSX.

## Scope (MVP)

| Change | What |
|---|---|
| **New** | `src/config/commission.ts` — `DEFAULT_COMMISSION` + `EFFECTIVE_RATES` + `formatRate()` |
| **Modified** | `src/lib/pricing.ts` — `RAV_MARKUP_RATE` now re-exports from central config |
| **Modified** | `scripts/financial-model/data.ts` — PLATFORM input row defaults imported from central config |

## What's out of scope (separate follow-ups)

The full vision of #510 is larger — these come later:
- Reading from `system_settings.platform_commission_rate` at runtime (async refactor)
- Admin UI for changing the rate with audit log
- Migration adding pro_disc / business_disc columns
- BRAND-LOCK.md / RAV-PRICING-TAXES-ACCOUNTING.md prose updates
- Refactoring all pricing-function callers to pass rate as parameter

Each can land as its own focused PR. Together they fulfill #510 in full.

## Test plan

- [x] `npm run financials:build` produces correct .xlsx with values 0.15 / 0.02 / 0.05
- [x] All 27 `src/lib/pricing.test.ts` tests pass unchanged
- [x] No behavior change at runtime — every consumer sees the same numbers

## After this merges

Phase 2 Stage 2a starts — React UI for the financial model under `/executive-dashboard`, importing from `src/config/commission.ts` and `scripts/financial-model/data.ts`.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)