### PR TITLE
feat(executive): shared tab navigation — Live Metrics ↔ Financial Model

### DIFF
--- a/src/components/executive/DashboardTabs.tsx
+++ b/src/components/executive/DashboardTabs.tsx
@@ -1,0 +1,70 @@
+import { Link, useLocation } from 'react-router-dom';
+import { TrendingUp, BarChart3 } from 'lucide-react';
+
+/**
+ * Top-of-page tab navigation shared between the Executive Dashboard
+ * (live metrics) and the Financial Model (24-month forecast).
+ *
+ * Active tab is determined from `useLocation()` so the same component
+ * works on both routes without props. Clicking a tab navigates client-side.
+ */
+
+const TABS = [
+  {
+    id: 'live',
+    label: 'Live Metrics',
+    href: '/executive-dashboard',
+    description: 'Real-time business performance',
+    icon: BarChart3,
+  },
+  {
+    id: 'forecast',
+    label: 'Financial Model',
+    href: '/executive-dashboard/financial-model',
+    description: '24-month forward projection',
+    icon: TrendingUp,
+  },
+] as const;
+
+export function DashboardTabs() {
+  const location = useLocation();
+
+  // Determine active tab by exact path or descendant path
+  const activeTab =
+    location.pathname === '/executive-dashboard' || location.pathname === '/executive-dashboard/'
+      ? 'live'
+      : location.pathname.startsWith('/executive-dashboard/financial-model')
+        ? 'forecast'
+        : 'live';
+
+  return (
+    <nav className="border-b border-slate-700/50 bg-slate-900/50 backdrop-blur" aria-label="Dashboard sections">
+      <div className="container mx-auto px-6">
+        <div className="flex items-center gap-1">
+          {TABS.map((tab) => {
+            const isActive = tab.id === activeTab;
+            const Icon = tab.icon;
+            return (
+              <Link
+                key={tab.id}
+                to={tab.href}
+                className={`group relative flex items-center gap-2 px-4 py-3 text-sm font-medium transition border-b-2 -mb-px ${
+                  isActive
+                    ? 'border-teal-400 text-white'
+                    : 'border-transparent text-slate-400 hover:text-slate-200 hover:border-slate-600'
+                }`}
+                aria-current={isActive ? 'page' : undefined}
+              >
+                <Icon className={`h-4 w-4 ${isActive ? 'text-teal-300' : 'text-slate-500 group-hover:text-slate-300'}`} />
+                <span>{tab.label}</span>
+                <span className="hidden md:inline text-xs font-normal text-slate-500 ml-1">
+                  · {tab.description}
+                </span>
+              </Link>
+            );
+          })}
+        </div>
+      </div>
+    </nav>
+  );
+}

--- a/src/pages/ExecutiveDashboard.tsx
+++ b/src/pages/ExecutiveDashboard.tsx
@@ -1,7 +1,8 @@
 import { useState } from 'react';
-import { Navigate, Link } from 'react-router-dom';
-import { Monitor, TrendingUp } from 'lucide-react';
+import { Navigate } from 'react-router-dom';
+import { Monitor } from 'lucide-react';
 import { useAuth } from '@/contexts/AuthContext';
+import { DashboardTabs } from '@/components/executive/DashboardTabs';
 import { HeadlineBar } from '@/components/executive/HeadlineBar';
 import { BusinessPerformance } from '@/components/executive/BusinessPerformance';
 import { MarketplaceHealth } from '@/components/executive/MarketplaceHealth';
@@ -41,6 +42,7 @@ const ExecutiveDashboard = () => {
 
       {/* Main content — hidden below lg */}
       <div className="hidden lg:block pt-16 md:pt-20">
+        <DashboardTabs />
         <HeadlineBar />
 
         <main className="container mx-auto px-6 py-8 md:py-10 space-y-0">
@@ -55,14 +57,6 @@ const ExecutiveDashboard = () => {
                 Boardroom-grade intelligence. Real-time marketplace performance, proprietary metrics like Liquidity Score and Bid Spread Index,
                 competitive benchmarking, and industry intelligence — all in one boardroom-ready view.
               </p>
-              <Link
-                to="/executive-dashboard/financial-model"
-                className="inline-flex items-center gap-2 mt-4 text-sm font-medium text-teal-300 hover:text-teal-200 transition group"
-              >
-                <TrendingUp className="h-4 w-4" />
-                <span>View 24-Month Financial Projection</span>
-                <span className="text-slate-500 group-hover:text-slate-400">→</span>
-              </Link>
             </div>
             <IntegrationSettings open={settingsOpen} onOpenChange={setSettingsOpen} />
           </div>

--- a/src/pages/FinancialModelDashboard.tsx
+++ b/src/pages/FinancialModelDashboard.tsx
@@ -1,9 +1,10 @@
 import { Navigate, Link } from 'react-router-dom';
-import { TrendingUp, AlertTriangle, FileSpreadsheet, ArrowLeft } from 'lucide-react';
+import { TrendingUp, AlertTriangle, FileSpreadsheet } from 'lucide-react';
 import { useAuth } from '@/contexts/AuthContext';
 import { usePageMeta } from '@/hooks/usePageMeta';
 import Header from '@/components/Header';
 import Footer from '@/components/Footer';
+import { DashboardTabs } from '@/components/executive/DashboardTabs';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -57,6 +58,7 @@ export default function FinancialModelDashboard() {
       <Header />
 
       <div className="pt-16 md:pt-20">
+        <DashboardTabs />
         <main className="container mx-auto px-6 py-8 md:py-10">
           {/* Forward Projection banner — distinct from Exec Dashboard live metrics */}
           <div className="mb-6 flex items-start gap-3 rounded-lg border border-amber-500/30 bg-amber-500/10 p-4">
@@ -71,10 +73,6 @@ export default function FinancialModelDashboard() {
           {/* Page header */}
           <div className="flex items-start justify-between gap-4 mb-8">
             <div>
-              <Link to="/executive-dashboard" className="inline-flex items-center gap-1.5 text-xs font-medium text-slate-400 hover:text-slate-200 transition mb-3">
-                <ArrowLeft className="h-3.5 w-3.5" />
-                Back to Executive Dashboard
-              </Link>
               <div className="text-xs font-medium tracking-widest uppercase text-slate-400 mb-1.5">
                 Financial Model — Forward Projection
               </div>


### PR DESCRIPTION
## Summary

User feedback after PR #511: the Financial Model page existed but the only way to get there was a small inline link on the Executive Dashboard. Adds proper tab navigation at the top of both pages.

This PR also targets **`dev`** (not `main` directly) per the documented branching workflow — apologies for routing #511 straight to `main`. Going forward all my feature branches → `dev` → `main`.

## What's new

`src/components/executive/DashboardTabs.tsx` — a shared tab nav component:

- **Live Metrics** tab → `/executive-dashboard` (current real-time view)
- **Financial Model** tab → `/executive-dashboard/financial-model` (Stage 2a forecast view)
- Active state determined from `useLocation()` — same component works on both routes
- Matches the boardroom dark theme (slate-900 / teal-400 active border)
- Icon + label always visible; description text hides on small screens

Wired into both dashboards:

| Page | Change |
|---|---|
| `ExecutiveDashboard.tsx` | Tab bar replaces the inline "View 24-Month Financial Projection" link |
| `FinancialModelDashboard.tsx` | Tab bar replaces the "Back to Executive Dashboard" link |

## Why through dev this time

PR #511 (Stage 2a) went `feature → main` directly, which left `dev.rent-a-vacation.com` stale until I fast-forwarded `dev`. Per CLAUDE.md branching rules, the correct path is `feature → dev → main`. This PR follows that — once merged to `dev`, the next dev → main PR rolls everything (Stage 2a + tabs) into production together.

## Test plan

- [x] `npm run build` clean
- [x] `npm run lint` no new errors
- [ ] User to verify tab navigation works at `/executive-dashboard` and `/executive-dashboard/financial-model` once deployed to `dev.rent-a-vacation.com`

🤖 Generated with [Claude Code](https://claude.com/claude-code)