### PR TITLE
release: dev → main — Financial Model dashboard + executive dashboard tabs

### DIFF
--- a/src/components/executive/DashboardTabs.tsx
+++ b/src/components/executive/DashboardTabs.tsx
@@ -1,0 +1,70 @@
+import { Link, useLocation } from 'react-router-dom';
+import { TrendingUp, BarChart3 } from 'lucide-react';
+
+/**
+ * Top-of-page tab navigation shared between the Executive Dashboard
+ * (live metrics) and the Financial Model (24-month forecast).
+ *
+ * Active tab is determined from `useLocation()` so the same component
+ * works on both routes without props. Clicking a tab navigates client-side.
+ */
+
+const TABS = [
+  {
+    id: 'live',
+    label: 'Live Metrics',
+    href: '/executive-dashboard',
+    description: 'Real-time business performance',
+    icon: BarChart3,
+  },
+  {
+    id: 'forecast',
+    label: 'Financial Model',
+    href: '/executive-dashboard/financial-model',
+    description: '24-month forward projection',
+    icon: TrendingUp,
+  },
+] as const;
+
+export function DashboardTabs() {
+  const location = useLocation();
+
+  // Determine active tab by exact path or descendant path
+  const activeTab =
+    location.pathname === '/executive-dashboard' || location.pathname === '/executive-dashboard/'
+      ? 'live'
+      : location.pathname.startsWith('/executive-dashboard/financial-model')
+        ? 'forecast'
+        : 'live';
+
+  return (
+    <nav className="border-b border-slate-700/50 bg-slate-900/50 backdrop-blur" aria-label="Dashboard sections">
+      <div className="container mx-auto px-6">
+        <div className="flex items-center gap-1">
+          {TABS.map((tab) => {
+            const isActive = tab.id === activeTab;
+            const Icon = tab.icon;
+            return (
+              <Link
+                key={tab.id}
+                to={tab.href}
+                className={`group relative flex items-center gap-2 px-4 py-3 text-sm font-medium transition border-b-2 -mb-px ${
+                  isActive
+                    ? 'border-teal-400 text-white'
+                    : 'border-transparent text-slate-400 hover:text-slate-200 hover:border-slate-600'
+                }`}
+                aria-current={isActive ? 'page' : undefined}
+              >
+                <Icon className={`h-4 w-4 ${isActive ? 'text-teal-300' : 'text-slate-500 group-hover:text-slate-300'}`} />
+                <span>{tab.label}</span>
+                <span className="hidden md:inline text-xs font-normal text-slate-500 ml-1">
+                  · {tab.description}
+                </span>
+              </Link>
+            );
+          })}
+        </div>
+      </div>
+    </nav>
+  );
+}

--- a/src/pages/ExecutiveDashboard.tsx
+++ b/src/pages/ExecutiveDashboard.tsx
@@ -1,7 +1,8 @@
 import { useState } from 'react';
-import { Navigate, Link } from 'react-router-dom';
-import { Monitor, TrendingUp } from 'lucide-react';
+import { Navigate } from 'react-router-dom';
+import { Monitor } from 'lucide-react';
 import { useAuth } from '@/contexts/AuthContext';
+import { DashboardTabs } from '@/components/executive/DashboardTabs';
 import { HeadlineBar } from '@/components/executive/HeadlineBar';
 import { BusinessPerformance } from '@/components/executive/BusinessPerformance';
 import { MarketplaceHealth } from '@/components/executive/MarketplaceHealth';
@@ -41,6 +42,7 @@ const ExecutiveDashboard = () => {
 
       {/* Main content — hidden below lg */}
       <div className="hidden lg:block pt-16 md:pt-20">
+        <DashboardTabs />
         <HeadlineBar />
 
         <main className="container mx-auto px-6 py-8 md:py-10 space-y-0">
@@ -55,14 +57,6 @@ const ExecutiveDashboard = () => {
                 Boardroom-grade intelligence. Real-time marketplace performance, proprietary metrics like Liquidity Score and Bid Spread Index,
                 competitive benchmarking, and industry intelligence — all in one boardroom-ready view.
               </p>
-              <Link
-                to="/executive-dashboard/financial-model"
-                className="inline-flex items-center gap-2 mt-4 text-sm font-medium text-teal-300 hover:text-teal-200 transition group"
-              >
-                <TrendingUp className="h-4 w-4" />
-                <span>View 24-Month Financial Projection</span>
-                <span className="text-slate-500 group-hover:text-slate-400">→</span>
-              </Link>
             </div>
             <IntegrationSettings open={settingsOpen} onOpenChange={setSettingsOpen} />
           </div>

--- a/src/pages/FinancialModelDashboard.tsx
+++ b/src/pages/FinancialModelDashboard.tsx
@@ -1,9 +1,10 @@
 import { Navigate, Link } from 'react-router-dom';
-import { TrendingUp, AlertTriangle, FileSpreadsheet, ArrowLeft } from 'lucide-react';
+import { TrendingUp, AlertTriangle, FileSpreadsheet } from 'lucide-react';
 import { useAuth } from '@/contexts/AuthContext';
 import { usePageMeta } from '@/hooks/usePageMeta';
 import Header from '@/components/Header';
 import Footer from '@/components/Footer';
+import { DashboardTabs } from '@/components/executive/DashboardTabs';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -57,6 +58,7 @@ export default function FinancialModelDashboard() {
       <Header />
 
       <div className="pt-16 md:pt-20">
+        <DashboardTabs />
         <main className="container mx-auto px-6 py-8 md:py-10">
           {/* Forward Projection banner — distinct from Exec Dashboard live metrics */}
           <div className="mb-6 flex items-start gap-3 rounded-lg border border-amber-500/30 bg-amber-500/10 p-4">
@@ -71,10 +73,6 @@ export default function FinancialModelDashboard() {
           {/* Page header */}
           <div className="flex items-start justify-between gap-4 mb-8">
             <div>
-              <Link to="/executive-dashboard" className="inline-flex items-center gap-1.5 text-xs font-medium text-slate-400 hover:text-slate-200 transition mb-3">
-                <ArrowLeft className="h-3.5 w-3.5" />
-                Back to Executive Dashboard
-              </Link>
               <div className="text-xs font-medium tracking-widest uppercase text-slate-400 mb-1.5">
                 Financial Model — Forward Projection
               </div>


### PR DESCRIPTION
## Release rollup

Brings the latest dev state into main. Two changes since the previous main merge:

### Changes included

| PR | Commit | What |
|---|---|---|
| #511 (already on main) | `ec5cb14` | Phase 2 Stage 2a — `/executive-dashboard/financial-model` view-only dashboard |
| #512 | `50c8c0f` | Shared tab navigation between Executive Dashboard (live metrics) and Financial Model (forecast) |

Net new for this release: the tab navigation component. Stage 2a was already merged to main directly (apologies, that bypassed dev — corrected workflow from this point onward).

### What's deploying to production

- `/executive-dashboard` — Live Metrics view (unchanged content), new top-of-page tab bar
- `/executive-dashboard/financial-model` — 24-month forward projection view (Stage 2a)
- Tab bar shows both options with active-state highlighting

Both routes auth-gated to RAV team only.

### Verified on dev

`dev.rent-a-vacation.com` deployed with both changes — user confirmed visuals and observed the commission revenue spread across scenarios (separate analytical discussion).

### Test plan

- [x] CI green on PR #512 against dev
- [x] dev.rent-a-vacation.com renders both tabs correctly
- [x] Switching tabs navigates client-side without full page reload
- [x] Auth gating enforced (non-RAV users redirect to /)

🤖 Generated with [Claude Code](https://claude.com/claude-code)