### PR TITLE
feat(commission): platform rate 15% → 12% (Business disc 5% → 4%)

### DIFF
--- a/src/config/commission.ts
+++ b/src/config/commission.ts
@@ -19,23 +19,33 @@ export const DEFAULT_COMMISSION = {
   /**
    * Base commission rate charged on the booking subtotal.
    * RAV keeps this % of every booking; the rest is owner payout.
-   * 0.15 = 15%.
+   * 0.12 = 12%.
+   *
+   * Set to 12% (was 15%) after competitor analysis on 2026-05-11:
+   *   - RedWeek "Verified Rental" charges 15-20% — high-service tier
+   *   - Koala charges 10% — lighter-feature competitor
+   *   - 12% positions RAV as "premium over Koala, below RedWeek"
+   *     justified by extra service stack (escrow + AI + bid mechanics)
    */
-  base: 0.15,
+  base: 0.12,
 
   /**
    * Discount applied to the base rate for Owner Pro tier subscribers.
    * Effective rate = base - proDiscount.
-   * 0.02 = 2 percentage points off (e.g., 15% base → 13% effective).
+   * 0.02 = 2 percentage points off → 10% effective (matches Koala baseline).
    */
   proDiscount: 0.02,
 
   /**
    * Discount applied to the base rate for Owner Business tier subscribers.
    * Effective rate = base - businessDiscount.
-   * 0.05 = 5 percentage points off (e.g., 15% base → 10% effective).
+   * 0.04 = 4 percentage points off → 8% effective.
+   *
+   * Tightened from 5% (which would give 7% effective at 12% base — below
+   * Koala and aggressively low). 8% is still competitive for high-volume
+   * owners while preserving margin.
    */
-  businessDiscount: 0.05,
+  businessDiscount: 0.04,
 } as const;
 
 /**

--- a/src/lib/pricing.test.ts
+++ b/src/lib/pricing.test.ts
@@ -31,15 +31,15 @@ describe('computeListingPricing @p0', () => {
   it('computes correct pricing for $200/night x 7 nights', () => {
     const result = computeListingPricing(200, 7);
     expect(result.ownerPrice).toBe(1400);
-    expect(result.ravMarkup).toBe(210);
-    expect(result.finalPrice).toBe(1610);
+    expect(result.ravMarkup).toBe(168); // round(1400 * 0.12) = 168
+    expect(result.finalPrice).toBe(1568);
   });
 
   it('computes correct pricing for $150/night x 3 nights', () => {
     const result = computeListingPricing(150, 3);
     expect(result.ownerPrice).toBe(450);
-    expect(result.ravMarkup).toBe(68); // round(450 * 0.15) = round(67.5) = 68
-    expect(result.finalPrice).toBe(518);
+    expect(result.ravMarkup).toBe(54); // round(450 * 0.12) = 54
+    expect(result.finalPrice).toBe(504);
   });
 
   it('returns zeros for 0 nights', () => {
@@ -59,8 +59,8 @@ describe('computeListingPricing @p0', () => {
   it('rounds to whole dollars', () => {
     const result = computeListingPricing(99, 5);
     expect(result.ownerPrice).toBe(495);
-    expect(result.ravMarkup).toBe(74); // round(495 * 0.15) = round(74.25) = 74
-    expect(result.finalPrice).toBe(569);
+    expect(result.ravMarkup).toBe(59); // round(495 * 0.12) = round(59.4) = 59
+    expect(result.finalPrice).toBe(554);
   });
 });
 
@@ -68,18 +68,18 @@ describe('computeFeeBreakdown @p0', () => {
   it('computes correct breakdown for $200/night x 7 nights, no cleaning fee', () => {
     const result = computeFeeBreakdown(200, 7);
     expect(result.baseAmount).toBe(1400);
-    expect(result.serviceFee).toBe(210); // round(1400 * 0.15)
+    expect(result.serviceFee).toBe(168); // round(1400 * 0.12)
     expect(result.cleaningFee).toBe(0);
-    expect(result.subtotal).toBe(1610); // 1400 + 210 + 0
+    expect(result.subtotal).toBe(1568); // 1400 + 168 + 0
     expect(result.ownerPayout).toBe(1400); // 1400 + 0
   });
 
   it('includes cleaning fee in subtotal and owner payout', () => {
     const result = computeFeeBreakdown(200, 7, 150);
     expect(result.baseAmount).toBe(1400);
-    expect(result.serviceFee).toBe(210);
+    expect(result.serviceFee).toBe(168);
     expect(result.cleaningFee).toBe(150);
-    expect(result.subtotal).toBe(1760); // 1400 + 210 + 150
+    expect(result.subtotal).toBe(1718); // 1400 + 168 + 150
     expect(result.ownerPayout).toBe(1550); // 1400 + 150
   });
 
@@ -111,15 +111,15 @@ describe('computeFeeBreakdown @p0', () => {
   it('rounds base amount to whole dollars', () => {
     const result = computeFeeBreakdown(99, 3);
     expect(result.baseAmount).toBe(297);
-    expect(result.serviceFee).toBe(45); // round(297 * 0.15) = round(44.55) = 45
-    expect(result.subtotal).toBe(342);
+    expect(result.serviceFee).toBe(36); // round(297 * 0.12) = round(35.64) = 36
+    expect(result.subtotal).toBe(333);
   });
 
-  it('service fee is 15% of base (not base + cleaning)', () => {
+  it('service fee is 12% of base (not base + cleaning)', () => {
     const result = computeFeeBreakdown(100, 1, 500);
     expect(result.baseAmount).toBe(100);
-    expect(result.serviceFee).toBe(15); // 15% of 100, NOT 15% of 600
-    expect(result.subtotal).toBe(615); // 100 + 15 + 500
+    expect(result.serviceFee).toBe(12); // 12% of 100, NOT 12% of 600
+    expect(result.subtotal).toBe(612); // 100 + 12 + 500
     expect(result.ownerPayout).toBe(600); // 100 + 500
   });
 


### PR DESCRIPTION
## Summary

Decision made in 2026-05-11 session: platform commission **15% → 12%**. To prevent the Business tier from going to an aggressively-low 7% effective rate (12% - 5%), the Business discount is also tightened from 5pp → 4pp, keeping Business at 8% effective.

| Tier | Before | After |
|---|---|---|
| Free | 15% | **12%** (above Koala 10%, below RedWeek 15-20%) |
| Pro | 13% | **10%** (matches Koala baseline) |
| Business | 10% | **8%** (rewards high-volume; sustainable margin) |

## Why this works architecturally

Single-file edit, thanks to #510 (central commission config). One change in `src/config/commission.ts` flows to:

- Live booking commission via `src/lib/pricing.ts` → `RAV_MARKUP_RATE`
- Financial model defaults via `src/lib/financial-model/data.ts` (PLATFORM rows)
- Excel generator via the re-export shim in `scripts/financial-model/data.ts`

If the rate ever changes again (10%? 11%? promo-driven dip?), one edit handles everything.

## What's NOT in this PR (separate follow-ups)

- **DEC entry** in `docs/PROJECT-HUB.md` Key Decisions Log
- **BRAND-LOCK.md § 5** numerical claims registry — currently says 15%
- **`docs/RAV-PRICING-TAXES-ACCOUNTING.md`** — prose mentions 15% throughout
- **Runtime DB read** (#510 full scope) — `system_settings.platform_commission_rate`

Each is a small focused PR. This PR is the code-level change only.

## Test plan

- [x] `src/lib/pricing.test.ts` — all 27 tests pass (values updated for 12% math)
- [x] `npm run build` — Vite production build clean
- [x] `npm run financials:build` — xlsx INPUTS Section A shows `0.12 / 0.02 / 0.04`
- [ ] User to verify visually on `dev.rent-a-vacation.com/executive-dashboard/financial-model` once deployed — commission rate cards should show Free 12% / Pro 10% / Business 8%

🤖 Generated with [Claude Code](https://claude.com/claude-code)