### PR TITLE
fix(executive): dashboard tabs more prominent — filled active pill on banded background

### DIFF
--- a/src/components/executive/DashboardTabs.tsx
+++ b/src/components/executive/DashboardTabs.tsx
@@ -5,8 +5,10 @@ import { TrendingUp, BarChart3 } from 'lucide-react';
  * Top-of-page tab navigation shared between the Executive Dashboard
  * (live metrics) and the Financial Model (24-month forecast).
  *
+ * Visual style: distinct horizontal band with filled active state.
+ * Reads as a secondary header rather than a subtle underline.
  * Active tab is determined from `useLocation()` so the same component
- * works on both routes without props. Clicking a tab navigates client-side.
+ * works on both routes without props.
  */
 
 const TABS = [
@@ -38,9 +40,12 @@ export function DashboardTabs() {
         : 'live';
 
   return (
-    <nav className="border-b border-slate-700/50 bg-slate-900/50 backdrop-blur" aria-label="Dashboard sections">
+    <nav
+      className="border-y border-slate-700 bg-slate-800 shadow-md"
+      aria-label="Dashboard sections"
+    >
       <div className="container mx-auto px-6">
-        <div className="flex items-center gap-1">
+        <div className="flex items-center gap-2 py-3">
           {TABS.map((tab) => {
             const isActive = tab.id === activeTab;
             const Icon = tab.icon;
@@ -48,16 +53,20 @@ export function DashboardTabs() {
               <Link
                 key={tab.id}
                 to={tab.href}
-                className={`group relative flex items-center gap-2 px-4 py-3 text-sm font-medium transition border-b-2 -mb-px ${
-                  isActive
-                    ? 'border-teal-400 text-white'
-                    : 'border-transparent text-slate-400 hover:text-slate-200 hover:border-slate-600'
-                }`}
                 aria-current={isActive ? 'page' : undefined}
+                className={`group inline-flex items-center gap-2.5 rounded-md px-5 py-3 text-base font-semibold transition-all ${
+                  isActive
+                    ? 'bg-teal-600 text-white shadow-lg shadow-teal-600/30 ring-1 ring-teal-400/40'
+                    : 'text-slate-300 hover:bg-slate-700 hover:text-white'
+                }`}
               >
-                <Icon className={`h-4 w-4 ${isActive ? 'text-teal-300' : 'text-slate-500 group-hover:text-slate-300'}`} />
+                <Icon className={`h-5 w-5 ${isActive ? 'text-white' : 'text-slate-400 group-hover:text-slate-200'}`} />
                 <span>{tab.label}</span>
-                <span className="hidden md:inline text-xs font-normal text-slate-500 ml-1">
+                <span
+                  className={`hidden lg:inline text-xs font-normal ml-1.5 ${
+                    isActive ? 'text-teal-50/90' : 'text-slate-500 group-hover:text-slate-400'
+                  }`}
+                >
                   · {tab.description}
                 </span>
               </Link>


### PR DESCRIPTION
## Summary

User feedback on the previous tab design (screenshot 2026-05-11 210541): the tabs were "very unimpressive" — too subtle. The active state didn't stand out from inactive tabs, and the whole nav blended into the page background.

## Redesign

Now reads as a secondary header strip:

| Element | Before | After |
|---|---|---|
| Tab bar background | Transparent (page bg) | `bg-slate-800` — distinct banded strip with top + bottom borders |
| Active tab | Text-only with thin teal border-bottom | **Filled teal pill (`bg-teal-600`)** with white text, shadow, and subtle teal ring |
| Inactive tab | Subtle gray text | Hover-responsive: gray text → bg-slate-700 + white text on hover |
| Typography | `text-sm` regular | **`text-base font-semibold`** |
| Icons | `h-4 w-4` | **`h-5 w-5`** |
| Description text | Inline, muted | Hidden below lg breakpoint; tinted to match state above lg |
| Padding | `py-3` | **`px-5 py-3`** per tab — bigger click targets |

## No behavior change

- Same routes
- Same auth gating
- Same `useLocation()`-based active detection
- Component API unchanged

## Test plan

- [x] `npm run build` clean
- [ ] User to verify on `dev.rent-a-vacation.com` once deployed — active tab should be clearly visible (filled teal pill), and the whole tab bar should feel like a section header rather than a footnote

🤖 Generated with [Claude Code](https://claude.com/claude-code)