### PR TITLE
release: dev → main — commission 12% + prominent dashboard tabs

### DIFF
--- a/src/components/admin/AdminListingEditDialog.test.tsx
+++ b/src/components/admin/AdminListingEditDialog.test.tsx
@@ -121,9 +121,9 @@ describe("AdminListingEditDialog", () => {
         onSaved={vi.fn()}
       />
     );
-    // 7 nights × $200 = $1400 owner, $210 markup, $1610 total
+    // 7 nights × $200 = $1400 owner, $168 markup at 12% commission, $1568 total
     expect(screen.getByText("7 nights × $200/night")).toBeInTheDocument();
-    expect(screen.getByText("$1,610")).toBeInTheDocument();
+    expect(screen.getByText("$1,568")).toBeInTheDocument();
   });
 
   it("disables form for booked listings", () => {

--- a/src/components/executive/DashboardTabs.tsx
+++ b/src/components/executive/DashboardTabs.tsx
@@ -5,8 +5,10 @@ import { TrendingUp, BarChart3 } from 'lucide-react';
  * Top-of-page tab navigation shared between the Executive Dashboard
  * (live metrics) and the Financial Model (24-month forecast).
  *
+ * Visual style: distinct horizontal band with filled active state.
+ * Reads as a secondary header rather than a subtle underline.
  * Active tab is determined from `useLocation()` so the same component
- * works on both routes without props. Clicking a tab navigates client-side.
+ * works on both routes without props.
  */
 
 const TABS = [
@@ -38,9 +40,12 @@ export function DashboardTabs() {
         : 'live';
 
   return (
-    <nav className="border-b border-slate-700/50 bg-slate-900/50 backdrop-blur" aria-label="Dashboard sections">
+    <nav
+      className="border-y border-slate-700 bg-slate-800 shadow-md"
+      aria-label="Dashboard sections"
+    >
       <div className="container mx-auto px-6">
-        <div className="flex items-center gap-1">
+        <div className="flex items-center gap-2 py-3">
           {TABS.map((tab) => {
             const isActive = tab.id === activeTab;
             const Icon = tab.icon;
@@ -48,16 +53,20 @@ export function DashboardTabs() {
               <Link
                 key={tab.id}
                 to={tab.href}
-                className={`group relative flex items-center gap-2 px-4 py-3 text-sm font-medium transition border-b-2 -mb-px ${
-                  isActive
-                    ? 'border-teal-400 text-white'
-                    : 'border-transparent text-slate-400 hover:text-slate-200 hover:border-slate-600'
-                }`}
                 aria-current={isActive ? 'page' : undefined}
+                className={`group inline-flex items-center gap-2.5 rounded-md px-5 py-3 text-base font-semibold transition-all ${
+                  isActive
+                    ? 'bg-teal-600 text-white shadow-lg shadow-teal-600/30 ring-1 ring-teal-400/40'
+                    : 'text-slate-300 hover:bg-slate-700 hover:text-white'
+                }`}
               >
-                <Icon className={`h-4 w-4 ${isActive ? 'text-teal-300' : 'text-slate-500 group-hover:text-slate-300'}`} />
+                <Icon className={`h-5 w-5 ${isActive ? 'text-white' : 'text-slate-400 group-hover:text-slate-200'}`} />
                 <span>{tab.label}</span>
-                <span className="hidden md:inline text-xs font-normal text-slate-500 ml-1">
+                <span
+                  className={`hidden lg:inline text-xs font-normal ml-1.5 ${
+                    isActive ? 'text-teal-50/90' : 'text-slate-500 group-hover:text-slate-400'
+                  }`}
+                >
                   · {tab.description}
                 </span>
               </Link>

--- a/src/config/commission.ts
+++ b/src/config/commission.ts
@@ -19,23 +19,33 @@ export const DEFAULT_COMMISSION = {
   /**
    * Base commission rate charged on the booking subtotal.
    * RAV keeps this % of every booking; the rest is owner payout.
-   * 0.15 = 15%.
+   * 0.12 = 12%.
+   *
+   * Set to 12% (was 15%) after competitor analysis on 2026-05-11:
+   *   - RedWeek "Verified Rental" charges 15-20% — high-service tier
+   *   - Koala charges 10% — lighter-feature competitor
+   *   - 12% positions RAV as "premium over Koala, below RedWeek"
+   *     justified by extra service stack (escrow + AI + bid mechanics)
    */
-  base: 0.15,
+  base: 0.12,
 
   /**
    * Discount applied to the base rate for Owner Pro tier subscribers.
    * Effective rate = base - proDiscount.
-   * 0.02 = 2 percentage points off (e.g., 15% base → 13% effective).
+   * 0.02 = 2 percentage points off → 10% effective (matches Koala baseline).
    */
   proDiscount: 0.02,
 
   /**
    * Discount applied to the base rate for Owner Business tier subscribers.
    * Effective rate = base - businessDiscount.
-   * 0.05 = 5 percentage points off (e.g., 15% base → 10% effective).
+   * 0.04 = 4 percentage points off → 8% effective.
+   *
+   * Tightened from 5% (which would give 7% effective at 12% base — below
+   * Koala and aggressively low). 8% is still competitive for high-volume
+   * owners while preserving margin.
    */
-  businessDiscount: 0.05,
+  businessDiscount: 0.04,
 } as const;
 
 /**

--- a/src/lib/pricing.test.ts
+++ b/src/lib/pricing.test.ts
@@ -31,15 +31,15 @@ describe('computeListingPricing @p0', () => {
   it('computes correct pricing for $200/night x 7 nights', () => {
     const result = computeListingPricing(200, 7);
     expect(result.ownerPrice).toBe(1400);
-    expect(result.ravMarkup).toBe(210);
-    expect(result.finalPrice).toBe(1610);
+    expect(result.ravMarkup).toBe(168); // round(1400 * 0.12) = 168
+    expect(result.finalPrice).toBe(1568);
   });
 
   it('computes correct pricing for $150/night x 3 nights', () => {
     const result = computeListingPricing(150, 3);
     expect(result.ownerPrice).toBe(450);
-    expect(result.ravMarkup).toBe(68); // round(450 * 0.15) = round(67.5) = 68
-    expect(result.finalPrice).toBe(518);
+    expect(result.ravMarkup).toBe(54); // round(450 * 0.12) = 54
+    expect(result.finalPrice).toBe(504);
   });
 
   it('returns zeros for 0 nights', () => {
@@ -59,8 +59,8 @@ describe('computeListingPricing @p0', () => {
   it('rounds to whole dollars', () => {
     const result = computeListingPricing(99, 5);
     expect(result.ownerPrice).toBe(495);
-    expect(result.ravMarkup).toBe(74); // round(495 * 0.15) = round(74.25) = 74
-    expect(result.finalPrice).toBe(569);
+    expect(result.ravMarkup).toBe(59); // round(495 * 0.12) = round(59.4) = 59
+    expect(result.finalPrice).toBe(554);
   });
 });
 
@@ -68,18 +68,18 @@ describe('computeFeeBreakdown @p0', () => {
   it('computes correct breakdown for $200/night x 7 nights, no cleaning fee', () => {
     const result = computeFeeBreakdown(200, 7);
     expect(result.baseAmount).toBe(1400);
-    expect(result.serviceFee).toBe(210); // round(1400 * 0.15)
+    expect(result.serviceFee).toBe(168); // round(1400 * 0.12)
     expect(result.cleaningFee).toBe(0);
-    expect(result.subtotal).toBe(1610); // 1400 + 210 + 0
+    expect(result.subtotal).toBe(1568); // 1400 + 168 + 0
     expect(result.ownerPayout).toBe(1400); // 1400 + 0
   });
 
   it('includes cleaning fee in subtotal and owner payout', () => {
     const result = computeFeeBreakdown(200, 7, 150);
     expect(result.baseAmount).toBe(1400);
-    expect(result.serviceFee).toBe(210);
+    expect(result.serviceFee).toBe(168);
     expect(result.cleaningFee).toBe(150);
-    expect(result.subtotal).toBe(1760); // 1400 + 210 + 150
+    expect(result.subtotal).toBe(1718); // 1400 + 168 + 150
     expect(result.ownerPayout).toBe(1550); // 1400 + 150
   });
 
@@ -111,15 +111,15 @@ describe('computeFeeBreakdown @p0', () => {
   it('rounds base amount to whole dollars', () => {
     const result = computeFeeBreakdown(99, 3);
     expect(result.baseAmount).toBe(297);
-    expect(result.serviceFee).toBe(45); // round(297 * 0.15) = round(44.55) = 45
-    expect(result.subtotal).toBe(342);
+    expect(result.serviceFee).toBe(36); // round(297 * 0.12) = round(35.64) = 36
+    expect(result.subtotal).toBe(333);
   });
 
-  it('service fee is 15% of base (not base + cleaning)', () => {
+  it('service fee is 12% of base (not base + cleaning)', () => {
     const result = computeFeeBreakdown(100, 1, 500);
     expect(result.baseAmount).toBe(100);
-    expect(result.serviceFee).toBe(15); // 15% of 100, NOT 15% of 600
-    expect(result.subtotal).toBe(615); // 100 + 15 + 500
+    expect(result.serviceFee).toBe(12); // 12% of 100, NOT 12% of 600
+    expect(result.subtotal).toBe(612); // 100 + 12 + 500
     expect(result.ownerPayout).toBe(600); // 100 + 500
   });
 


### PR DESCRIPTION
## Release rollup

Two PRs since the last main release, both ready for production:

| PR | Commit | Change |
|---|---|---|
| #514 | `86e178d` | Platform commission **15% → 12%** (Business discount 5% → 4%) — competitor-anchored repositioning |
| #515 | `df9cbdb` | Dashboard tabs redesigned — filled teal pill on banded background, bigger typography |

### Commission change details

Effective rates after this release:

| Tier | Before | After |
|---|---|---|
| Free Owner | 15% | **12%** |
| Pro Owner | 13% | **10%** |
| Business Owner | 10% | **8%** |

Lives in `src/config/commission.ts` — single source of truth via #510 MVP. Live booking pricing (`src/lib/pricing.ts`) and the financial model (`src/lib/financial-model/data.ts`) both pick up the new rates automatically.

### Tabs visibility

Active tab is now a clearly-visible filled teal pill on a distinct banded background. The previous subtle underline style felt "unimpressive" per user feedback.

### Outstanding work after this release (not in this PR)

- DEC entry in PROJECT-HUB for the commission rate change
- BRAND-LOCK.md § 5 numerical claims update (15% → 12%)
- `docs/RAV-PRICING-TAXES-ACCOUNTING.md` prose updates
- Stage 2b (live actuals overlay)
- #509 (promotional discount feature)
- #510 full scope (DB-driven runtime rate + admin UI)

Each is its own focused PR.

### Test plan

- [x] CI green on #514 and #515 individually
- [x] Vercel preview deploy verified at dev.rent-a-vacation.com
- [ ] Production deploy verified at rent-a-vacation.com (will check post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)