### PR TITLE
fix(test): AdminListingEditDialog stale 15% price assertion → 12%

### DIFF
--- a/src/components/admin/AdminListingEditDialog.test.tsx
+++ b/src/components/admin/AdminListingEditDialog.test.tsx
@@ -121,9 +121,9 @@ describe("AdminListingEditDialog", () => {
         onSaved={vi.fn()}
       />
     );
-    // 7 nights × $200 = $1400 owner, $210 markup, $1610 total
+    // 7 nights × $200 = $1400 owner, $168 markup at 12% commission, $1568 total
     expect(screen.getByText("7 nights × $200/night")).toBeInTheDocument();
-    expect(screen.getByText("$1,610")).toBeInTheDocument();
+    expect(screen.getByText("$1,568")).toBeInTheDocument();
   });
 
   it("disables form for booked listings", () => {


### PR DESCRIPTION
## Problem

PR #516 (dev → main release rollup) failed CI on one test:

\`\`\`
src/components/admin/AdminListingEditDialog.test.tsx:126
  expect(screen.getByText("\$1,610")).toBeInTheDocument();
\`\`\`

That \$1,610 was the OLD total at 15% commission ($1,400 + $210). With #514's commission change (15% → 12%), \`computeListingPricing(200, 7)\` now returns \`{ ownerPrice: 1400, ravMarkup: 168, finalPrice: 1568 }\` — so the rendered text is \$1,568, not \$1,610.

PR #514 updated \`src/lib/pricing.test.ts\` but missed this cascading consumer test. CI on #514 passed because the failing test only became visible when the actual component rendered with the new rate via the dev branch.

## Fix

One-line change to the expected value and comment. All 1663 tests pass locally on dev.

## After this merges

I'll reopen / regenerate the dev → main release PR (#516 or new) — it should pass CI cleanly with this fix included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)