### PR TITLE
docs(session-65): handoff + DEC-041 (commission 12%) + DEC-042 (financial-model web tool)

### DIFF
--- a/docs/LAUNCH-READINESS.md
+++ b/docs/LAUNCH-READINESS.md
@@ -1,7 +1,7 @@
 ---
-last_updated: "2026-04-25T06:41:23"
-change_ref: "2dd6116"
-change_type: "session-63"
+last_updated: "2026-05-12T02:00:00"
+change_ref: "025404c"
+change_type: "session-65"
 status: "active"
 ---
 # Launch Readiness Checklist

--- a/docs/PRIORITY-ROADMAP.md
+++ b/docs/PRIORITY-ROADMAP.md
@@ -1,7 +1,7 @@
 ---
-last_updated: "2026-04-28T10:04:52"
-change_ref: "dfba76b"
-change_type: "session-64"
+last_updated: "2026-05-12T01:55:00"
+change_ref: "025404c"
+change_type: "session-65"
 status: "active"
 ---
 # PRIORITY ROADMAP — Rent-A-Vacation
@@ -48,15 +48,24 @@ When `/sdlc pickup` runs next, the user has explicitly scoped the next session a
 
 **Also consider after those:** A controlled PROD deploy window for the accumulated Phase 22 + Session 59 changes (migrations 060–065, text-chat updates with support context + 5 tools + classifier, ingest-support-docs + cancel-listing edge fns, support_conversations + listing-proofs + dispute_source schemas). All currently sit on DEV per CLAUDE.md human-confirmation rule.
 
-## Current Priority Tiers (as of May 6, 2026 — Session 64)
+## Current Priority Tiers (as of May 11-12, 2026 — Session 65)
 
 ### Tier A: Build Next (High Impact, Code-Ready)
 
-_Empty after Session 60. #371 + #442 + #445 all shipped (PRs #441, #446). All edge-fn harness work either complete or properly deferred (see Tier E for #443/#444)._
+**Session 65 close — Financial Model + Phase 2 Stage 2a shipped. Three next-up items confirmed with user (see Session 65 Pickup section below):**
 
-> **Phase 22 epic (#395) — COMPLETE (22/22 tickets).** Session 58 closed out C1+C4+C2+C5+C3+D1+D2 across 6 PRs (#428-#433). Session 59 cleared all remaining Tier A pre-launch marketplace items (#376 proof workflow, #378 Open-for-Offers, #381 Action Needed dashboards, #377 cancel-listing cascade, #393 PLATFORM-INVENTORY). Session 60 closed #371 (edge-fn test harness, DEC-037), #442 (Stripe Connect tests), #445 (vitest coverage extension).
->
-> Next pickup is **#438 (incorporation docs starter kit)** — see Tier B.
+1. **#510 full scope** — Complete the central-commission-config refactor: DB runtime read (`system_settings.platform_commission_rate` via `useSystemSettings` hook), admin UI for changing the rate with audit log, async pricing-function refactor. ~1-2 days. **Blocks #509.**
+2. **Phase 2 Stage 2b** — Live actuals overlay on `/executive-dashboard/financial-model`. Pull real user counts + bookings + revenue from Supabase. Show "actuals (Mo 1-N)" alongside forecast. ~3-5 days. Independent.
+3. **#509** — Promotional commission rate overrides (launch specials, seasonal campaigns, owner-tier promos). DB schema + admin UI + commission resolution chain + booking audit fields. ~1-2 weeks. **Builds on #510 full.**
+
+### Session 65 Pickup (confirmed with user end of Session 65)
+
+User confirmed at session close:
+- Commission rate locked at **12%** per DEC-041 (was status quo 15%)
+- Outstanding doc-only updates (deferred, not blocking): BRAND-LOCK.md § 5 (15% → 12%), `docs/RAV-PRICING-TAXES-ACCOUNTING.md` prose updates
+- A pre-existing git stash on local dev contains another session's MLA Notice + military profile work-in-progress (`supabase/migrations/076_profiles_active_duty_military.sql` + `src/components/legal/MLANotice*` + Checkout/Signup/Terms updates). Preserved via stash; user to decide whether to pop or drop on return.
+
+Work order on resume: **#510 full → Stage 2b → #509** (respects the #510 → #509 dependency).
 
 ### Tier B: Pre-Launch Important (Needs Human Input)
 

--- a/docs/PROJECT-HUB.md
+++ b/docs/PROJECT-HUB.md
@@ -1,7 +1,7 @@
 ---
-last_updated: "2026-05-01T02:17:14"
-change_ref: "8a06e90"
-change_type: "session-64"
+last_updated: "2026-05-12T01:50:00"
+change_ref: "025404c"
+change_type: "session-65"
 status: "active"
 ---
 # PROJECT HUB - Rent-A-Vacation
@@ -9,7 +9,7 @@ status: "active"
 > **Architectural decisions, session context, and agent instructions**
 > **Task tracking has moved to [GitHub Issues & Milestones](https://github.com/rent-a-vacation/rav-website/issues)**
 > **Project board: [RAV Roadmap](https://github.com/orgs/rent-a-vacation/projects/1)**
-> **Last Updated:** May 6, 2026 (Session 64: DEC-040 — sequential Phase numbering retired; new work uses themed milestones)
+> **Last Updated:** May 11-12, 2026 (Session 65: Financial Model Excel + Phase 2 Stage 2a web tool + commission rate to 12%)
 > **Repository:** https://github.com/rent-a-vacation/rav-website
 > **App Version:** v0.9.0 (build version visible in footer)
 
@@ -93,7 +93,7 @@ gh issue create --repo rent-a-vacation/rav-website --title "..." --label "..." -
 - Edge functions require `--no-verify-jwt` deployment flag
 
 ### Platform Status
-- **1492 automated tests** (157 test files, all passing), 0 type errors, 0 lint errors, build clean
+- **1669 automated tests** (169 test files, all passing), 0 type errors, 0 lint errors, build clean
 - **P0 tests:** 220+ tagged `@p0` — run with `npm run test:p0`
 - **CI reporting:** GitHub native via dorny/test-reporter (JUnit XML) — PR annotations on every run (Qase removed Mar 2026)
 - **Migrations created:** 001-072 (001-059 deployed to DEV + PROD; 060-072 deployed to DEV only — PROD held per CLAUDE.md) + 3 date-based MDM migrations
@@ -103,10 +103,51 @@ gh issue create --repo rent-a-vacation/rav-website --title "..." --label "..." -
 - **Marketplace flow distinction (DEC-034):** `listings.source_type` + `bookings.source_type` + `bookings.travel_proposal_id` live. Pre-Booked Stay = instant confirm; Wish-Matched Stay = owner-confirmation required. Implemented via #380 Phases 1–5 (PRs #385–#389).
 - **PROD platform:** locked (Staff Only Mode enabled)
 - **Supabase CLI:** currently linked to DEV
-- **dev and main:** Session 63 8-PR sweep (PR #474) sits on `dev` awaiting `dev → main` merge (1492 tests, 7 new migrations, 3 new edge fns, 1 refactored).
+- **dev and main:** In sync as of Session 65 close (PR #516 dev→main merged 2026-05-12). Latest release: financial model TS port + Phase 2 Stage 2a + commission rate 12%.
 - **GitHub Project:** RAV Roadmap — 202 issues, all with Status/Category/Sub-Category/Type populated. Auto-add workflow enabled. PRs excluded.
 
-### Session Handoff (Sessions 25-64)
+### Session Handoff (Sessions 25-65)
+
+**Session 65 — Financial Model TS port + Phase 2 Stage 2a web tool + commission rate 12% (May 11-12, 2026):**
+
+Long working session covering the full financial-model arc: Excel generator overhaul, then a parallel web-app surface that consumes the same data.
+
+**Financial Model Excel — Phase 1a + 1b (PRs #501–#507):**
+1. **#501** Phase 1a — ported the Google Apps Script .gs generator to TypeScript + exceljs. `scripts/financial-model/` now produces `docs/financials/RAV_Financial_Model_YYYY-MM-DD_HHMM.xlsx` via `npm run financials:build`. Removed the Google Apps Script round-trip. 7 tabs: Cover / INPUTS / EXPENSES / REVENUE MODEL / BREAK-EVEN / FUNDING ASK / INSTRUCTIONS. .xlsx is gitignored (confidential).
+2. **#502** Phase 1b polish — 2 new tabs (UNIT ECON: LTV/CAC/Payback; SENSITIVITY: ±20% on 3 drivers) + REVENUE MODEL additions: cohort booking ramp, voice overage revenue line, hiring plan with burdened costs. INPUTS Sections G (Hiring) + H (Unit Econ & Ramp).
+3. **#503 / #504 / #505** Bug-fix cascade — circular-ref Funding Ask formulas (D7/D8 referencing label cells), consistent SUMIFS for all 5 Use-of-Funds categories, seed users injected at launch month (model previously returned 0 for any gLaunchMo > 1), recurring costs missing from per-month column (SUMPRODUCT inner-IF didn't work without dynamic arrays), break-even MATCH false-negative, freeze pane extended to row 8.
+4. **#506 / #507** Hover-notes layer — 133 → 110 cell hover-notes across calculated tabs (removed duplicative ones per user feedback principle "don't copy nearby cell content"). Enlarged comment box from default 97.8×59.1pt to 280×140pt (monkey-patched exceljs internals). Calibri 10pt RAV navy font. UNIT ECON metrics show "Calculation: ... / In plain terms: ..." dual format.
+
+**Central commission config — #510 MVP (PR #508, merged with Guest Protection):**
+- `src/config/commission.ts` is now the single source of truth for base rate + tier discounts. `src/lib/pricing.ts` and `src/lib/financial-model/data.ts` both import from it. Editing one file flows to live booking pricing AND the financial model. Full DEC-driven runtime read (system_settings.platform_commission_rate via useSystemSettings hook) is the remaining scope of #510.
+
+**Phase 2 Stage 2a — financial-model web tool (PRs #511, #512, #515, #517):**
+- New route **`/executive-dashboard/financial-model`** (RAV team auth-gated). Distinct from `/executive-dashboard` (live metrics). "Forward Projection — Not Live Data" banner enforces the differentiation.
+- New shared `DashboardTabs` component at top of both pages — Live Metrics ↔ Financial Model. Final design: filled teal pill on banded slate-800 background (after iteration on visibility feedback).
+- Pure-TS calc engine at `src/lib/financial-model/calc.ts` mirroring all .xlsx formulas. Inputs: scenario (Conservative/Base/Optimistic). Outputs: 24 monthly rows + aggregates + break-even month.
+- Data file moved to `src/lib/financial-model/data.ts`; `scripts/financial-model/data.ts` is now a re-export shim. ONE data source consumed by both Node-side Excel generator and Vite-side React UI.
+
+**Commission rate decision — 15% → 12% (PR #514):**
+Competitor anchoring: RedWeek Verified Rental 15-20%, Koala 10%. 12% positions RAV "premium over Koala, below RedWeek" justifiable by extra service stack (escrow + AI + bid mechanics). Business discount tightened from 5% → 4% to prevent the highest-volume tier going to an unsustainable 7%. Effective rates: Free **12%**, Pro **10%**, Business **8%**. **DEC-041 logged.**
+
+**Issues filed for follow-up:**
+- **#509** Promotional commission rate overrides — launch specials, seasonal campaigns, owner-tier promos. Pre-launch necessity per user. Needs DB schema + admin UI + commission resolution chain + booking audit fields.
+- **#510** Centralize commission rate config — MVP done (above). Full scope (DB runtime read + admin UI + audit log) is pending.
+
+**Next-Session pickup (user confirmed at session close):**
+1. **#510 full scope** — DB-driven runtime rate, admin UI, audit log (blocks #509)
+2. **Phase 2 Stage 2b** — live actuals overlay on financial model dashboard
+3. **#509** — promotional discount feature
+
+Workflow correction at session close: I'd routed early PRs feature → main directly (bypassed dev). User flagged this; remainder of session followed feature → dev → main correctly. Going forward: all feature branches → dev → main per CLAUDE.md branching strategy.
+
+**Outstanding doc updates (deferred, not blocking):**
+- BRAND-LOCK.md § 5 — "15% commission" → "12%" prose
+- `docs/RAV-PRICING-TAXES-ACCOUNTING.md` — multiple mentions of 15% to update
+
+**Platform delta:** 1492 → 1669 tests (177 new across financial-model + Phase 2 + commission + Guest Protection from parallel session). No new migrations from this session. Two new edge functions from parallel work (auto-confirm-checkins, sla-monitor from Session 63 continuation; confirm-checkin, process-escrow-release split). Single source: `src/config/commission.ts`.
+
+---
 
 **Session 64 — Phase numbering retired; themed milestones formalized (May 6, 2026):**
 
@@ -1092,6 +1133,63 @@ Three workstreams shipped plus Phase 21 DoD cleanup. All backed by GitHub issues
 - #190 — Webhook delivery to partners (event notifications)
 - #191 — Chat endpoint (`/v1/chat`) via gateway
 - #192 — SDK packages for partners (npm, Python)
+
+---
+
+### DEC-042: Financial Model as Distinct Web Tool from Executive Dashboard
+**Date:** May 11-12, 2026 (Session 65)
+**Decision:** The **Financial Model** (24-month forward projection) lives at `/executive-dashboard/financial-model` as a separate page distinct from the **Executive Dashboard** (`/executive-dashboard`, real-time business metrics). Per DEC-014, Executive Dashboard is already a standalone page (not an admin tab); the Financial Model is positioned as its sibling. Both are auth-gated to RAV team only. A shared `DashboardTabs` component navigates between the two — they share top-level chrome but render distinct content.
+
+**Distinction enforced visually:**
+- Executive Dashboard: live Supabase queries, HeadlineBar, real-time KPIs
+- Financial Model: "Forward Projection — Not Live Data" amber banner, scenario toggle (Conservative/Base/Optimistic), forecast-only KPI cards
+- Cells/numbers on one page never duplicate those on the other; the Financial Model can consume Executive Dashboard actuals as a future overlay (Stage 2b), but they never overlap as redundant copies
+
+**Architecture:**
+- `src/lib/financial-model/data.ts` — single source of truth for all model inputs (typed); used by both the Node-side Excel generator (`scripts/financial-model/`) and the React UI (`src/pages/FinancialModelDashboard.tsx`)
+- `src/lib/financial-model/calc.ts` — pure-TS port of every .xlsx formula; same scenarios produce same numbers as the .xlsx
+- `npm run financials:build` produces the .xlsx artifact for sharing; the React UI provides instant-view access without leaving the browser
+
+**Rationale:**
+1. **Live vs forecast are different mental models.** Conflating them in one page risks an investor or co-founder mistaking a forecast for reality (or vice versa). The distinct banner + route eliminates that risk.
+2. **Single source of truth scales.** Both the Excel artifact and the web UI consume the same `data.ts`. Edit it once, both update. Prevents the drift that plagued the Apps Script → Excel → docs reality before Phase 1a.
+3. **Phased delivery.** Stage 2a (this session) is view-only. Stage 2b adds live actuals overlay (forecast vs reality side-by-side). Stage 2c adds interactive input editing + scenario save/load in Supabase. Stage 2d adds recharts + PDF export. Each is a shippable PR.
+
+**Status:** Active. Supersedes the earlier "rebuild it as a tab inside ExecutiveDashboard" framing — implemented as separate child route with shared tabs instead.
+
+---
+
+### DEC-041: Platform Commission Rate Repositioned to 12% (was 15%); Tier Discounts Recalibrated
+**Date:** May 11-12, 2026 (Session 65, PR #514)
+**Decision:** The base platform commission rate is changed from **15% to 12%**. Tier discounts are recalibrated accordingly so the highest-volume Business tier doesn't drop to an aggressive 7%:
+
+| Tier | Effective rate before | Effective rate after |
+|------|------------------------|------------------------|
+| Free Owner | 15% | **12%** |
+| Pro Owner ($10/mo) | 13% (15% − 2pp) | **10%** (12% − 2pp) |
+| Business Owner ($25/mo) | 10% (15% − 5pp) | **8%** (12% − 4pp) — business discount tightened 5pp → 4pp |
+
+**Rationale — competitor anchoring:**
+- **RedWeek "Verified Rental"** charges 15-20% to owners — RAV's most direct full-service competitor
+- **Koala** charges 10% to owners — lighter-feature competitor, RAV beats on escrow + AI + bid mechanics
+- **12% positions RAV as "premium over Koala, below RedWeek"** — defensible by the extra service stack
+- 10% would match Koala exactly, removing price as friction but failing to capture RAV's incremental service value
+- 15% was harder to explain in head-to-head: travelers/owners see "+50% over Koala" before they hear about extra features
+
+**Why 4pp Business discount (not 5pp):**
+- At 12% base, 5pp discount → Business effective 7% — materially below Koala (10%) for no clear strategic gain. Hard to walk back if market doesn't reward it.
+- 8% still rewards high-volume Business owners while preserving sustainable RAV margin.
+
+**Implementation:**
+- One-file edit: `src/config/commission.ts` (single source of truth via DEC-041's prerequisite — central commission config, #510 MVP).
+- Live booking pricing (`src/lib/pricing.ts` → `RAV_MARKUP_RATE`) and the financial model (`src/lib/financial-model/data.ts` PLATFORM rows) both pull from the central config — no code drift possible.
+- Tests updated: `src/lib/pricing.test.ts` (4 hardcoded value assertions) + `src/components/admin/AdminListingEditDialog.test.tsx` (one rendered-text assertion). 1669/1669 pass.
+
+**Status:** Active. Replaces prior 15% rate locked in DEC-022 (Pricing, Tax & Accounting Framework). Outstanding doc updates: BRAND-LOCK.md § 5 numerical claims registry (still says 15%); `docs/RAV-PRICING-TAXES-ACCOUNTING.md` prose. Both pending separate doc-PR follow-up.
+
+**Modeled impact:**
+- At current scenario assumptions, dropping base 15% → 12% reduces 24-month Net Commission Revenue by roughly 20% (base scenario). Sensitivity tab on the financial model shows the full curve. Subscription + voice overage revenue unaffected.
+- The decision is anchored to long-term competitive positioning, not short-term forecast optimization. If the strategic positioning works, the modest revenue compression is recovered through faster owner acquisition.
 
 ---
 

--- a/docs/testing/TESTING-STATUS.md
+++ b/docs/testing/TESTING-STATUS.md
@@ -15,8 +15,8 @@ status: "active"
 
 | Metric | Value |
 |--------|-------|
-| **Total tests** | 1663 |
-| **Test files** | 171 |
+| **Total tests** | 1669 |
+| **Test files** | 169 |
 | **P0 critical-path tests** | 290+ tagged `@p0` (Session 64 added @p0 on disclaimer registry, DisclaimerBlock, StateSpecificDisclaimer, Footer registry sourcing, Terms 8.3+8.6, About page, placement audit) |
 | **E2E smoke tests** | 3 (Playwright) |
 | **Local run time** | ~2.5 min (full), ~2s (P0 only) |


### PR DESCRIPTION
## Summary

Session 65 close — doc-only PR so \`/sdlc status\` reads accurate state on next session start.

### Changes

| Doc | Update |
|---|---|
| PROJECT-HUB.md | Session 65 handoff entry, DEC-041 + DEC-042, Platform Status (1492→1669 tests, dev/main in sync), frontmatter session-65 |
| PRIORITY-ROADMAP.md | "as of Session 65" header, Tier A populated with #510 full → Stage 2b → #509 pickup order, noted git stash with parallel MLA work |
| TESTING-STATUS.md | 1663 → 1669 tests, 171 → 169 files |
| LAUNCH-READINESS.md | change_type session-63 → session-65 |

### Decisions documented

- **DEC-041**: Platform commission 15% → 12% (Business disc 5% → 4%, effective Free/Pro/Business: 12%/10%/8%). Competitor-anchored: above Koala (10%), below RedWeek (15-20%).
- **DEC-042**: Financial Model as distinct web tool from Executive Dashboard. Single source of truth in \`src/lib/financial-model/data.ts\` shared by both .xlsx generator and React UI. Shared DashboardTabs nav with "Forward Projection — Not Live Data" banner enforcing the distinction.

### Test plan

- [x] \`npm run docs:sync-check\` — 6/6 ok, 0 warn, 0 error
- [x] All four /sdlc-tracked docs aligned to session-65
- [ ] Next session: \`/sdlc status\` should show current platform state correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)