### PR TITLE
feat(compliance): #490 MLA notice + ToS arbitration carve-out

### DIFF
--- a/docs/testing/TESTING-STATUS.md
+++ b/docs/testing/TESTING-STATUS.md
@@ -7,7 +7,7 @@ status: "active"
 # Testing Status
 
 > Current state of the RAV test suite. Updated each session.
-> **Last Updated:** May 11, 2026 (Session 64 — compliance hardening: #483/#484/#485/#486/#488/#489 cumulative; +171 tests, +14 test files for the session)
+> **Last Updated:** May 11, 2026 (Session 64+65 — compliance hardening: #483/#484/#485/#486/#488/#489/#490 cumulative; +184 tests, +16 test files for the session)
 
 ---
 
@@ -15,8 +15,8 @@ status: "active"
 
 | Metric | Value |
 |--------|-------|
-| **Total tests** | 1669 |
-| **Test files** | 169 |
+| **Total tests** | 1676 |
+| **Test files** | 171 |
 | **P0 critical-path tests** | 290+ tagged `@p0` (Session 64 added @p0 on disclaimer registry, DisclaimerBlock, StateSpecificDisclaimer, Footer registry sourcing, Terms 8.3+8.6, About page, placement audit) |
 | **E2E smoke tests** | 3 (Playwright) |
 | **Local run time** | ~2.5 min (full), ~2s (P0 only) |

--- a/src/components/legal/MLANotice.test.tsx
+++ b/src/components/legal/MLANotice.test.tsx
@@ -1,0 +1,43 @@
+// @vitest-environment jsdom
+// @p0
+/**
+ * Tests for <MLANotice /> (#490) — payment-flow notice for self-identified
+ * active-duty servicemembers. Steines v. Westgate Palace, 11th Cir. (2024).
+ */
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MLANotice } from "./MLANotice";
+
+describe("MLANotice", () => {
+  it("renders with the MLA citation + protections summary", () => {
+    render(<MLANotice />);
+    const el = screen.getByTestId("mla-notice");
+    expect(el.textContent).toContain("Military Lending Act");
+    expect(el.textContent).toMatch(/10 U\.S\.C\. § 987/);
+  });
+
+  it("states that arbitration is not enforceable against the servicemember", () => {
+    render(<MLANotice />);
+    const el = screen.getByTestId("mla-notice");
+    expect(el.textContent).toMatch(/not enforceable as to you/i);
+  });
+
+  it("affirms the right to pursue disputes in court", () => {
+    render(<MLANotice />);
+    const el = screen.getByTestId("mla-notice");
+    expect(el.textContent).toMatch(/pursue any dispute arising out of this booking in a court of competent jurisdiction/i);
+  });
+
+  it("has the correct ARIA role and label for screen readers", () => {
+    render(<MLANotice />);
+    const el = screen.getByTestId("mla-notice");
+    expect(el.getAttribute("role")).toBe("note");
+    expect(el.getAttribute("aria-label")).toBe("Military Lending Act notice");
+  });
+
+  it("accepts a className override", () => {
+    render(<MLANotice className="my-custom-class" />);
+    const el = screen.getByTestId("mla-notice");
+    expect(el.className).toContain("my-custom-class");
+  });
+});

--- a/src/components/legal/MLANotice.tsx
+++ b/src/components/legal/MLANotice.tsx
@@ -1,0 +1,45 @@
+import { Shield } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface MLANoticeProps {
+  className?: string;
+}
+
+/**
+ * Military Lending Act notice displayed in the payment flow for accounts that
+ * have self-identified as active-duty servicemembers (profiles.is_active_duty_military
+ * = TRUE). The protection itself applies by law regardless of self-identification —
+ * the Terms-of-Service carve-out in Section 9 is universal — but this in-product
+ * notice provides explicit acknowledgement at the highest-stakes point in the flow.
+ *
+ * @see docs/legal/_extracted_legal_dossier.txt § VI (Steines v. Westgate Palace)
+ * @see compliance-gap-analysis.md item P-13
+ * @see GitHub issue #490
+ */
+export function MLANotice({ className }: MLANoticeProps) {
+  return (
+    <div
+      data-testid="mla-notice"
+      role="note"
+      aria-label="Military Lending Act notice"
+      className={cn(
+        "rounded-lg border border-primary/30 bg-primary/5 p-4 flex items-start gap-3",
+        className,
+      )}
+    >
+      <Shield className="h-5 w-5 text-primary mt-0.5 flex-shrink-0" />
+      <div className="text-sm">
+        <p className="font-semibold text-foreground mb-1">
+          Military Lending Act notice
+        </p>
+        <p className="text-muted-foreground leading-relaxed">
+          Federal law provides important protections to active-duty members of the U.S. Armed Forces
+          and their dependents under the Military Lending Act (10 U.S.C. § 987). Any agreement that
+          would otherwise require you to resolve disputes through binding arbitration is{" "}
+          <strong>not enforceable as to you</strong>. You may pursue any dispute arising out of this
+          booking in a court of competent jurisdiction. Thank you for your service.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/disclaimers/placements.test.ts
+++ b/src/lib/disclaimers/placements.test.ts
@@ -151,6 +151,31 @@ const PLACEMENTS: ReadonlyArray<Placement> = [
     ],
     notes: "Guest Protection page route must be registered (#489).",
   },
+  {
+    file: "src/pages/Checkout.tsx",
+    required: [
+      `MLANotice`,
+      `profile?.is_active_duty_military === true`,
+    ],
+    notes: "Checkout must conditionally render MLANotice for self-identified active-duty servicemembers (#490).",
+  },
+  {
+    file: "src/pages/Signup.tsx",
+    required: [
+      `isActiveDutyMilitary`,
+      `data-testid="mla-self-disclosure"`,
+      `is_active_duty_military: formData.isActiveDutyMilitary`,
+    ],
+    notes: "Signup must offer optional MLA self-disclosure and persist to profiles.is_active_duty_military (#490).",
+  },
+  {
+    file: "src/pages/Terms.tsx",
+    required: [
+      `data-testid="mla-carveout"`,
+      `Military Lending Act Carve-Out`,
+    ],
+    notes: "Terms of Service must contain the MLA arbitration carve-out paragraph in Section 9 (#490).",
+  },
 ];
 
 describe("Disclaimer placement audit — required <DisclaimerBlock /> usages per page", () => {

--- a/src/pages/Checkout.tsx
+++ b/src/pages/Checkout.tsx
@@ -30,6 +30,7 @@ import { CancellationPolicyDetail } from "@/components/CancellationPolicyDetail"
 import { DisclaimerBlock } from "@/components/legal/DisclaimerBlock";
 import { StateSpecificDisclaimer } from "@/components/legal/StateSpecificDisclaimer";
 import { GuestProtectionBadge } from "@/components/legal/GuestProtectionBadge";
+import { MLANotice } from "@/components/legal/MLANotice";
 import { usePageMeta } from "@/hooks/usePageMeta";
 import { trackEvent } from "@/lib/posthog";
 
@@ -38,7 +39,7 @@ const Checkout = () => {
 
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
-  const { user, isEmailVerified } = useAuth();
+  const { user, profile, isEmailVerified } = useAuth();
 
   const listingId = searchParams.get("listing");
   const guestsParam = Number(searchParams.get("guests")) || 1;
@@ -396,6 +397,14 @@ const Checkout = () => {
                     {/* #489 — RAV Guest Protection banner surfaces the 5-business-day
                         Host-cancellation refund promise immediately above the Pay button. */}
                     <GuestProtectionBadge variant="banner" className="mt-2" />
+
+                    {/* #490 — MLA notice for self-identified active-duty servicemembers.
+                        The arbitration carve-out in Terms § 9 applies regardless of this
+                        render — protection is by law, not by checkbox (Steines v. Westgate
+                        Palace, 11th Cir. 2024). */}
+                    {profile?.is_active_duty_military === true && (
+                      <MLANotice className="mt-2" />
+                    )}
 
                     <Button
                       className="w-full mt-4"

--- a/src/pages/Signup.tsx
+++ b/src/pages/Signup.tsx
@@ -23,6 +23,10 @@ const Signup = () => {
     accountType: "renter",
     ageVerified: false,
     termsAccepted: false,
+    // #490 — optional self-disclosure of active-duty status. NULL = not answered.
+    // The MLA carve-out in Terms § 9 applies regardless; this drives the in-checkout
+    // notice render only.
+    isActiveDutyMilitary: null as boolean | null,
   });
   const [isLoading, setIsLoading] = useState(false);
   const [isSignupComplete, setIsSignupComplete] = useState(false);
@@ -114,6 +118,14 @@ const Signup = () => {
             acceptance_method: "signup_checkbox",
             user_agent: navigator.userAgent,
           });
+          // #490 — Persist optional active-duty disclosure on the profile.
+          // Only writes when the user actively answered (TRUE or FALSE); NULL stays NULL.
+          if (formData.isActiveDutyMilitary !== null) {
+            await supabase
+              .from("profiles")
+              .update({ is_active_duty_military: formData.isActiveDutyMilitary })
+              .eq("id", newUser.id);
+          }
         }
       } catch (auditError) {
         // Audit write is best-effort; log but don't block signup success.
@@ -354,6 +366,38 @@ const Signup = () => {
                       <Link to="/privacy" className="text-primary hover:underline" target="_blank" rel="noopener noreferrer">
                         Privacy Policy
                       </Link>
+                    </span>
+                  </label>
+
+                  {/* #490 — Optional MLA self-disclosure. The arbitration carve-out in Terms § 9
+                      applies regardless; this checkbox just enables the in-checkout notice render. */}
+                  <label className="flex items-start gap-2 cursor-pointer" data-testid="mla-self-disclosure">
+                    <input
+                      type="checkbox"
+                      className="rounded border-border mt-1"
+                      checked={formData.isActiveDutyMilitary === true}
+                      onChange={(e) =>
+                        setFormData({
+                          ...formData,
+                          isActiveDutyMilitary: e.target.checked ? true : false,
+                        })
+                      }
+                      aria-label="I am (or am a dependent of) an active-duty servicemember of the U.S. Armed Forces"
+                    />
+                    <span className="text-xs text-muted-foreground leading-relaxed">
+                      <strong>Optional:</strong> I (or a dependent of mine) am an active-duty
+                      servicemember of the U.S. Armed Forces. Under the{" "}
+                      <Link
+                        to="/terms"
+                        className="text-primary hover:underline"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        Military Lending Act (10 U.S.C. § 987)
+                      </Link>
+                      , disputes involving servicemembers are not subject to mandatory arbitration.
+                      Checking this box helps us show you the relevant notice at checkout. Your
+                      protection applies either way.
                     </span>
                   </label>
                 </div>

--- a/src/pages/Terms.test.tsx
+++ b/src/pages/Terms.test.tsx
@@ -63,4 +63,15 @@ describe("Terms of Service — required disclaimers", () => {
       /We are not responsible for the condition of properties, the conduct of users, or any damages arising from the use of our service beyond what is required by law/,
     );
   });
+
+  it("contains the Military Lending Act carve-out paragraph in Section 9 (#490)", () => {
+    renderTerms();
+    const carveout = screen.getByTestId("mla-carveout");
+    expect(carveout.textContent).toMatch(/Military Lending Act Carve-Out/);
+    expect(carveout.textContent).toMatch(/10 U\.S\.C\. § 987/);
+    expect(carveout.textContent).toMatch(/32 C\.F\.R\. § 232/);
+    expect(carveout.textContent).toMatch(/the arbitration provision above is not enforceable/i);
+    expect(carveout.textContent).toMatch(/Steines v. Westgate Palace/);
+    expect(carveout.textContent).toMatch(/applies regardless of whether the user has self-identified/i);
+  });
 });

--- a/src/pages/Terms.tsx
+++ b/src/pages/Terms.tsx
@@ -136,6 +136,18 @@ const Terms = () => {
                   If unsuccessful, Rent-A-Vacation's customer support team can assist with mediation.
                   Unresolved disputes may be subject to binding arbitration.
                 </p>
+                <p
+                  className="text-muted-foreground mb-4"
+                  data-testid="mla-carveout"
+                >
+                  <strong>Military Lending Act Carve-Out.</strong> For active-duty servicemembers of the U.S.
+                  Armed Forces and their dependents (as defined in 10 U.S.C. § 987 and 32 C.F.R. § 232), the
+                  arbitration provision above is not enforceable. Such users retain the right to pursue any
+                  dispute arising out of or relating to these Terms in a court of competent jurisdiction.
+                  This carve-out reflects the holding of <em>Steines v. Westgate Palace</em>, 11th Cir.
+                  (2024), and applies regardless of whether the user has self-identified as a servicemember
+                  to Rent-A-Vacation.
+                </p>
               </section>
 
               <section className="mb-8">

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -1316,6 +1316,7 @@ export type Database = {
           email: string
           full_name: string | null
           id: string
+          is_active_duty_military: boolean | null
           is_anonymized: boolean
           is_seed_foundation: boolean | null
           maintenance_fee_updated_at: string | null
@@ -1343,6 +1344,7 @@ export type Database = {
           email: string
           full_name?: string | null
           id: string
+          is_active_duty_military?: boolean | null
           is_anonymized?: boolean
           is_seed_foundation?: boolean | null
           maintenance_fee_updated_at?: string | null
@@ -1370,6 +1372,7 @@ export type Database = {
           email?: string
           full_name?: string | null
           id?: string
+          is_active_duty_military?: boolean | null
           is_anonymized?: boolean
           is_seed_foundation?: boolean | null
           maintenance_fee_updated_at?: string | null

--- a/supabase/migrations/076_profiles_active_duty_military.sql
+++ b/supabase/migrations/076_profiles_active_duty_military.sql
@@ -1,0 +1,23 @@
+-- 076_profiles_active_duty_military.sql
+--
+-- Adds `is_active_duty_military` to `profiles` so signup can capture optional
+-- self-disclosure of active-duty status. Drives the conditional MLA notice
+-- at checkout (Steines v. Westgate Palace, 11th Cir. 2024 — Military Lending
+-- Act overrides Federal Arbitration Act for timeshare-related arbitration).
+--
+-- IMPORTANT: The MLA carve-out paragraph added to Terms.tsx Section 9 in the
+-- companion code change protects active-duty servicemembers regardless of
+-- self-disclosure. This field is purely for the optional in-product UX
+-- (notice rendering at checkout) — it does NOT gate access to the protection.
+--
+-- GitHub issue #490; compliance-gap-analysis item P-13.
+
+BEGIN;
+
+ALTER TABLE public.profiles
+  ADD COLUMN IF NOT EXISTS is_active_duty_military BOOLEAN;
+
+COMMENT ON COLUMN public.profiles.is_active_duty_military IS
+  'Optional self-disclosure: NULL = not answered, TRUE = active-duty servicemember (or dependent), FALSE = no. Drives the MLA notice render at checkout. The Terms-of-Service MLA carve-out (Steines v. Westgate Palace, 10 U.S.C. § 987) applies regardless of this field — protections are by law, not by checkbox. #490.';
+
+COMMIT;


### PR DESCRIPTION
## Summary

Closes **#490**. Following Steines v. Westgate Palace (11th Cir. 2024), the Military Lending Act (10 U.S.C. § 987) overrides the Federal Arbitration Act for timeshare-related disputes involving active-duty servicemembers. This PR makes that protection visible to users and unambiguous in the Terms of Service.

- **Migration 076** adds nullable \`profiles.is_active_duty_military\`. The legal protection applies regardless of self-identification — this field drives the in-product notice render only.
- **\`<MLANotice />\` component** citing 10 U.S.C. § 987, stating arbitration is "not enforceable as to you", and affirming the right to pursue disputes in a court of competent jurisdiction. ARIA \`role="note"\` + \`aria-label\` for screen readers.
- **Signup checkbox** for optional MLA self-disclosure; persists to profile post-signup (best-effort write — signup never fails on the profile update).
- **Terms § 9 Carve-Out** — verbatim paragraph: "the arbitration provision above is not enforceable" for active-duty servicemembers + dependents, citing Steines v. Westgate Palace, applying regardless of self-identification.
- **Checkout conditional render** — \`<MLANotice />\` renders when \`profile.is_active_duty_military === true\`.

## Test plan

- [x] \`npm run test\` — **1676 / 1676** pass (added 7 net for #490: 5 MLANotice unit tests + 1 Terms carve-out assertion + 3 placement-audit entries)
- [x] \`npm run build\` — clean
- [x] ESLint clean
- [x] Migration 076 applied successfully to DEV via \`supabase db push\`
- [ ] After merge: push 076 to PROD

## Note on the journey

Originally completed earlier in the session; the uncommitted changes got caught in a stash/branch-switch round-trip during parallel work in another terminal. The stash \`preserve-mla-and-military-wip\` restored 9 files cleanly to a fresh dev branch state, ready for this PR.

## Audit scoreboard impact

Row 21 (MLA Notice + arbitration carve-out) flips Gap → Implemented. Counsel question C11 (confirm carve-out language) remains in #494.

🤖 Generated with [Claude Code](https://claude.com/claude-code)