### PR TITLE
feat(compliance): #492 fraud reporting + Migration 078

### DIFF
--- a/docs/testing/TESTING-STATUS.md
+++ b/docs/testing/TESTING-STATUS.md
@@ -7,7 +7,7 @@ status: "active"
 # Testing Status
 
 > Current state of the RAV test suite. Updated each session.
-> **Last Updated:** May 11, 2026 (Session 64+65 — compliance hardening: #483/#484/#485/#486/#488/#489/#490/#491 cumulative; +204 tests, +18 test files for the session)
+> **Last Updated:** May 11, 2026 (Session 64+65 — compliance hardening: #483/#484/#485/#486/#488/#489/#490/#491/#492 cumulative; +237 tests, +20 test files for the session)
 
 ---
 
@@ -15,8 +15,8 @@ status: "active"
 
 | Metric | Value |
 |--------|-------|
-| **Total tests** | 1696 |
-| **Test files** | 173 |
+| **Total tests** | 1729 |
+| **Test files** | 175 |
 | **P0 critical-path tests** | 290+ tagged `@p0` (Session 64 added @p0 on disclaimer registry, DisclaimerBlock, StateSpecificDisclaimer, Footer registry sourcing, Terms 8.3+8.6, About page, placement audit) |
 | **E2E smoke tests** | 3 (Playwright) |
 | **Local run time** | ~2.5 min (full), ~2s (P0 only) |

--- a/src/components/Footer.test.tsx
+++ b/src/components/Footer.test.tsx
@@ -4,9 +4,17 @@
  * Tests for the global Footer — trademark/affiliation disclaimer.
  * GitHub Issue: #479 — Add trademark disclaimer footer
  */
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
+
+// Footer mounts <FraudReportDialog /> for the "Report fraud" link (#492); that
+// dialog calls useAuth(). Mock the context so the dialog can render without a
+// real AuthProvider in the test tree.
+vi.mock("@/contexts/AuthContext", () => ({
+  useAuth: () => ({ user: null }),
+}));
+
 import Footer from "./Footer";
 
 const renderFooter = () =>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,8 +1,11 @@
-import { Mail, Phone, MapPin, Gavel } from "lucide-react";
+import { useState } from "react";
+import { Mail, Phone, MapPin, Gavel, ShieldAlert } from "lucide-react";
 import { Link } from "react-router-dom";
 import { DisclaimerBlock } from "@/components/legal/DisclaimerBlock";
+import { FraudReportDialog } from "@/components/legal/FraudReportDialog";
 
 const Footer = () => {
+  const [fraudDialogOpen, setFraudDialogOpen] = useState(false);
   return (
     <footer className="bg-foreground text-white/80">
       <div className="container mx-auto px-4 py-16">
@@ -106,10 +109,19 @@ const Footer = () => {
               <Gavel className="w-4 h-4 text-primary" />
               <span>A Marketplace for Renters and Owners</span>
             </div>
-            <div className="flex gap-6 text-sm">
+            <div className="flex flex-wrap gap-6 text-sm">
               <Link to="/about" className="text-white/50 hover:text-white transition-colors">About</Link>
               <Link to="/privacy" className="text-white/50 hover:text-white transition-colors">Privacy Policy</Link>
               <Link to="/terms" className="text-white/50 hover:text-white transition-colors">Terms of Service</Link>
+              <button
+                type="button"
+                onClick={() => setFraudDialogOpen(true)}
+                className="text-white/50 hover:text-white transition-colors inline-flex items-center gap-1"
+                data-testid="footer-report-fraud"
+              >
+                <ShieldAlert className="w-3.5 h-3.5" />
+                Report fraud
+              </button>
             </div>
           </div>
           <div className="text-center mt-4">
@@ -119,6 +131,7 @@ const Footer = () => {
           </div>
         </div>
       </div>
+      <FraudReportDialog open={fraudDialogOpen} onOpenChange={setFraudDialogOpen} />
     </footer>
   );
 };

--- a/src/components/admin/AdminFraudReports.tsx
+++ b/src/components/admin/AdminFraudReports.tsx
@@ -1,0 +1,515 @@
+import { useEffect, useMemo, useState } from "react";
+import { supabase } from "@/lib/supabase";
+import { useAuth } from "@/hooks/useAuth";
+import { useToast } from "@/hooks/use-toast";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { ShieldAlert, ExternalLink, MessageSquare, AlertTriangle } from "lucide-react";
+
+type FraudStatus =
+  | "pending"
+  | "investigating"
+  | "escalated_to_legal"
+  | "escalated_to_law_enforcement"
+  | "resolved_action_taken"
+  | "resolved_no_fraud_found"
+  | "dismissed_spam"
+  | "dismissed_duplicate";
+
+type Severity = "low" | "medium" | "high" | "critical";
+
+interface FraudReportRow {
+  id: string;
+  listing_id: string | null;
+  reported_user_id: string | null;
+  booking_id: string | null;
+  reporter_id: string | null;
+  reporter_email: string | null;
+  reporter_name: string | null;
+  category: string;
+  severity: Severity;
+  description: string;
+  status: FraudStatus;
+  resolution_notes: string | null;
+  internal_notes: string | null;
+  resolved_at: string | null;
+  resolved_by: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+const STATUS_LABELS: Record<FraudStatus, string> = {
+  pending: "Pending",
+  investigating: "Investigating",
+  escalated_to_legal: "Escalated — legal",
+  escalated_to_law_enforcement: "Escalated — law enforcement",
+  resolved_action_taken: "Resolved — action taken",
+  resolved_no_fraud_found: "Resolved — no fraud",
+  dismissed_spam: "Dismissed — spam",
+  dismissed_duplicate: "Dismissed — duplicate",
+};
+
+const STATUS_VARIANTS: Record<FraudStatus, "default" | "secondary" | "outline" | "destructive"> = {
+  pending: "destructive",
+  investigating: "secondary",
+  escalated_to_legal: "destructive",
+  escalated_to_law_enforcement: "destructive",
+  resolved_action_taken: "default",
+  resolved_no_fraud_found: "outline",
+  dismissed_spam: "outline",
+  dismissed_duplicate: "outline",
+};
+
+const SEVERITY_VARIANTS: Record<Severity, "default" | "secondary" | "outline" | "destructive"> = {
+  critical: "destructive",
+  high: "destructive",
+  medium: "secondary",
+  low: "outline",
+};
+
+const CATEGORY_LABELS: Record<string, string> = {
+  payment_fraud: "Payment fraud",
+  identity_fraud: "Identity fraud",
+  fake_listing: "Fake listing",
+  phishing: "Phishing",
+  scam_pattern: "Scam pattern",
+  unauthorized_access: "Unauthorized access",
+  timeshare_exit_scheme: "Exit scheme",
+  other: "Other",
+};
+
+function formatDateTime(value: string | null): string {
+  if (!value) return "—";
+  return new Date(value).toLocaleString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+export function AdminFraudReports() {
+  const { user } = useAuth();
+  const { toast } = useToast();
+  const [rows, setRows] = useState<FraudReportRow[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [statusFilter, setStatusFilter] = useState<FraudStatus | "all">("pending");
+  const [severityFilter, setSeverityFilter] = useState<Severity | "all">("all");
+  const [editTarget, setEditTarget] = useState<FraudReportRow | null>(null);
+  const [draftStatus, setDraftStatus] = useState<FraudStatus>("investigating");
+  const [draftSeverity, setDraftSeverity] = useState<Severity>("high");
+  const [draftResolution, setDraftResolution] = useState("");
+  const [draftInternal, setDraftInternal] = useState("");
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+
+  useEffect(() => {
+    void load();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  async function load() {
+    setIsLoading(true);
+    const { data, error } = await supabase
+      .from("fraud_reports")
+      .select("*")
+      .order("created_at", { ascending: false });
+    if (error) {
+      toast({ title: "Failed to load fraud reports", description: error.message, variant: "destructive" });
+      setIsLoading(false);
+      return;
+    }
+    setRows((data ?? []) as FraudReportRow[]);
+    setIsLoading(false);
+  }
+
+  const summary = useMemo(() => {
+    return {
+      critical_open: rows.filter((r) => r.severity === "critical" && (r.status === "pending" || r.status === "investigating")).length,
+      pending: rows.filter((r) => r.status === "pending").length,
+      investigating: rows.filter((r) => r.status === "investigating").length,
+      escalated: rows.filter((r) => r.status.startsWith("escalated_")).length,
+      resolved: rows.filter((r) => r.status.startsWith("resolved_")).length,
+    };
+  }, [rows]);
+
+  const filteredRows = useMemo(() => {
+    return rows.filter((r) => {
+      if (statusFilter !== "all" && r.status !== statusFilter) return false;
+      if (severityFilter !== "all" && r.severity !== severityFilter) return false;
+      return true;
+    });
+  }, [rows, statusFilter, severityFilter]);
+
+  function openEdit(row: FraudReportRow) {
+    setEditTarget(row);
+    setDraftStatus(row.status === "pending" ? "investigating" : row.status);
+    setDraftSeverity(row.severity);
+    setDraftResolution(row.resolution_notes ?? "");
+    setDraftInternal(row.internal_notes ?? "");
+  }
+
+  function closeEdit() {
+    setEditTarget(null);
+    setConfirmOpen(false);
+  }
+
+  async function save() {
+    if (!editTarget || !user) return;
+    setIsSaving(true);
+    const isTerminal = draftStatus.startsWith("resolved_") || draftStatus.startsWith("dismissed_");
+    const payload: Record<string, unknown> = {
+      status: draftStatus,
+      severity: draftSeverity,
+      resolution_notes: draftResolution.trim() || null,
+      internal_notes: draftInternal.trim() || null,
+    };
+    if (isTerminal) {
+      payload.resolved_at = new Date().toISOString();
+      payload.resolved_by = user.id;
+    } else if (!editTarget.status.startsWith("resolved_") && !editTarget.status.startsWith("dismissed_")) {
+      payload.resolved_at = null;
+      payload.resolved_by = null;
+    }
+    const { error } = await supabase
+      .from("fraud_reports")
+      .update(payload)
+      .eq("id", editTarget.id);
+    setIsSaving(false);
+    if (error) {
+      toast({ title: "Save failed", description: error.message, variant: "destructive" });
+      return;
+    }
+    toast({
+      title: "Fraud report updated",
+      description: `Status set to ${STATUS_LABELS[draftStatus]}.`,
+    });
+    closeEdit();
+    void load();
+  }
+
+  if (isLoading) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Fraud reports</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-2">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <Skeleton key={i} className="h-12 w-full" />
+          ))}
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <ShieldAlert className="h-5 w-5 text-destructive" />
+            Fraud reports
+          </CardTitle>
+          <CardDescription>
+            Senior-admin-only triage. Reports may be filed against listings, hosts, bookings, or
+            generically against the platform. Compliance brief § 3.6 + FTC v. Carroll (2026)
+            enforcement context — all critical-severity reports need attention within 24 hours.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="grid grid-cols-2 sm:grid-cols-5 gap-3 mb-6">
+            <div className="rounded-lg border border-destructive/40 bg-destructive/5 p-3">
+              <p className="text-xs text-destructive font-medium">Critical open</p>
+              <p className="text-2xl font-bold text-destructive">{summary.critical_open}</p>
+            </div>
+            <div className="rounded-lg border border-border p-3">
+              <p className="text-xs text-muted-foreground">Pending</p>
+              <p className="text-2xl font-semibold">{summary.pending}</p>
+            </div>
+            <div className="rounded-lg border border-border p-3">
+              <p className="text-xs text-muted-foreground">Investigating</p>
+              <p className="text-2xl font-semibold">{summary.investigating}</p>
+            </div>
+            <div className="rounded-lg border border-border p-3">
+              <p className="text-xs text-muted-foreground">Escalated</p>
+              <p className="text-2xl font-semibold">{summary.escalated}</p>
+            </div>
+            <div className="rounded-lg border border-border p-3">
+              <p className="text-xs text-muted-foreground">Resolved</p>
+              <p className="text-2xl font-semibold">{summary.resolved}</p>
+            </div>
+          </div>
+
+          <div className="flex flex-wrap items-center gap-2 mb-3">
+            <span className="text-sm text-muted-foreground">Filter:</span>
+            <Select value={statusFilter} onValueChange={(v) => setStatusFilter(v as FraudStatus | "all")}>
+              <SelectTrigger className="w-[220px]">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">All statuses</SelectItem>
+                {(Object.keys(STATUS_LABELS) as FraudStatus[]).map((s) => (
+                  <SelectItem key={s} value={s}>
+                    {STATUS_LABELS[s]}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <Select value={severityFilter} onValueChange={(v) => setSeverityFilter(v as Severity | "all")}>
+              <SelectTrigger className="w-[160px]">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">All severities</SelectItem>
+                <SelectItem value="critical">Critical</SelectItem>
+                <SelectItem value="high">High</SelectItem>
+                <SelectItem value="medium">Medium</SelectItem>
+                <SelectItem value="low">Low</SelectItem>
+              </SelectContent>
+            </Select>
+            <span className="text-xs text-muted-foreground">{filteredRows.length} shown</span>
+          </div>
+
+          <div className="rounded-md border overflow-x-auto">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Created</TableHead>
+                  <TableHead>Severity</TableHead>
+                  <TableHead>Category</TableHead>
+                  <TableHead>Context</TableHead>
+                  <TableHead>Reporter</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead>Description</TableHead>
+                  <TableHead className="text-right">Action</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {filteredRows.length === 0 ? (
+                  <TableRow>
+                    <TableCell colSpan={8} className="text-center text-muted-foreground py-8">
+                      No reports in this view.
+                    </TableCell>
+                  </TableRow>
+                ) : (
+                  filteredRows.map((row) => (
+                    <TableRow key={row.id} data-report-id={row.id}>
+                      <TableCell className="text-xs text-muted-foreground whitespace-nowrap">
+                        {formatDateTime(row.created_at)}
+                      </TableCell>
+                      <TableCell>
+                        <Badge variant={SEVERITY_VARIANTS[row.severity]} className="uppercase text-xs">
+                          {row.severity}
+                        </Badge>
+                      </TableCell>
+                      <TableCell className="text-sm">
+                        {CATEGORY_LABELS[row.category] ?? row.category}
+                      </TableCell>
+                      <TableCell className="text-xs">
+                        {row.listing_id ? (
+                          <a
+                            href={`/listings/${row.listing_id}`}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="text-primary hover:underline inline-flex items-center gap-1 font-mono"
+                          >
+                            listing {row.listing_id.slice(0, 8)}
+                            <ExternalLink className="h-3 w-3" />
+                          </a>
+                        ) : row.reported_user_id ? (
+                          <span className="font-mono text-muted-foreground">
+                            user {row.reported_user_id.slice(0, 8)}
+                          </span>
+                        ) : (
+                          <span className="text-muted-foreground italic">general</span>
+                        )}
+                      </TableCell>
+                      <TableCell className="text-xs text-muted-foreground">
+                        {row.reporter_id ? "Authed user" : row.reporter_email ?? "Anonymous"}
+                      </TableCell>
+                      <TableCell>
+                        <Badge variant={STATUS_VARIANTS[row.status]} className="text-xs">
+                          {STATUS_LABELS[row.status]}
+                        </Badge>
+                      </TableCell>
+                      <TableCell className="text-xs max-w-[260px]">
+                        <span className="line-clamp-2" title={row.description}>
+                          {row.description}
+                        </span>
+                      </TableCell>
+                      <TableCell className="text-right">
+                        <Button variant="ghost" size="sm" onClick={() => openEdit(row)}>
+                          <MessageSquare className="h-4 w-4 mr-1.5" />
+                          Triage
+                        </Button>
+                      </TableCell>
+                    </TableRow>
+                  ))
+                )}
+              </TableBody>
+            </Table>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Dialog open={editTarget !== null} onOpenChange={(open) => !open && closeEdit()}>
+        <DialogContent className="max-w-xl" data-testid="fraud-triage-dialog">
+          <DialogHeader>
+            <DialogTitle>Triage fraud report</DialogTitle>
+            <DialogDescription>
+              Senior-admin action — recorded with your user ID + timestamp. You'll confirm before save.
+            </DialogDescription>
+          </DialogHeader>
+
+          {editTarget && (
+            <div className="space-y-3">
+              <div className="rounded-lg bg-muted/30 p-3 text-xs space-y-1">
+                <p>
+                  <strong>Reporter:</strong>{" "}
+                  {editTarget.reporter_id
+                    ? `Authenticated user (${editTarget.reporter_id.slice(0, 8)})`
+                    : editTarget.reporter_email
+                      ? `${editTarget.reporter_name ?? "Anonymous"} <${editTarget.reporter_email}>`
+                      : "Anonymous (no contact)"}
+                </p>
+                <p>
+                  <strong>Category:</strong> {CATEGORY_LABELS[editTarget.category] ?? editTarget.category}
+                </p>
+                <p>
+                  <strong>Filed at:</strong> {formatDateTime(editTarget.created_at)}
+                </p>
+                <p>
+                  <strong>Description:</strong>
+                </p>
+                <p className="whitespace-pre-wrap text-muted-foreground">{editTarget.description}</p>
+              </div>
+
+              <div className="grid grid-cols-2 gap-3">
+                <div>
+                  <label className="text-sm font-medium block mb-1">Status</label>
+                  <Select value={draftStatus} onValueChange={(v) => setDraftStatus(v as FraudStatus)}>
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {(Object.keys(STATUS_LABELS) as FraudStatus[]).map((s) => (
+                        <SelectItem key={s} value={s}>
+                          {STATUS_LABELS[s]}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div>
+                  <label className="text-sm font-medium block mb-1">Severity</label>
+                  <Select value={draftSeverity} onValueChange={(v) => setDraftSeverity(v as Severity)}>
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="critical">Critical</SelectItem>
+                      <SelectItem value="high">High</SelectItem>
+                      <SelectItem value="medium">Medium</SelectItem>
+                      <SelectItem value="low">Low</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+              </div>
+
+              <div>
+                <label className="text-sm font-medium block mb-1">Resolution notes (visible to reporter)</label>
+                <Textarea
+                  placeholder="Externally-visible summary of action taken."
+                  value={draftResolution}
+                  onChange={(e) => setDraftResolution(e.target.value)}
+                  rows={3}
+                />
+              </div>
+
+              <div>
+                <label className="text-sm font-medium block mb-1">
+                  Internal notes <span className="text-muted-foreground">(admin only)</span>
+                </label>
+                <Textarea
+                  placeholder="Pattern matches, law-enforcement coordination, internal escalation notes."
+                  value={draftInternal}
+                  onChange={(e) => setDraftInternal(e.target.value)}
+                  rows={3}
+                />
+              </div>
+            </div>
+          )}
+
+          <DialogFooter>
+            <Button variant="outline" onClick={closeEdit} disabled={isSaving}>
+              Cancel
+            </Button>
+            <Button onClick={() => setConfirmOpen(true)} disabled={!draftStatus}>
+              Save…
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <AlertDialog open={confirmOpen} onOpenChange={setConfirmOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle className="flex items-center gap-2">
+              <AlertTriangle className="h-5 w-5 text-amber-500" />
+              Confirm fraud-triage decision
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              Setting status to <strong>{STATUS_LABELS[draftStatus]}</strong>, severity{" "}
+              <strong>{draftSeverity}</strong>. Your user ID is recorded as the actor. Fraud-report
+              changes are auditable; confirm only when you've completed the investigative work.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isSaving}>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={save} disabled={isSaving}>
+              {isSaving ? "Saving…" : "I understand — save"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}

--- a/src/components/legal/FraudReportDialog.test.tsx
+++ b/src/components/legal/FraudReportDialog.test.tsx
@@ -1,0 +1,80 @@
+// @vitest-environment jsdom
+// @p0
+/**
+ * Tests for <FraudReportDialog /> (#492). FTC v. Carroll (2026).
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+
+const insertMock = vi.fn();
+const fromMock = vi.fn(() => ({ insert: insertMock }));
+const toastMock = vi.fn();
+
+vi.mock("@/lib/supabase", () => ({
+  supabase: { from: (...args: unknown[]) => fromMock(...args) },
+}));
+
+vi.mock("@/hooks/use-toast", () => ({
+  useToast: () => ({ toast: toastMock }),
+}));
+
+vi.mock("@/contexts/AuthContext", () => ({
+  useAuth: () => ({ user: null }),
+}));
+
+import { FraudReportDialog } from "./FraudReportDialog";
+
+beforeEach(() => {
+  insertMock.mockReset();
+  fromMock.mockClear();
+  toastMock.mockClear();
+  insertMock.mockResolvedValue({ error: null });
+});
+
+describe("FraudReportDialog", () => {
+  it("renders with the senior-admin triage messaging", () => {
+    render(
+      <FraudReportDialog
+        open={true}
+        onOpenChange={() => {}}
+        listingId="listing-abc"
+        listingLabel="Marriott Aruba"
+      />,
+    );
+    expect(screen.getByTestId("fraud-report-dialog")).toBeTruthy();
+    expect(screen.getByText(/Marriott Aruba/)).toBeTruthy();
+  });
+
+  it("warns about active emergencies in the dialog copy", () => {
+    render(<FraudReportDialog open={true} onOpenChange={() => {}} />);
+    expect(screen.getByText(/active emergencies/i)).toBeTruthy();
+    expect(screen.getByText(/local authorities/i)).toBeTruthy();
+  });
+
+  it("blocks submission when category is missing", async () => {
+    render(<FraudReportDialog open={true} onOpenChange={() => {}} />);
+    fireEvent.click(screen.getByRole("button", { name: /Submit fraud report/i }));
+    await waitFor(() => {
+      expect(toastMock).toHaveBeenCalledWith(
+        expect.objectContaining({ title: "Pick a category", variant: "destructive" }),
+      );
+    });
+    expect(insertMock).not.toHaveBeenCalled();
+  });
+
+  it("blocks submission when description is too short (< 20 chars)", async () => {
+    render(<FraudReportDialog open={true} onOpenChange={() => {}} />);
+    fireEvent.change(screen.getByLabelText(/Describe what happened/i), {
+      target: { value: "short" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /Submit fraud report/i }));
+    await waitFor(() => {
+      expect(insertMock).not.toHaveBeenCalled();
+    });
+  });
+
+  it("shows anonymous contact fields when user is signed out", () => {
+    render(<FraudReportDialog open={true} onOpenChange={() => {}} />);
+    expect(screen.getByLabelText(/Email/i)).toBeTruthy();
+  });
+});

--- a/src/components/legal/FraudReportDialog.tsx
+++ b/src/components/legal/FraudReportDialog.tsx
@@ -1,0 +1,290 @@
+import { useState } from "react";
+import { supabase } from "@/lib/supabase";
+import { useAuth } from "@/contexts/AuthContext";
+import { useToast } from "@/hooks/use-toast";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { ShieldAlert, Send, Loader2 } from "lucide-react";
+
+export type FraudCategory =
+  | "payment_fraud"
+  | "identity_fraud"
+  | "fake_listing"
+  | "phishing"
+  | "scam_pattern"
+  | "unauthorized_access"
+  | "timeshare_exit_scheme"
+  | "other";
+
+const CATEGORY_LABELS: Record<FraudCategory, string> = {
+  payment_fraud: "Payment fraud — money taken, no service rendered",
+  identity_fraud: "Identity fraud — fake host / impersonation",
+  fake_listing: "Fake listing — property doesn't exist or isn't theirs",
+  phishing: "Phishing — suspicious email/message asking for credentials",
+  scam_pattern: "Scam pattern — coordinated suspicious behavior",
+  unauthorized_access: "Unauthorized account access (mine or someone else's)",
+  timeshare_exit_scheme: "Timeshare-exit scheme being marketed via RAV",
+  other: "Something else suspicious",
+};
+
+const SEVERITY_LABELS = {
+  critical: "Critical — active fraud right now (e.g. payment in progress)",
+  high: "High — confident, fraud appears real",
+  medium: "Medium — suspicious, want investigation",
+  low: "Low — pattern observation",
+} as const;
+
+interface FraudReportDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Optional — set when reporting against a specific listing (PropertyDetail), omit when filed from Footer. */
+  listingId?: string;
+  /** Optional — for "more options" menus on listing pages. */
+  listingLabel?: string;
+}
+
+/**
+ * Fraud reporting intake (#492). FTC v. Carroll (2026) made clear the FTC
+ * actively enforces in the timeshare space. Compliance brief § 3.6 requires
+ * a fraud-reporting mechanism with a documented response protocol.
+ *
+ * Separate from the post-booking dispute system — fraud reports can be:
+ * - filed by anonymous users
+ * - tied to a listing OR not (footer-filed reports have no listingId)
+ * - higher severity → routes to senior admin queue
+ */
+export function FraudReportDialog({
+  open,
+  onOpenChange,
+  listingId,
+  listingLabel,
+}: FraudReportDialogProps) {
+  const { user } = useAuth();
+  const { toast } = useToast();
+  const [category, setCategory] = useState<FraudCategory | "">("");
+  const [severity, setSeverity] = useState<keyof typeof SEVERITY_LABELS>("high");
+  const [description, setDescription] = useState("");
+  const [reporterName, setReporterName] = useState("");
+  const [reporterEmail, setReporterEmail] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const isAuthed = !!user;
+
+  function reset() {
+    setCategory("");
+    setSeverity("high");
+    setDescription("");
+    setReporterName("");
+    setReporterEmail("");
+  }
+
+  function close(open: boolean) {
+    if (!open) reset();
+    onOpenChange(open);
+  }
+
+  async function submit() {
+    if (!category) {
+      toast({
+        title: "Pick a category",
+        description: "Tell us what kind of fraud this is.",
+        variant: "destructive",
+      });
+      return;
+    }
+    if (description.trim().length < 20) {
+      toast({
+        title: "Tell us more",
+        description: "Please describe the fraud in at least 20 characters so our team can investigate.",
+        variant: "destructive",
+      });
+      return;
+    }
+    if (!isAuthed && !reporterEmail.trim()) {
+      toast({
+        title: "Email needed",
+        description: "Please leave an email so we can follow up if needed. You can also leave it blank — but we may not be able to update you.",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    setIsSubmitting(true);
+    const payload = {
+      listing_id: listingId ?? null,
+      reporter_id: user?.id ?? null,
+      reporter_email: isAuthed ? null : reporterEmail.trim() || null,
+      reporter_name: isAuthed ? null : reporterName.trim() || null,
+      category,
+      severity,
+      description: description.trim(),
+    };
+
+    const { error } = await supabase.from("fraud_reports").insert(payload);
+    setIsSubmitting(false);
+    if (error) {
+      toast({
+        title: "Couldn't submit",
+        description: error.message,
+        variant: "destructive",
+      });
+      return;
+    }
+    toast({
+      title: "Fraud report received",
+      description:
+        "Thanks. A senior member of our team will review and may contact you. If this is an active emergency, also call your local authorities.",
+    });
+    close(false);
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={close}>
+      <DialogContent className="max-w-lg" data-testid="fraud-report-dialog">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <ShieldAlert className="h-5 w-5 text-destructive" />
+            Report suspected fraud
+          </DialogTitle>
+          <DialogDescription>
+            {listingLabel
+              ? `Reporting against "${listingLabel}".`
+              : "Fraud reports go to RAV's senior trust & safety team."}{" "}
+            For active emergencies (money being taken from you right now), also call your local
+            authorities or your bank's fraud line. You can stay anonymous — email helps us follow up.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-3">
+          <div>
+            <Label htmlFor="fr-category" className="text-sm font-medium">
+              What kind of fraud?
+            </Label>
+            <Select value={category} onValueChange={(v) => setCategory(v as FraudCategory)}>
+              <SelectTrigger id="fr-category" className="mt-1">
+                <SelectValue placeholder="Pick a category" />
+              </SelectTrigger>
+              <SelectContent>
+                {(Object.keys(CATEGORY_LABELS) as FraudCategory[]).map((c) => (
+                  <SelectItem key={c} value={c}>
+                    {CATEGORY_LABELS[c]}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div>
+            <Label htmlFor="fr-severity" className="text-sm font-medium">
+              How urgent?
+            </Label>
+            <Select
+              value={severity}
+              onValueChange={(v) => setSeverity(v as keyof typeof SEVERITY_LABELS)}
+            >
+              <SelectTrigger id="fr-severity" className="mt-1">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {(Object.keys(SEVERITY_LABELS) as Array<keyof typeof SEVERITY_LABELS>).map((s) => (
+                  <SelectItem key={s} value={s}>
+                    {SEVERITY_LABELS[s]}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div>
+            <Label htmlFor="fr-description" className="text-sm font-medium">
+              Describe what happened (or what you're seeing)
+            </Label>
+            <Textarea
+              id="fr-description"
+              className="mt-1"
+              placeholder="What happened, who's involved, when, what evidence you have. Specific details help our team move faster."
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              rows={5}
+              maxLength={10000}
+            />
+            <p className="text-xs text-muted-foreground mt-1">
+              {description.length}/10000 characters · 20 minimum
+            </p>
+          </div>
+
+          {!isAuthed && (
+            <div className="rounded-lg border border-border bg-muted/30 p-3 space-y-2">
+              <p className="text-xs font-medium text-foreground">
+                Contact info <span className="font-normal text-muted-foreground">(name optional; email recommended)</span>
+              </p>
+              <div className="grid grid-cols-2 gap-2">
+                <div>
+                  <Label htmlFor="fr-name" className="text-xs">
+                    Name <span className="text-muted-foreground">(optional)</span>
+                  </Label>
+                  <Input
+                    id="fr-name"
+                    className="mt-1"
+                    placeholder="Optional"
+                    value={reporterName}
+                    onChange={(e) => setReporterName(e.target.value)}
+                  />
+                </div>
+                <div>
+                  <Label htmlFor="fr-email" className="text-xs">
+                    Email
+                  </Label>
+                  <Input
+                    id="fr-email"
+                    type="email"
+                    className="mt-1"
+                    placeholder="you@example.com"
+                    value={reporterEmail}
+                    onChange={(e) => setReporterEmail(e.target.value)}
+                  />
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => close(false)} disabled={isSubmitting}>
+            Cancel
+          </Button>
+          <Button variant="destructive" onClick={submit} disabled={isSubmitting}>
+            {isSubmitting ? (
+              <>
+                <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                Submitting…
+              </>
+            ) : (
+              <>
+                <Send className="h-4 w-4 mr-2" />
+                Submit fraud report
+              </>
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/lib/disclaimers/fraudReports.test.ts
+++ b/src/lib/disclaimers/fraudReports.test.ts
@@ -1,0 +1,122 @@
+// @vitest-environment jsdom
+// @p0
+/**
+ * Migration audit for Migration 078 — fraud_reports (#492).
+ *
+ * @see docs/legal/compliance-gap-analysis.md item P-15
+ * @see FTC v. Carroll et al., Fed. Dist. Ct. (2026)
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const sqlPath = resolve(
+  __dirname,
+  "../../../supabase/migrations/078_fraud_reports.sql",
+);
+const sql = readFileSync(sqlPath, "utf-8");
+
+describe("Migration 078 — fraud_reports table", () => {
+  it("creates the table idempotently", () => {
+    expect(sql).toMatch(/CREATE TABLE IF NOT EXISTS public\.fraud_reports/);
+  });
+
+  it("all three context FKs (listing_id, reported_user_id, booking_id) are nullable", () => {
+    expect(sql).toMatch(/listing_id UUID REFERENCES public\.listings\(id\) ON DELETE SET NULL/);
+    expect(sql).toMatch(/reported_user_id UUID REFERENCES auth\.users\(id\) ON DELETE SET NULL/);
+    expect(sql).toMatch(/booking_id UUID REFERENCES public\.bookings\(id\) ON DELETE SET NULL/);
+  });
+
+  it("anon reports require email (anon_contact CHECK)", () => {
+    expect(sql).toMatch(/CONSTRAINT fraud_reports_anon_contact CHECK \(/);
+    expect(sql).toMatch(/reporter_id IS NOT NULL OR reporter_email IS NOT NULL/);
+  });
+
+  it("enforces 8 category values including timeshare_exit_scheme (FTC v. Carroll)", () => {
+    for (const cat of [
+      "payment_fraud",
+      "identity_fraud",
+      "fake_listing",
+      "phishing",
+      "scam_pattern",
+      "unauthorized_access",
+      "timeshare_exit_scheme",
+      "other",
+    ]) {
+      expect(sql).toContain(`'${cat}'`);
+    }
+  });
+
+  it("enforces severity enum (low/medium/high/critical) with high default", () => {
+    expect(sql).toMatch(/severity TEXT NOT NULL DEFAULT 'high'/);
+    expect(sql).toMatch(/CHECK \(severity IN \('low', 'medium', 'high', 'critical'\)\)/);
+  });
+
+  it("enforces description length 20..10000", () => {
+    expect(sql).toMatch(/CHECK \(length\(description\) BETWEEN 20 AND 10000\)/);
+  });
+
+  it("status enum includes escalation paths (legal + law enforcement)", () => {
+    expect(sql).toMatch(/'escalated_to_legal'/);
+    expect(sql).toMatch(/'escalated_to_law_enforcement'/);
+  });
+
+  it("status enum includes both resolved and dismissed terminal states", () => {
+    expect(sql).toMatch(/'resolved_action_taken'/);
+    expect(sql).toMatch(/'resolved_no_fraud_found'/);
+    expect(sql).toMatch(/'dismissed_spam'/);
+    expect(sql).toMatch(/'dismissed_duplicate'/);
+  });
+
+  it("has internal_notes column separate from resolution_notes (admin-only)", () => {
+    expect(sql).toMatch(/internal_notes TEXT/);
+    expect(sql).toMatch(/resolution_notes TEXT/);
+  });
+
+  it("creates updated_at trigger", () => {
+    expect(sql).toMatch(/CREATE OR REPLACE FUNCTION public\.touch_fraud_reports_updated_at/);
+    expect(sql).toMatch(/CREATE TRIGGER fraud_reports_updated_at/);
+  });
+
+  it("enables row-level security", () => {
+    expect(sql).toMatch(/ALTER TABLE public\.fraud_reports ENABLE ROW LEVEL SECURITY/);
+  });
+
+  it("allows INSERT from anon + authenticated with no impersonation", () => {
+    expect(sql).toMatch(/"Anyone can submit a fraud report"/);
+    expect(sql).toMatch(/TO anon, authenticated/);
+    expect(sql).toMatch(/auth\.uid\(\) IS NOT NULL AND reporter_id = auth\.uid\(\)/);
+    expect(sql).toMatch(/auth\.uid\(\) IS NULL AND reporter_id IS NULL/);
+  });
+
+  it("read access restricted to admins ONLY (stricter than accuracy reports)", () => {
+    expect(sql).toMatch(/"RAV admins can read all fraud reports"/);
+    expect(sql).toMatch(/ur\.role IN \('rav_admin', 'rav_owner'\)/);
+    // Should NOT have a rav_staff or is_rav_team based read policy
+    expect(sql).not.toMatch(/public\.is_rav_team[^"]+FOR SELECT/);
+  });
+
+  it("authenticated reporters can read their own reports", () => {
+    expect(sql).toMatch(/"Reporters can read their own fraud reports"/);
+    expect(sql).toMatch(/USING \(reporter_id = auth\.uid\(\)\)/);
+  });
+
+  it("only RAV admin/owner can UPDATE", () => {
+    expect(sql).toMatch(/"RAV admins can update fraud reports"/);
+  });
+
+  it("does NOT expose DELETE via RLS", () => {
+    expect(sql).not.toMatch(/CREATE POLICY[^"]+FOR DELETE[^"]+fraud_reports/);
+  });
+
+  it("creates indexes including a critical-open partial index for triage dashboards", () => {
+    expect(sql).toMatch(/CREATE INDEX IF NOT EXISTS idx_fraud_reports_status/);
+    expect(sql).toMatch(/CREATE INDEX IF NOT EXISTS idx_fraud_reports_severity/);
+    expect(sql).toMatch(/idx_fraud_reports_critical_open[\s\S]+WHERE severity = 'critical' AND status IN \('pending', 'investigating'\)/);
+  });
+
+  it("wraps in a transaction", () => {
+    expect(sql).toMatch(/^BEGIN;/m);
+    expect(sql).toMatch(/^COMMIT;/m);
+  });
+});

--- a/src/lib/disclaimers/placements.test.ts
+++ b/src/lib/disclaimers/placements.test.ts
@@ -192,6 +192,30 @@ const PLACEMENTS: ReadonlyArray<Placement> = [
     ],
     notes: "Admin dashboard must register the listing-accuracy-reports tab (#491).",
   },
+  {
+    file: "src/components/Footer.tsx",
+    required: [
+      `FraudReportDialog`,
+      `data-testid="footer-report-fraud"`,
+    ],
+    notes: "Footer must surface a 'Report fraud' link (#492, FTC v. Carroll).",
+  },
+  {
+    file: "src/pages/PropertyDetail.tsx",
+    required: [
+      `FraudReportDialog`,
+      `data-testid="report-fraud-button"`,
+    ],
+    notes: "Listing page must surface a 'Report fraud' button distinct from the accuracy-report button (#492).",
+  },
+  {
+    file: "src/pages/AdminDashboard.tsx",
+    required: [
+      `AdminFraudReports`,
+      `value="fraud-reports"`,
+    ],
+    notes: "Admin dashboard must register the fraud-reports tab gated to rav_admin (#492).",
+  },
 ];
 
 describe("Disclaimer placement audit — required <DisclaimerBlock /> usages per page", () => {

--- a/src/pages/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard.tsx
@@ -62,6 +62,7 @@ import AdminDisputes from "@/components/admin/AdminDisputes";
 import AdminTaxReporting from "@/components/admin/AdminTaxReporting";
 import { AdminMarketplaceRegistrations } from "@/components/admin/AdminMarketplaceRegistrations";
 import { AdminListingAccuracyReports } from "@/components/admin/AdminListingAccuracyReports";
+import { AdminFraudReports } from "@/components/admin/AdminFraudReports";
 import AdminResortImport from "@/components/admin/AdminResortImport";
 import AdminResortTagEditor from "@/components/admin/AdminResortTagEditor";
 import { LaunchReadinessChecklist } from "@/components/admin/LaunchReadinessChecklist";
@@ -257,6 +258,12 @@ const AdminDashboard = () => {
               <span className="hidden sm:inline">Accuracy reports</span>
             </TabsTrigger>
             {isRavAdmin() && (
+              <TabsTrigger value="fraud-reports" className="gap-2">
+                <ShieldAlert className="h-4 w-4 text-destructive" />
+                <span className="hidden sm:inline">Fraud reports</span>
+              </TabsTrigger>
+            )}
+            {isRavAdmin() && (
               <TabsTrigger value="payouts" className="gap-2">
                 <Wallet className="h-4 w-4" />
                 <span className="hidden sm:inline">Payouts</span>
@@ -405,6 +412,12 @@ const AdminDashboard = () => {
           <TabsContent value="accuracy-reports">
             <AdminListingAccuracyReports />
           </TabsContent>
+
+          {isRavAdmin() && (
+            <TabsContent value="fraud-reports">
+              <AdminFraudReports />
+            </TabsContent>
+          )}
 
           {isRavAdmin() && (
             <TabsContent value="payouts">

--- a/src/pages/PropertyDetail.tsx
+++ b/src/pages/PropertyDetail.tsx
@@ -54,6 +54,7 @@ import { DisclaimerBlock } from "@/components/legal/DisclaimerBlock";
 import { StateSpecificDisclaimer } from "@/components/legal/StateSpecificDisclaimer";
 import { GuestProtectionBadge } from "@/components/legal/GuestProtectionBadge";
 import { ListingAccuracyReportDialog } from "@/components/listings/ListingAccuracyReportDialog";
+import { FraudReportDialog } from "@/components/legal/FraudReportDialog";
 import { CancellationPolicyDetail } from "@/components/CancellationPolicyDetail";
 import { OwnerProfileCard } from "@/components/OwnerProfileCard";
 import { InquiryDialog } from "@/components/InquiryDialog";
@@ -85,6 +86,8 @@ const PropertyDetail = () => {
   const [inquiryDialogOpen, setInquiryDialogOpen] = useState(false);
   // #491 — Listing accuracy reporting (pre-booking; may be anonymous)
   const [accuracyReportOpen, setAccuracyReportOpen] = useState(false);
+  // #492 — Fraud reporting (pre-booking; may be anonymous; senior-admin triage)
+  const [fraudReportOpen, setFraudReportOpen] = useState(false);
 
   // Auth
   const { user } = useAuth();
@@ -869,6 +872,14 @@ const PropertyDetail = () => {
               >
                 Report a listing inaccuracy
               </button>
+              <button
+                type="button"
+                onClick={() => setFraudReportOpen(true)}
+                className="text-xs text-destructive/80 hover:text-destructive underline underline-offset-2 transition-colors"
+                data-testid="report-fraud-button"
+              >
+                Report fraud
+              </button>
               <GuestProtectionBadge />
             </div>
             <DisclaimerBlock id="8.1" variant="compact" />
@@ -952,6 +963,16 @@ const PropertyDetail = () => {
         <ListingAccuracyReportDialog
           open={accuracyReportOpen}
           onOpenChange={setAccuracyReportOpen}
+          listingId={listing.id}
+          listingLabel={displayName}
+        />
+      )}
+
+      {/* #492 — Fraud report dialog (pre-booking, anonymous OK, senior-admin triage) */}
+      {listing && (
+        <FraudReportDialog
+          open={fraudReportOpen}
+          onOpenChange={setFraudReportOpen}
           listingId={listing.id}
           listingLabel={displayName}
         />

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -678,6 +678,69 @@ export type Database = {
         }
         Relationships: []
       }
+      fraud_reports: {
+        Row: {
+          booking_id: string | null
+          category: string
+          created_at: string
+          description: string
+          evidence_urls: string[] | null
+          id: string
+          internal_notes: string | null
+          listing_id: string | null
+          reported_user_id: string | null
+          reporter_email: string | null
+          reporter_id: string | null
+          reporter_name: string | null
+          resolution_notes: string | null
+          resolved_at: string | null
+          resolved_by: string | null
+          severity: string
+          status: string
+          updated_at: string
+        }
+        Insert: {
+          booking_id?: string | null
+          category: string
+          created_at?: string
+          description: string
+          evidence_urls?: string[] | null
+          id?: string
+          internal_notes?: string | null
+          listing_id?: string | null
+          reported_user_id?: string | null
+          reporter_email?: string | null
+          reporter_id?: string | null
+          reporter_name?: string | null
+          resolution_notes?: string | null
+          resolved_at?: string | null
+          resolved_by?: string | null
+          severity?: string
+          status?: string
+          updated_at?: string
+        }
+        Update: {
+          booking_id?: string | null
+          category?: string
+          created_at?: string
+          description?: string
+          evidence_urls?: string[] | null
+          id?: string
+          internal_notes?: string | null
+          listing_id?: string | null
+          reported_user_id?: string | null
+          reporter_email?: string | null
+          reporter_id?: string | null
+          reporter_name?: string | null
+          resolution_notes?: string | null
+          resolved_at?: string | null
+          resolved_by?: string | null
+          severity?: string
+          status?: string
+          updated_at?: string
+        }
+        Relationships: []
+      }
       listing_bids: {
         Row: {
           bid_amount: number

--- a/supabase/migrations/078_fraud_reports.sql
+++ b/supabase/migrations/078_fraud_reports.sql
@@ -1,0 +1,181 @@
+-- 078_fraud_reports.sql
+--
+-- Fraud reporting intake (#492). FTC v. Carroll et al. (Fed. Dist. Ct. 2026)
+-- entered a $140M judgment against a timeshare exit-scheme operator and made
+-- clear that the FTC is actively enforcing in the timeshare space. The
+-- compliance brief § 3.6 requires a fraud-reporting mechanism with a
+-- documented response protocol — this migration creates the intake table
+-- and a senior-admin-only triage path.
+--
+-- Architectural mirror of 077 (listing_accuracy_reports): separate table
+-- because fraud reports may be:
+--   * filed by anonymous users (not yet signed in)
+--   * filed against a listing OR against a host OR generic platform fraud
+--     (so listing_id is nullable)
+--   * higher-severity than accuracy complaints — alerts senior admins
+--
+-- GitHub issue #492; compliance-gap-analysis item P-15.
+
+BEGIN;
+
+-- ── Table ────────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS public.fraud_reports (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  -- All three context FKs are nullable: a fraud report may be against a
+  -- listing, against an owner profile, against a booking — or generic.
+  listing_id UUID REFERENCES public.listings(id) ON DELETE SET NULL,
+  reported_user_id UUID REFERENCES auth.users(id) ON DELETE SET NULL,
+  booking_id UUID REFERENCES public.bookings(id) ON DELETE SET NULL,
+  reporter_id UUID REFERENCES auth.users(id) ON DELETE SET NULL,
+  reporter_email TEXT,
+  reporter_name TEXT,
+  category TEXT NOT NULL CHECK (category IN (
+    'payment_fraud',
+    'identity_fraud',
+    'fake_listing',
+    'phishing',
+    'scam_pattern',
+    'unauthorized_access',
+    'timeshare_exit_scheme',
+    'other'
+  )),
+  severity TEXT NOT NULL DEFAULT 'high'
+    CHECK (severity IN ('low', 'medium', 'high', 'critical')),
+  description TEXT NOT NULL CHECK (length(description) BETWEEN 20 AND 10000),
+  evidence_urls TEXT[] DEFAULT '{}',
+  status TEXT NOT NULL DEFAULT 'pending'
+    CHECK (status IN (
+      'pending',
+      'investigating',
+      'escalated_to_legal',
+      'escalated_to_law_enforcement',
+      'resolved_action_taken',
+      'resolved_no_fraud_found',
+      'dismissed_spam',
+      'dismissed_duplicate'
+    )),
+  resolution_notes TEXT,
+  resolved_at TIMESTAMPTZ,
+  resolved_by UUID REFERENCES auth.users(id) ON DELETE SET NULL,
+  internal_notes TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  -- Anonymous reports must provide at least an email for follow-up
+  CONSTRAINT fraud_reports_anon_contact CHECK (
+    reporter_id IS NOT NULL OR reporter_email IS NOT NULL
+  )
+);
+
+COMMENT ON TABLE public.fraud_reports IS
+  'Fraud-reporting intake. Required by compliance brief § 3.6 + FTC v. Carroll (2026) enforcement context. Separate from disputes because fraud may be pre-booking, anonymous, and tied to a host/listing/booking or none of the above. Senior-admin-only triage. See GitHub issue #492.';
+
+COMMENT ON COLUMN public.fraud_reports.severity IS
+  'Initial severity guess from the reporter — admin may adjust during triage. critical = active fraud in progress (e.g. payment being processed now); high = default; medium/low = circumstantial / pattern-based reports.';
+
+COMMENT ON COLUMN public.fraud_reports.status IS
+  'pending → investigating → (escalated_to_legal | escalated_to_law_enforcement | resolved_action_taken | resolved_no_fraud_found | dismissed_spam | dismissed_duplicate). Escalation paths are separate so an audit shows when RAV moved a matter outside the platform.';
+
+COMMENT ON COLUMN public.fraud_reports.internal_notes IS
+  'Admin-only notes (not shown to reporter). For tracking pattern matches across reports, coordination with law enforcement, etc.';
+
+-- ── updated_at trigger ─────────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION public.touch_fraud_reports_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS fraud_reports_updated_at ON public.fraud_reports;
+CREATE TRIGGER fraud_reports_updated_at
+  BEFORE UPDATE ON public.fraud_reports
+  FOR EACH ROW EXECUTE FUNCTION public.touch_fraud_reports_updated_at();
+
+-- ── RLS ────────────────────────────────────────────────────────────────────
+ALTER TABLE public.fraud_reports ENABLE ROW LEVEL SECURITY;
+
+-- Anyone (authenticated or anonymous) can INSERT — fraud reports must be
+-- openly accepted to be useful. Spam mitigation via description length CHECK
+-- + dismissed_spam status + admin email alerting (out of scope here).
+DROP POLICY IF EXISTS "Anyone can submit a fraud report" ON public.fraud_reports;
+CREATE POLICY "Anyone can submit a fraud report"
+  ON public.fraud_reports FOR INSERT
+  TO anon, authenticated
+  WITH CHECK (
+    (auth.uid() IS NOT NULL AND reporter_id = auth.uid())
+    OR (auth.uid() IS NULL AND reporter_id IS NULL)
+  );
+
+-- Authenticated reporters can read their own reports — useful for "what
+-- happened to my report?" UX. Anonymous reporters lose this ability (by
+-- design — no way to authenticate later).
+DROP POLICY IF EXISTS "Reporters can read their own fraud reports" ON public.fraud_reports;
+CREATE POLICY "Reporters can read their own fraud reports"
+  ON public.fraud_reports FOR SELECT
+  TO authenticated
+  USING (reporter_id = auth.uid());
+
+-- RAV admin / owner can read all reports. Note this is STRICTER than the
+-- accuracy-reports policy (rav_staff can read those) because fraud reports
+-- often contain sensitive third-party allegations.
+DROP POLICY IF EXISTS "RAV admins can read all fraud reports" ON public.fraud_reports;
+CREATE POLICY "RAV admins can read all fraud reports"
+  ON public.fraud_reports FOR SELECT
+  TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.user_roles ur
+      WHERE ur.user_id = auth.uid()
+        AND ur.role IN ('rav_admin', 'rav_owner')
+    )
+  );
+
+-- Only RAV admin / owner can update — investigation, escalation, resolution.
+DROP POLICY IF EXISTS "RAV admins can update fraud reports" ON public.fraud_reports;
+CREATE POLICY "RAV admins can update fraud reports"
+  ON public.fraud_reports FOR UPDATE
+  TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.user_roles ur
+      WHERE ur.user_id = auth.uid()
+        AND ur.role IN ('rav_admin', 'rav_owner')
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM public.user_roles ur
+      WHERE ur.user_id = auth.uid()
+        AND ur.role IN ('rav_admin', 'rav_owner')
+    )
+  );
+
+COMMENT ON POLICY "RAV admins can read all fraud reports" ON public.fraud_reports IS
+  'Senior-admin-only read. Stricter than the accuracy-reports analogue because fraud reports contain sensitive allegations about third parties.';
+
+-- DELETE not exposed. Service-role only.
+
+-- ── Indexes ────────────────────────────────────────────────────────────────
+CREATE INDEX IF NOT EXISTS idx_fraud_reports_listing_id
+  ON public.fraud_reports (listing_id)
+  WHERE listing_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_fraud_reports_reported_user_id
+  ON public.fraud_reports (reported_user_id)
+  WHERE reported_user_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_fraud_reports_status
+  ON public.fraud_reports (status);
+
+CREATE INDEX IF NOT EXISTS idx_fraud_reports_severity
+  ON public.fraud_reports (severity);
+
+CREATE INDEX IF NOT EXISTS idx_fraud_reports_created_at
+  ON public.fraud_reports (created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_fraud_reports_critical_open
+  ON public.fraud_reports (created_at DESC)
+  WHERE severity = 'critical' AND status IN ('pending', 'investigating');
+
+COMMIT;


### PR DESCRIPTION
## Summary

Closes **#492**. FTC v. Carroll (2026) entered a $140M judgment against a timeshare exit-scheme operator — the FTC is actively enforcing in the timeshare space. Compliance brief § 3.6 requires a fraud-reporting mechanism with senior-admin triage.

- **Migration 078** creates \`fraud_reports\` with nullable listing/user/booking FKs (fraud may be against any of those or generic), 8 category values incl. \`timeshare_exit_scheme\`, severity enum (default high), explicit escalation paths (\`escalated_to_legal\` / \`escalated_to_law_enforcement\` separate from resolution states for audit trail), separate resolution_notes (reporter-visible) and internal_notes (admin-only), description 20..10000 chars, RLS that allows anon + authed INSERT (no impersonation) but restricts SELECT to **rav_admin / rav_owner only** (stricter than accuracy reports), UPDATE same, no DELETE; partial \`idx_fraud_reports_critical_open\` for triage dashboards.
- **\`<FraudReportDialog />\`** — category + severity selects, description, optional anon contact, emergency-contact reminder ("also call your local authorities").
- **Footer** — "Report fraud" link with ShieldAlert icon; Footer is now stateful. **AdminDashboard** — "Fraud reports" tab gated to \`rav_admin\` only (matches stricter RLS).
- **PropertyDetail** — "Report fraud" button next to "Report inaccuracy".
- **AdminFraudReports** — Senior-admin queue with critical-open count, status + severity filters, context column (listing / user / generic), Triage dialog with AlertDialog confirmation.
- **Footer.test.tsx** mocked \`useAuth\` so the embedded dialog renders without AuthProvider in tests.

## Test plan

- [x] \`npm run test\` — **1729 / 1729** pass (+33 net: 18 migration audit + 5 dialog + 4 placement audit + 6 Footer tests still pass with mock fix). Initial run found 6 Footer-test failures from the new useAuth dependency; mocked in same PR.
- [x] \`npm run build\` — clean
- [x] ESLint clean
- [x] Migration 078 applied to DEV via \`supabase db push\`
- [ ] After merge: push 078 to PROD

## Architectural notes

- Separate table from \`disputes\` (consistent with #491's pattern): fraud reports may be anonymous, pre-booking, and target a listing / host / booking / nothing-in-particular. Different RLS shape from disputes.
- **Stricter read RLS than accuracy reports**: only \`rav_admin\` / \`rav_owner\` can read fraud reports (vs. any \`is_rav_team()\` member for accuracy). Rationale: fraud reports contain sensitive third-party allegations.
- Footer placement of the CTA + a per-listing button means reporters can file from anywhere — they don't need to be logged in or on a specific listing.

## Audit scoreboard impact

Row 20 (Fraud reporting and response) flips Gap → Implemented. Documented response SOP for \`docs/support/policies/trust-safety-policy.md\` is a follow-up — that file is currently \`status: draft\` blocked on #80 (legal review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)