### PR TITLE
ci(workflow): trigger CI + docs-audit on PRs targeting dev

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, dev]
   pull_request:
-    branches: [main]
+    branches: [main, dev]
 
 env:
   NODE_VERSION: "20"

--- a/.github/workflows/docs-audit.yml
+++ b/.github/workflows/docs-audit.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [dev, main]
   pull_request:
-    branches: [main]
+    branches: [main, dev]
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- Both `ci.yml` and `docs-audit.yml` only fired on PRs targeting `main`, leaving Stage A (feature → dev) PRs with no CI signal.
- PR #528 (`feature/issue-510-commission-rate-runtime → dev`) hit exactly this gap — only Vercel ran.
- Adds `dev` to `pull_request.branches` on both workflows; also adds `dev` to `ci.yml`'s `push.branches` so direct-to-dev pushes get CI too.

## What changes
- `ci.yml`: \`push: [main]\` → \`[main, dev]\`; \`pull_request: [main]\` → \`[main, dev]\`
- `docs-audit.yml`: \`pull_request: [main]\` → \`[main, dev]\` (push already had \`[dev, main]\`)

No change for the \`dev → main\` release PR path (this PR itself will run under the old rules from main, which already triggers on PRs targeting main).

## Test plan
- [ ] This PR's CI runs (Lint, Type Check, Unit, E2E, Lighthouse, Percy, Audit Documentation, Vercel)
- [ ] After merge to main, PR #528 needs a re-trigger (close+reopen, or push an empty commit) so it picks up the updated workflow file from its target branch
- [ ] Verify a future feature → dev PR fires the full check suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)