### PR TITLE
docs: post-merge sync-line refresh + L-001 confirmation note

### DIFF
--- a/docs/PROJECT-HUB.md
+++ b/docs/PROJECT-HUB.md
@@ -103,7 +103,7 @@ gh issue create --repo rent-a-vacation/rav-website --title "..." --label "..." -
 - **Marketplace flow distinction (DEC-034):** `listings.source_type` + `bookings.source_type` + `bookings.travel_proposal_id` live. Pre-Booked Stay = instant confirm; Wish-Matched Stay = owner-confirmation required. Implemented via #380 Phases 1–5 (PRs #385–#389).
 - **PROD platform:** locked (Staff Only Mode enabled)
 - **Supabase CLI:** currently linked to DEV
-- **dev and main:** `dev` is **4 commits ahead of `main`** at `8816a4c`, all doc-only or security-patch-only (Session 67 docs lessons, Session 67 28-file commission rate doc sweep, Session 68 subscription price sync, Session 68 #530 wave-1 patch). Awaiting next coordinated `dev → main` release PR. PRs #527/#528/#529 (Sessions 66/67) already merged.
+- **dev and main:** **In sync at commit `1132d1d`** after PR #533 release (merged 2026-05-15T15:41 UTC). Sessions 67-68 batch (5 commits: lessons L-001/L-002, 28-doc commission sweep, subscription price sync, security wave 1, housekeeping) all landed on `main`. L-001 verified in real-time: `origin/dev` was auto-deleted on merge, recreated from `main` immediately per the documented recovery procedure; no open PRs were silently re-targeted this time (clean recovery — contrast with Session 67 surprise that originated the lesson).
 - **GitHub Project:** RAV Roadmap — 202 issues, all with Status/Category/Sub-Category/Type populated. Auto-add workflow enabled. PRs excluded.
 
 ### Session Handoff (Sessions 25-68)

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -18,6 +18,8 @@ Session 67. After PR #527 (`dev → main`) merged with "auto-delete head branche
 
 **Related:** [[feedback_github_pr_auto_retarget]] (auto-memory — broader than this repo)
 
+**Confirmation 2026-05-15 (Session 68, PR #533):** Lesson held. `origin/dev` was auto-deleted on `dev → main` merge as expected. Re-created from `main` within seconds per the documented procedure. Pre-merge check (`gh pr list --base dev`) returned empty — no PRs got silently re-targeted. Clean recovery. The procedure works; the surprise from Session 67 only bites if open PRs exist at merge time.
+
 ---
 
 ## L-002 — Supabase CLI needs `--include-all` when mixing numeric and timestamp migration prefixes


### PR DESCRIPTION
## Summary

Trivial doc-only follow-up from PR #533. Two small edits committed in `b7a780f`:

- `docs/PROJECT-HUB.md` line ~106 — refreshed dev/main sync state from "4 commits ahead at 8816a4c" (true when committed, stale 30s later after PR #533 merge) to "in sync at 1132d1d after PR #533 release"
- `tasks/lessons.md` L-001 — appended a real-time confirmation note that the documented recovery procedure (recreate `origin/dev` from `main`, check for orphaned PRs) worked as written when PR #533 merged. Lesson now battle-tested twice.

## Risk
+3 / −1 lines, both in `docs/`. No code, no tests, no schema, no edge functions.

## Test plan
- [ ] CI green (Lint, Type Check, Unit, E2E, Audit Documentation, Vercel preview)

🤖 Generated with [Claude Code](https://claude.com/claude-code)